### PR TITLE
Functions block code actions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionProvider.cs
@@ -36,14 +36,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             }
 
             var owner = syntaxTree.Root.LocateOwner(change);
-            if (owner == null)
+            if (owner is null)
             {
                 Debug.Fail("Owner should never be null.");
                 return false;
             }
 
             var node = owner.Ancestors().FirstOrDefault(n => n.Kind == SyntaxKind.RazorDirective);
-            if (node == null || !(node is RazorDirectiveSyntax directiveNode))
+            if (node is not RazorDirectiveSyntax directiveNode)
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             IEnumerable<RazorCodeAction> codeActions,
             CancellationToken cancellationToken);
 
-        protected static bool InFunctionsBlock(RazorCodeActionContext context)
+        protected static bool InFunctionsBlockThatCantHaveCodeActions(RazorCodeActionContext context)
         {
             var change = new SourceChange(context.Location.AbsoluteIndex, length: 0, newText: string.Empty);
             var syntaxTree = context.CodeDocument.GetSyntaxTree();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
@@ -51,9 +51,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return EmptyResult;
             }
 
-            // Disable multi-line code actions in @functions block
-            // Will be removed once https://github.com/dotnet/aspnetcore/issues/26501 is unblocked.
-            if (InFunctionsBlock(context))
+            if (InFunctionsBlockThatCantHaveCodeActions(context))
             {
                 return EmptyResult;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         }
 
         [Fact]
-        public async Task ProvideAsync_FunctionsBlock_ValidCodeActions_ReturnsEmpty()
+        public async Task ProvideAsync_FunctionsBlock_SingleLine_ValidCodeActions_ReturnsEmpty()
         {
             // Arrange
             var documentPath = "c:/Test.razor";
@@ -108,6 +108,66 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             // Assert
             Assert.Empty(providedCodeActions);
+        }
+
+        [Fact]
+        public async Task ProvideAsync_FunctionsBlock_OpenBraceSameLine_ValidCodeActions_ReturnsEmpty()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var contents = @"@functions {
+Path;
+}";
+            var request = new CodeActionParams()
+            {
+                TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
+                Range = new Range(),
+                Context = new CodeActionContext()
+            };
+
+            var location = new SourceLocation(14, -1, -1);
+            var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(13, 4));
+            context.CodeDocument.SetFileKind(FileKinds.Legacy);
+
+            var provider = new DefaultCSharpCodeActionProvider();
+
+            // Act
+            var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
+
+            // Assert
+            Assert.Empty(providedCodeActions);
+        }
+
+        [Fact]
+        public async Task ProvideAsync_FunctionsBlock_OpenBraceNextLine_ValidCodeActions_ReturnsProvidedCodeAction()
+        {
+            // Arrange
+            var documentPath = "c:/Test.razor";
+            var contents = @"@functions
+{
+Path;
+}";
+            var request = new CodeActionParams()
+            {
+                TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
+                Range = new Range(),
+                Context = new CodeActionContext()
+            };
+
+            var location = new SourceLocation(15, -1, -1);
+            var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(13, 4));
+            context.CodeDocument.SetFileKind(FileKinds.Legacy);
+
+            var provider = new DefaultCSharpCodeActionProvider();
+
+            // Act
+            var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
+
+            // Assert
+            Assert.Equal(_supportedCodeActions.Length, providedCodeActions.Count);
+            var providedNames = providedCodeActions.Select(action => action.Name);
+            var expectedNames = _supportedCodeActions.Select(action => action.Name);
+            Assert.Equal(expectedNames, providedNames);
         }
 
         [Fact]


### PR DESCRIPTION
Part of fixing https://github.com/dotnet/razor-tooling/issues/5747 by allowing code actions in functions blocks where it won't cause problems.

Unfortunately allowing them in other functions blocks is still a problem, but I'm working on it (and if I get it then it will fix override completion too)