### PR TITLE
Fix directive attribute completion in legacy Razor editor

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveAttributeCompletionSourceTest.cs
@@ -45,7 +45,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 Mock.Of<VisualStudioRazorParser>(MockBehavior.Strict),
                 Mock.Of<RazorCompletionFactsService>(MockBehavior.Strict),
                 Mock.Of<ICompletionBroker>(MockBehavior.Strict),
-                descriptionFactory);
+                descriptionFactory,
+                JoinableTaskFactory);
             var completionSessionSource = Mock.Of<IAsyncCompletionSource>(MockBehavior.Strict);
             var completionItem = new CompletionItem("@random", completionSessionSource);
             completionItem.Properties.AddProperty(RazorDirectiveAttributeCompletionSource.DescriptionKey, description);
@@ -234,7 +235,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 Mock.Of<VisualStudioRazorParser>(MockBehavior.Strict),
                 Mock.Of<RazorCompletionFactsService>(MockBehavior.Strict),
                 Mock.Of<ICompletionBroker>(MockBehavior.Strict),
-                Mock.Of<VisualStudioDescriptionFactory>(MockBehavior.Strict));
+                Mock.Of<VisualStudioDescriptionFactory>(MockBehavior.Strict),
+                JoinableTaskFactory);
             return source;
         }
     }


### PR DESCRIPTION
- In legacy editor's directive attribute completion we used to dismiss the active completion session to take over and show our own attribute completion. Looks like when we changed our threading model we broke the UI thread expectation of dismissing that old active session. This in turn results in a flooding of directive completion sessions.
- Updated tests

### Before

![image](https://user-images.githubusercontent.com/2008729/141396947-9a107ff8-1760-451a-a4af-11a0ce75f28b.png)

### After

![image](https://user-images.githubusercontent.com/2008729/141396883-3b4dd048-a53b-47c5-987e-f9c03bf8312a.png)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1434858