### PR TITLE
Add failing test

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
@@ -593,5 +593,42 @@ expected: @"
 
             Assert.Empty(edits);
         }
+
+        [Fact(Skip = "https://github.com/dotnet/razor-tooling/issues/5676")]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5693")]
+        public async Task IfStatementInsideLambda()
+        {
+            await RunOnTypeFormattingTestAsync(
+input: @"
+@code
+{
+    public RenderFragment RenderFoo()
+    {
+        return (__builder) =>
+        {
+            @if (true)
+            {
+
+            }$$
+        };
+    }
+}
+",
+expected: @"
+@code
+{
+    public RenderFragment RenderFoo()
+    {
+        return (__builder) =>
+        {
+            @if (true)
+            {
+
+            }
+        };
+    }
+}
+", triggerCharacter: '}');
+        }
     }
 }


### PR DESCRIPTION
Was investigating https://github.com/dotnet/razor-tooling/issues/5693, found it was another repro of the `InputSelect` bug (https://github.com/dotnet/razor-tooling/issues/5676) which will be fixed by https://github.com/dotnet/roslyn/issues/57465 but figured we should at least have a regression test.

I temporarily added a second formatted pass [here](https://github.com/dotnet/razor-tooling/blob/main/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs#L174) and verified that the test passed.