### PR TITLE
Fix Enqueue_DisposedPreventsRestart flaky test.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchingWorkQueue.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/BatchingWorkQueue.cs
@@ -69,6 +69,9 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
         // Used in unit tests to ensure we can know when errors are reported
         private ManualResetEventSlim? NotifyErrorBeingReported { get; set; }
 
+        // Used in unit tests to ensure we can know when background workloads are completing
+        private ManualResetEventSlim? NotifyBackgroundWorkCompleting { get; set; }
+
         /// <summary>
         /// Adds the provided <paramref name="workItem"/> to a work queue under the specified <paramref name="key"/>.
         /// Multiple enqueues under the same <paramref name="key"/> will use the last enqueued <paramref name="workItem"/>.
@@ -197,6 +200,8 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
         private void OnCompletingBackgroundWork()
         {
+            NotifyBackgroundWorkCompleting?.Set();
+
             if (BlockBackgroundWorkCompleting != null)
             {
                 BlockBackgroundWorkCompleting.Wait();
@@ -264,6 +269,12 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             {
                 get => _queue.NotifyErrorBeingReported;
                 set => _queue.NotifyErrorBeingReported = value;
+            }
+
+            public ManualResetEventSlim? NotifyBackgroundWorkCompleting
+            {
+                get => _queue.NotifyBackgroundWorkCompleting;
+                set => _queue.NotifyBackgroundWorkCompleting = value;
             }
         }
     }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/BatchingWorkQueueTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/BatchingWorkQueueTest.cs
@@ -170,6 +170,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             TestAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
             TestAccessor.NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false);
             TestAccessor.NotifyBackgroundCapturedWorkload = new ManualResetEventSlim(initialState: false);
+            TestAccessor.NotifyBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false);
             TestAccessor.BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false);
             TestAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
 
@@ -188,6 +189,9 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
             TestAccessor.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(3));
             Assert.Empty(TestAccessor.Work);
+
+            // Wait for the background workload to complete
+            TestAccessor.NotifyBackgroundWorkCompleting.Wait(TimeSpan.FromSeconds(5));
 
             WorkQueue.Enqueue("key", workItemToCauseRestart);
             Assert.NotEmpty(TestAccessor.Work);


### PR DESCRIPTION
- Turns out we weren't waiting for our background workloads to actually complete before disposing our baching work queue resulting in the possibility that dispose occurs before actually processing any items.
- Ran the test over 20k times (`Combinatorial` attribute) and didn't see a failure after the fix (saw failures pre-fix).

Fixes #4398