### PR TITLE
Reduce how frequently completion races can happen in a low risk way.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -199,6 +199,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     }
                 };
 
+                // Purposefully slow down completion to fix a race condition (fixed in 17.1) where the "didChange" from retrieving the projection above
+                // doesn't hit the corresponding sub-language language server in time resulting in a 0 item completion list.
+                await Task.Delay(5).ConfigureAwait(false);
+
                 _logger.LogInformation($"Requesting non-provisional completions for {projectedDocumentUri}.");
 
                 var response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(


### PR DESCRIPTION
- This is a 17.0-GA port of https://github.com/dotnet/razor-tooling/issues/5017. After pulling down the latest 17.0-RC bits I found that more-often than not I was entering state where I was hitting the completion race. This lead me down the path of hackville trying to find a low-risk alternative. Through profiling I found that the race is sub-millisecond (really it happens around the same nanosecond) which put me on the path of what if we were to purposefully slow down completion by a few milliseconds in the effort to make it more consistent? Turns out with this approach I wasn't able to reproduce the completion race a single time.


**Note:** This will not be ported to the 17.1 / our main branch because in that branch this issue is already fixed. The changeset here is TRULY just to minimize how frequently a race happens in a low-risk way.

Port of #5017
