### PR TITLE
Nullable in CodeActions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Threading;
@@ -39,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         public override string Action => LanguageServerConstants.CodeActions.AddUsing;
 
-        public async override Task<CodeAction> ResolveAsync(
+        public async override Task<CodeAction?> ResolveAsync(
             CSharpCodeActionParams csharpParams,
             CodeAction codeAction,
             CancellationToken cancellationToken)
@@ -57,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             cancellationToken.ThrowIfCancellationRequested();
 
             var resolvedCodeAction = await ResolveCodeActionWithServerAsync(csharpParams.RazorFileUri, codeAction, cancellationToken).ConfigureAwait(false);
-            if (resolvedCodeAction.Edit?.DocumentChanges is null)
+            if (resolvedCodeAction is null || resolvedCodeAction.Edit?.DocumentChanges is null)
             {
                 // Unable to resolve code action with server, return original code action
                 return codeAction;
@@ -76,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return codeAction;
             }
 
-            var addUsingTextEdit = documentChanged.TextDocumentEdit.Edits.FirstOrDefault();
+            var addUsingTextEdit = documentChanged.TextDocumentEdit?.Edits.FirstOrDefault();
             if (addUsingTextEdit is null)
             {
                 // No text edit available

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             cancellationToken.ThrowIfCancellationRequested();
 
             var resolvedCodeAction = await ResolveCodeActionWithServerAsync(csharpParams.RazorFileUri, codeAction, cancellationToken).ConfigureAwait(false);
-            if (resolvedCodeAction is null || resolvedCodeAction.Edit?.DocumentChanges is null)
+            if (resolvedCodeAction?.Edit?.DocumentChanges is null)
             {
                 // Unable to resolve code action with server, return original code action
                 return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionResolver.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,16 +27,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             LanguageServer = languageServer;
         }
 
-        public abstract Task<CodeAction> ResolveAsync(
+        public abstract Task<CodeAction?> ResolveAsync(
             CSharpCodeActionParams csharpParams,
             CodeAction codeAction,
             CancellationToken cancellationToken);
 
-        protected async Task<CodeAction> ResolveCodeActionWithServerAsync(DocumentUri uri, CodeAction codeAction, CancellationToken cancellationToken)
+        protected async Task<CodeAction?> ResolveCodeActionWithServerAsync(DocumentUri uri, CodeAction codeAction, CancellationToken cancellationToken)
         {
             var resolveCodeActionParams = new RazorResolveCodeActionParams(uri, codeAction);
             var response = await LanguageServer.SendRequestAsync(LanguageServerConstants.RazorResolveCodeActionsEndpoint, resolveCodeActionParams).ConfigureAwait(false);
-            var resolvedCodeAction = await response.Returning<CodeAction>(cancellationToken).ConfigureAwait(false);
+            var resolvedCodeAction = await response.Returning<CodeAction?>(cancellationToken).ConfigureAwait(false);
 
             return resolvedCodeAction;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         internal async Task<IEnumerable<RazorCodeAction>> GetCSharpCodeActionsFromLanguageServerAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
         {
             Range projectedRange = null;
-            if (context.Request.Range != null &&
+            if (context.Request.Range is not null &&
                 !_documentMappingService.TryMapToProjectedDocumentRange(
                     context.CodeDocument,
                     context.Request.Range,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -313,8 +313,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             return codeActions;
         }
-
-        public override async Task<VSInternalCodeAction> ResolveCodeActionsAsync(RazorResolveCodeActionParams resolveCodeActionParams, CancellationToken cancellationToken)
+#nullable enable
+        public override async Task<VSInternalCodeAction?> ResolveCodeActionsAsync(RazorResolveCodeActionParams resolveCodeActionParams, CancellationToken cancellationToken)
         {
             if (resolveCodeActionParams is null)
             {
@@ -329,7 +329,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var csharpTextBuffer = LanguageServerKind.CSharp.GetTextBuffer(documentSnapshot);
             var codeAction = resolveCodeActionParams.CodeAction;
-            var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSInternalCodeAction, VSInternalCodeAction>(
+            var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSInternalCodeAction, VSInternalCodeAction?>(
                 csharpTextBuffer,
                 Methods.CodeActionResolveName,
                 SupportsCSharpCodeActions,
@@ -338,7 +338,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             await foreach (var response in requests)
             {
-                if (response.Response != null)
+                if (response.Response is not null)
                 {
                     // Only take the first response from a resolution
                     return response.Response;
@@ -347,6 +347,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             return null;
         }
+#nullable disable
 
         public override async Task<ProvideSemanticTokensResponse> ProvideSemanticTokensAsync(
             ProvideSemanticTokensParams semanticTokensParams,


### PR DESCRIPTION
### Summary of the changes
 - Ran into the following error when testing
```
Error: Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc.RazorOmniSharpRequestInvoker: Failed to handle request codeAction/resolve:302. Unhandled exception - OmniSharp.Extensions.JsonRpc.Server.JsonRpcException: Unexpected null - line 76
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at OmniSharp.Extensions.JsonRpc.ResponseRouter.ResponseRouterReturnsImpl.<Returning>d__4`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.CSharpCodeActionResolver.<ResolveCodeActionWithServerAsync>d__3.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.AddUsingsCSharpCodeActionResolver.<ResolveAsync>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.CodeActionResolutionEndpoint.<ResolveCSharpCodeActionAsync>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.CodeActionResolutionEndpoint.<Handle>d__4.MoveNext()
```
- This lacks some specifics about what property was unexpectedly null (and I wasn't able to get it to happen again), but I took the opportunity to make more things nullable and clarify a couple of expected return types.