### PR TITLE
[Port to main] Add feature flag for legacy Razor editor

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultLSPEditorFeatureDetector.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
     [Export(typeof(LSPEditorFeatureDetector))]
     internal class DefaultLSPEditorFeatureDetector : LSPEditorFeatureDetector
     {
+        private const string LegacyRazorEditorFeatureFlag = "Razor.LSP.LegacyEditor";
         private const string DotNetCoreCSharpCapability = "CSharp&CPS";
         private const string UseLegacyASPNETCoreEditorSetting = "TextEditor.HTML.Specific.UseLegacyASPNETCoreRazorEditor";
 
@@ -44,6 +45,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             _useLegacyEditor = new Lazy<bool>(() =>
             {
+                var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+                var legacyEditorFeatureFlagEnabled = featureFlags.IsFeatureEnabled(LegacyRazorEditorFeatureFlag, defaultValue: false);
+                if (legacyEditorFeatureFlagEnabled)
+                {
+                    return true;
+                }
+
                 var settingsManager = (ISettingsManager)ServiceProvider.GlobalProvider.GetService(typeof(SVsSettingsPersistenceManager));
                 Assumes.Present(settingsManager);
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -36,3 +36,9 @@
 "Package"="{13b72f58-279e-49e0-a56d-296be02f0805}"
 "ShowBraceCompletion"=dword:00000001
 "ShowSmartIndent"=dword:00000001
+
+[$RootKey$\FeatureFlags\Razor\LSP\LegacyEditor]
+"Description"="Uses the legacy Razor editor when editing Razor (ASP.NET Core)."
+"Value"=dword:00000000
+"Title"="Use legacy Razor editor (requires restart)"
+"PreviewPaneChannels"="int.main"


### PR DESCRIPTION
- This allows us to remotely configure old editor usage and only presents the feature flag in main builds for internal customers.
