### PR TITLE
Handle nuget.org API change

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -26,13 +26,19 @@ async function downloadProxyPackage(version) {
     }
     const extractTarget = path.join(tmpDirectory, `extracted-${packageName}.${version}`);
 
-    const versionedPackageName = `${packageName}.${version}.nupkg`;
-    const downloadUrl = `${nugetUrl}/${packageName}/${version}/${versionedPackageName}`;
+    const versionedPackageName = `${packageName.toLowerCase()}.${version}.nupkg`;
+    // nuget.org requires the package name be lower-case
+    const downloadUrl = `${nugetUrl}/${packageName.toLowerCase()}/${version}/${versionedPackageName}`;
     const downloadPath = path.join(tmpDirectory, versionedPackageName);
 
     // Download and save nupkg to disk
     log(`Fetching package from ${downloadUrl}...`)
     const response = await fetch(downloadUrl)
+
+    if (!response.ok)
+    {
+        log(`Failed to download ${downloadUrl}`)
+    }
     const outputStream = fs.createWriteStream(downloadPath);
     response.body.pipe(outputStream);
 


### PR DESCRIPTION
### Summary of the changes
 - Looks like Nuget.org started enforcing that the url to download a package be lower-case.
 - This exposed that we assume the request succeeded without checking to at least log the failure when we attempted to open a `.nupkg` which was actually a 0-length file.
 
Fixes: https://github.com/dotnet/razor-tooling/issues/5702