### PR TITLE
Add a capability check for textDocument/documentColor

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,7 +93,7 @@
     <MicrosoftVisualStudioShellPackagesVersion>17.0.0-previews-1-31410-258</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.0.35-gdeb9415fdc</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.1.0-1.21471.13</RoslynPackageVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.0.5133</VisualStudioLanguageServerProtocolVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.1.2</VisualStudioLanguageServerProtocolVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFallbackCapabilitiesFilterResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFallbackCapabilitiesFilterResolver.cs
@@ -66,6 +66,8 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                     return CheckLinkedEditingRangeCapabilities;
                 case Methods.CodeActionResolveName:
                     return CheckCodeActionResolveCapabilities;
+                case Methods.TextDocumentDocumentColorName:
+                    return CheckDocumentColorCapabilities;
 
                 // VS LSP Expansion capabilities
                 case VSMethods.GetProjectContextsName:
@@ -81,6 +83,15 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                 default:
                     return FallbackCheckCapabilties;
             }
+        }
+
+        private bool CheckDocumentColorCapabilities(JToken token)
+        {
+            var serverCapabilities = token.ToObject<ServerCapabilities>();
+
+            return serverCapabilities?.DocumentColorProvider?.Match(
+                boolValue => boolValue,
+                options => options != null) ?? false;
         }
 
         private static bool CheckSemanticTokensCapabilities(JToken token)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultFallbackCapabilitiesFilterResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultFallbackCapabilitiesFilterResolverTest.cs
@@ -455,6 +455,44 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         }
 
         [Fact]
+        public void Resolve_DocumentColor_ReturnsTrue()
+        {
+            // Arrange
+            var methodName = Methods.TextDocumentDocumentColorName;
+            var capabilities = new ServerCapabilities()
+            {
+                DocumentColorProvider = true,
+            };
+            var jobjectCapabilities = JObject.FromObject(capabilities);
+            var filter = Resolver.Resolve(methodName);
+
+            // Act
+            var result = filter(jobjectCapabilities);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Resolve_DocumentColorOptions_ReturnsTrue()
+        {
+            // Arrange
+            var methodName = Methods.TextDocumentDocumentColorName;
+            var capabilities = new ServerCapabilities()
+            {
+                DocumentColorProvider = new DocumentColorOptions(),
+            };
+            var jobjectCapabilities = JObject.FromObject(capabilities);
+            var filter = Resolver.Resolve(methodName);
+
+            // Act
+            var result = filter(jobjectCapabilities);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
         public void Resolve_Completion_ReturnsTrue()
         {
             // Arrange
@@ -684,6 +722,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         [InlineData(Methods.TextDocumentHoverName)]
         [InlineData(Methods.TextDocumentCodeActionName)]
         [InlineData(Methods.TextDocumentCodeLensName)]
+        [InlineData(Methods.TextDocumentDocumentColorName)]
         [InlineData(Methods.TextDocumentCompletionName)]
         [InlineData(Methods.TextDocumentCompletionResolveName)]
         [InlineData(Methods.TextDocumentDefinitionName)]


### PR DESCRIPTION
This required updating the VS protocol assemblies to 17.1.2, as that was
where this method name was introduced (though it's been in the LSP spec
for a long time).
