### PR TITLE
Pin vsce version used in release script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ stages:
             yarn
             node ./scripts/retrieveDebugProxy.js
             md $(Build.SourcesDirectory)/artifacts/packages/VSCode/$(_BuildConfig)/ -ea 0
-            npx vsce package -o $(Build.SourcesDirectory)/artifacts/packages/VSCode/$(_BuildConfig)/blazorwasm-companion-$version.vsix
+            npx vsce@1.100.2 package -o $(Build.SourcesDirectory)/artifacts/packages/VSCode/$(_BuildConfig)/blazorwasm-companion-$version.vsix
           displayName: Produce Blazor WASM Debugging Extension VSIX
           workingDirectory: $(Build.SourcesDirectory)/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))


### PR DESCRIPTION
Attempting to resolve recent issues with this build step by pinning the vsce version used to a known value.