### PR TITLE
Restrict C# forced "invoke base completion" to not apply to HTML.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -539,7 +539,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 // Non-triggered based completion
 
-                if (context is VSInternalCompletionContext internalContext && internalContext.InvokeKind == VSInternalCompletionInvokeKind.Typing)
+                if (languageKind == RazorLanguageKind.CSharp &&
+                    context is VSInternalCompletionContext internalContext &&
+                    internalContext.InvokeKind == VSInternalCompletionInvokeKind.Typing)
                 {
                     // We're in the midst of doing a C# typing completion. We consider this 24/7 completion and HTML & C# only offer 24/7 completion at the
                     // beginning of a word. Meaning, completions will be provided at `|D` but not for `|Da` which brings us to an interesting cross-roads.

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -281,13 +281,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
-        [Theory]
-        [InlineData(RazorLanguageKind.Html)]
-        [InlineData(RazorLanguageKind.CSharp)]
-        public async Task HandleRequestAsync_247Typing_InvokesLanguageServerWithExplicit(object languageKindObj) // Have to mark language kind as an object because RazorLanguageKind is internal
+        [Fact]
+        public async Task HandleRequestAsync_247Typing_InvokesLanguageServerWithExplicit()
         {
             // Arrange
-            var languageKind = (RazorLanguageKind)languageKindObj;
+            var languageKind = RazorLanguageKind.CSharp;
             var called = false;
             var expectedItem = new CompletionItem() { Label="Sampel", InsertText = "Sample" };
             var completionRequest = new CompletionParams()


### PR DESCRIPTION
- Our Razor language server provides component/TagHelper completions at start of words and when I originally added the completion logic to request full completion lists always I didn't consider that markup languages are a lot less "kind" to that approach. Therefore, I'm reverting that specific portion of logic + the test change that went with it.

### Before

![before experience](https://i.imgur.com/QlBo4xJ.gif)

### After

![after experience](https://i.imgur.com/xddr9id.gif)

Fixes #5685