### PR TITLE
Add better logging around project.razor.json handling.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly FilePathNormalizer _filePathNormalizer;
         private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver;
         private readonly IEnumerable<IProjectConfigurationFileChangeListener> _listeners;
-        private readonly ILogger<MonitorProjectConfigurationFilePathEndpoint> _logger;
+        private readonly ILogger _logger;
         private readonly ConcurrentDictionary<string, (string ConfigurationDirectory, IFileChangeDetector Detector)> _outputPathMonitors;
         private readonly object _disposeLock;
         private bool _disposed;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
         private readonly RazorProjectService _projectService;
         private readonly FilePathNormalizer _filePathNormalizer;
-        private readonly ILogger<ProjectConfigurationStateSynchronizer> _logger;
+        private readonly ILogger _logger;
         private readonly Dictionary<string, string> _configurationToProjectMap;
         internal readonly Dictionary<string, DelayedProjectInfo> ProjectInfoMap;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using Xunit.Sdk;
@@ -35,7 +36,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 directoryPathResolver.Object,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             configurationFileEndpoint.Dispose();
             var request = new MonitorProjectConfigurationFilePathParams()
             {
@@ -58,7 +60,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 directoryPathResolver.Object,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             var request = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:/dir/project.csproj",
@@ -79,7 +82,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 DirectoryPathResolver,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             var startRequest = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:/dir/project.csproj",
@@ -110,7 +114,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 DirectoryPathResolver,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             var startRequest = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:/dir/project.csproj",
@@ -134,7 +139,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 DirectoryPathResolver,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             var startRequest = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:/dir/project.csproj",
@@ -160,7 +166,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 DirectoryPathResolver,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             var debugOutputPath = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:\\dir\\project.csproj",
@@ -191,7 +198,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 DirectoryPathResolver,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             var externalRequest = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:\\dir\\project.csproj",
@@ -223,7 +231,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 FilePathNormalizer,
                 DirectoryPathResolver,
-                Enumerable.Empty<IProjectConfigurationFileChangeListener>());
+                Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                LoggerFactory);
             var debugOutputPath1 = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:\\dir\\project1.csproj",
@@ -260,12 +269,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
                 FilePathNormalizer filePathNormalizer,
                 WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
-                IEnumerable<IProjectConfigurationFileChangeListener> listeners) : this(
+                IEnumerable<IProjectConfigurationFileChangeListener> listeners,
+                ILoggerFactory loggerFactory) : this(
                     fileChangeDetectorFactory: null,
                     projectSnapshotManagerDispatcher,
                     filePathNormalizer,
                     workspaceDirectoryPathResolver,
-                    listeners)
+                    listeners,
+                    loggerFactory)
             {
             }
 
@@ -274,11 +285,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
                 FilePathNormalizer filePathNormalizer,
                 WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
-                IEnumerable<IProjectConfigurationFileChangeListener> listeners) : base(
+                IEnumerable<IProjectConfigurationFileChangeListener> listeners,
+                ILoggerFactory loggerFactory) : base(
                     projectSnapshotManagerDispatcher,
                     filePathNormalizer,
                     workspaceDirectoryPathResolver,
-                    listeners)
+                    listeners,
+                    loggerFactory)
             {
                 _fileChangeDetectorFactory = fileChangeDetectorFactory ?? (() => Mock.Of<IFileChangeDetector>(MockBehavior.Strict));
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         private ProjectConfigurationStateSynchronizer GetSynchronizer(RazorProjectService razorProjectService)
         {
-            var synchronizer = new ProjectConfigurationStateSynchronizer(LegacyDispatcher, razorProjectService, FilePathNormalizer);
+            var synchronizer = new ProjectConfigurationStateSynchronizer(LegacyDispatcher, razorProjectService, FilePathNormalizer, LoggerFactory);
             synchronizer.EnqueueDelay = 5;
 
             return synchronizer;


### PR DESCRIPTION
- After digging through countless customer logs I've had a hell of a time finding out why Debug/Release project.razor.json's occasionally result in lack of component IntelliSense. This PR introduces logging to key points that will help investigate what's going on with #5757.
- We have two entry points on the Razor language server that deal with project.razor.json. These two are the `MonitorProjectConfigurationFilePathEndpoint` which is responsible for monitoring external project.razor.json locations (if you set your obj directory to something outside of the workspace) and the `ProjectConfigurationStateSynchronizer` which listens to `project.razor.json` file changes and then harvests information and pushes it to our language server project manager.
    - For these two I enabled nullability + added logging to better understand what's going on under the covers.

Part of #5757