### PR TITLE
Automatically add using directives from code actions etc.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
@@ -124,7 +124,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             // Remaps the text edits from the generated C# to the razor file,
             // as well as applying appropriate formatting.
-            var formattedEdits = await _razorFormattingService.FormatCodeActionAsync(csharpParams.RazorFileUri, documentSnapshot, RazorLanguageKind.CSharp, csharpTextEdits, s_defaultFormattingOptions, cancellationToken);
+            var formattedEdits = await _razorFormattingService.FormatCodeActionAsync(
+                csharpParams.RazorFileUri,
+                documentSnapshot,
+                RazorLanguageKind.CSharp,
+                csharpTextEdits,
+                s_defaultFormattingOptions,
+                cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
@@ -124,14 +124,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             // Remaps the text edits from the generated C# to the razor file,
             // as well as applying appropriate formatting.
-            var formattedEdits = await _razorFormattingService.ApplyFormattedEditsAsync(
-                csharpParams.RazorFileUri,
-                documentSnapshot,
-                RazorLanguageKind.CSharp,
-                csharpTextEdits,
-                s_defaultFormattingOptions,
-                cancellationToken,
-                bypassValidationPasses: true);
+            var formattedEdits = await _razorFormattingService.FormatCodeActionAsync(csharpParams.RazorFileUri, documentSnapshot, RazorLanguageKind.CSharp, csharpTextEdits, s_defaultFormattingOptions, cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -149,7 +149,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var finalChanges = cleanedText.GetTextChanges(originalText);
             var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
 
-            finalEdits = await AddUsingStatementEditsAsync(codeDocument, finalEdits, csharpText, originalTextWithChanges, cancellationToken);
+            if (context.AutomaticallyAddUsings)
+            {
+                // Because we need to parse the C# code twice for this operation, lets do a quick check to see if its even necessary
+                if (result.Edits.Any(e => e.NewText.IndexOf("using") != -1))
+                {
+                    finalEdits = await AddUsingStatementEditsAsync(codeDocument, finalEdits, csharpText, originalTextWithChanges, cancellationToken);
+                }
+            }
 
             return new FormattingResult(finalEdits);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -83,6 +83,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public bool IsFormatOnType { get; private set; }
 
+        public bool AutomaticallyAddUsings { get; private set; }
+
         public Range Range { get; private set; } = null!;
 
         /// <summary>A Dictionary of int (line number) to IndentationContext.</summary>
@@ -248,33 +250,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             RazorCodeDocument codeDocument,
             FormattingOptions options,
             AdhocWorkspaceFactory workspaceFactory,
-            bool isFormatOnType = false)
+            bool isFormatOnType = false,
+            bool automaticallyAddUsings = false)
         {
-            if (uri is null)
-            {
-                throw new ArgumentNullException(nameof(uri));
-            }
-
-            if (originalSnapshot is null)
-            {
-                throw new ArgumentNullException(nameof(originalSnapshot));
-            }
-
-            if (codeDocument is null)
-            {
-                throw new ArgumentNullException(nameof(codeDocument));
-            }
-
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-            if (workspaceFactory is null)
-            {
-                throw new ArgumentNullException(nameof(workspaceFactory));
-            }
-
             var syntaxTree = codeDocument.GetSyntaxTree();
             var formattingSpans = syntaxTree.GetFormattingSpans();
 
@@ -285,6 +263,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 CodeDocument = codeDocument,
                 Options = options,
                 IsFormatOnType = isFormatOnType,
+                AutomaticallyAddUsings = automaticallyAddUsings,
                 FormattingSpans = formattingSpans
             };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -253,6 +253,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             bool isFormatOnType = false,
             bool automaticallyAddUsings = false)
         {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (originalSnapshot is null)
+            {
+                throw new ArgumentNullException(nameof(originalSnapshot));
+            }
+
+            if (codeDocument is null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (workspaceFactory is null)
+            {
+                throw new ArgumentNullException(nameof(workspaceFactory));
+            }
+
             var syntaxTree = codeDocument.GetSyntaxTree();
             var formattingSpans = syntaxTree.GetFormattingSpans();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -265,8 +265,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var formattedEdits = await _razorFormattingService.ApplyFormattedEditsAsync(
-                request.TextDocument.Uri, documentSnapshot, triggerCharacterKind, textEdits, request.Options, cancellationToken).ConfigureAwait(false);
+            var formattedEdits = await _razorFormattingService.FormatOnTypeAsync(request.TextDocument.Uri, documentSnapshot, triggerCharacterKind, textEdits, request.Options, cancellationToken).ConfigureAwait(false);
             if (formattedEdits.Length == 0)
             {
                 _logger.LogInformation("No formatting changes were necessary");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -21,14 +21,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             FormattingOptions options,
             CancellationToken cancellationToken);
 
-        public abstract Task<TextEdit[]> ApplyFormattedEditsAsync(
+        public abstract Task<TextEdit[]> FormatOnTypeAsync(
+           DocumentUri uri,
+           DocumentSnapshot documentSnapshot,
+           RazorLanguageKind kind,
+           TextEdit[] formattedEdits,
+           FormattingOptions options,
+           CancellationToken cancellationToken);
+
+        public abstract Task<TextEdit[]> FormatCodeActionAsync(
             DocumentUri uri,
             DocumentSnapshot documentSnapshot,
             RazorLanguageKind kind,
             TextEdit[] formattedEdits,
             FormattingOptions options,
-            CancellationToken cancellationToken,
-            bool bypassValidationPasses = false,
-            bool collapseEdits = false);
+            CancellationToken cancellationToken);
+
+        public abstract Task<TextEdit[]> FormatSnippetAsync(
+            DocumentUri uri,
+            DocumentSnapshot documentSnapshot,
+            RazorLanguageKind kind,
+            TextEdit[] formattedEdits,
+            FormattingOptions options,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -238,8 +238,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             if (request.TextEditKind == TextEditKind.FormatOnType)
             {
-                var mappedEdits = await _razorFormattingService.ApplyFormattedEditsAsync(
-                    request.RazorDocumentUri, documentSnapshot, request.Kind, request.ProjectedTextEdits, request.FormattingOptions, cancellationToken);
+                var mappedEdits = await _razorFormattingService.FormatOnTypeAsync(request.RazorDocumentUri, documentSnapshot, request.Kind, request.ProjectedTextEdits, request.FormattingOptions, cancellationToken);
 
                 return new RazorMapToDocumentEditsResponse()
                 {
@@ -254,15 +253,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     WrapCSharpSnippets(request.ProjectedTextEdits);
                 }
 
-                var mappedEdits = await _razorFormattingService.ApplyFormattedEditsAsync(
-                    request.RazorDocumentUri,
-                    documentSnapshot,
-                    request.Kind,
-                    request.ProjectedTextEdits,
-                    request.FormattingOptions,
-                    cancellationToken,
-                    bypassValidationPasses: true,
-                    collapseEdits: true);
+                var mappedEdits = await _razorFormattingService.FormatSnippetAsync(request.RazorDocumentUri, documentSnapshot, request.Kind, request.ProjectedTextEdits, request.FormattingOptions, cancellationToken);
 
                 if (request.Kind == RazorLanguageKind.CSharp)
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
@@ -212,15 +212,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         private static RazorFormattingService CreateRazorFormattingService(Uri documentUri)
         {
             var razorFormattingService = Mock.Of<RazorFormattingService>(
-                            rfs => rfs.ApplyFormattedEditsAsync(
+                            rfs => rfs.FormatCodeActionAsync(
                                 documentUri,
                                 It.IsAny<DocumentSnapshot>(),
                                 RazorLanguageKind.CSharp,
                                 It.IsAny<TextEdit[]>(),
                                 It.IsAny<FormattingOptions>(),
-                                It.IsAny<CancellationToken>(),
-                                /*bypassValidationPasses:*/ true,
-                                It.IsAny<bool>()) == Task.FromResult(s_defaultFormattedEdits), MockBehavior.Strict);
+                                It.IsAny<CancellationToken>()) == Task.FromResult(s_defaultFormattedEdits), MockBehavior.Strict);
             return razorFormattingService;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeActionFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeActionFormattingTest.cs
@@ -28,7 +28,7 @@ input: @"
 ",
 codeActionEdits: new []
 {
-    Edit(7, 17, 7, 17, "Diagnostics;\r\n    using System."),
+    Edit(7, 6, 7, 6, "System.Diagnostics;\r\nusing "),
     Edit(67, 0, 67, 8, ""),
     Edit(69, 34, 70, 7, "\r\n\r\n        [DebuggerDisplay($\"{{{nameof(GetDebuggerDisplay)}(),nq}}\")]"),
     Edit(71, 0, 71, 4, "        "),
@@ -36,9 +36,10 @@ codeActionEdits: new []
     Edit(73, 0, 73, 0, "                return ToString();\r\n            }\r\n"),
     Edit(73, 8, 74, 4, "")
 },
-expected: @"
+expected: @"@using System.Diagnostics;
+
 @functions {
-    [DebuggerDisplay($""{{{nameof(GetDebuggerDisplay)}(),nq}}"")] 
+    [DebuggerDisplay($""{{{nameof(GetDebuggerDisplay)}(),nq}}"")]  
     class Goo
     {
         private string GetDebuggerDisplay()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
@@ -589,9 +589,8 @@ expected: @"
     }
 }
 ";
-            var (_, edits) = await GetOnTypeFormattingEditsAsync(input, triggerCharacter: ';');
 
-            Assert.Empty(edits);
+            await RunOnTypeFormattingTestAsync(input, input.Replace("$$", ""), triggerCharacter: ';');
         }
 
         [Fact(Skip = "https://github.com/dotnet/razor-tooling/issues/5676")]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -157,10 +157,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var edits = await formattingService.FormatOnTypeAsync(uri, documentSnapshot, languageKind, projectedEdits, options, CancellationToken.None);
 
             // Assert
-            var edited = ApplyEdits(razorSourceText, edits);
-            var actual = edited.ToString();
+            if (input.Equals(expected))
+            {
+                Assert.Empty(edits);
+            }
+            else
+            {
+                var edited = ApplyEdits(razorSourceText, edits);
+                var actual = edited.ToString();
 
-            new XUnitVerifier().EqualOrDiff(expected, actual);
+                new XUnitVerifier().EqualOrDiff(expected, actual);
+            }
         }
 
         protected async Task RunCodeActionFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -117,41 +117,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             bool insertSpaces = true,
             string fileKind = null)
         {
-            var (razorSourceText, edits) = await GetOnTypeFormattingEditsAsync(input, triggerCharacter, tabSize, insertSpaces, fileKind);
-
-            // Assert
-            var edited = ApplyEdits(razorSourceText, edits);
-            var actual = edited.ToString();
-
-            new XUnitVerifier().EqualOrDiff(expected, actual);
-        }
-
-        protected async Task RunCodeActionFormattingTestAsync(
-            string input,
-            TextEdit[] codeActionEdits,
-            string expected,
-            int tabSize = 4,
-            bool insertSpaces = true,
-            string fileKind = null)
-        {
-            var (razorSourceText, edits) = await GetOnTypeFormattingEditsAsync(input, ' ', tabSize, insertSpaces, fileKind, codeActionEdits, bypassValidationPasses: true);
-
-            // Assert
-            var edited = ApplyEdits(razorSourceText, edits);
-            var actual = edited.ToString();
-
-            new XUnitVerifier().EqualOrDiff(expected, actual);
-        }
-
-        protected async Task<(SourceText, TextEdit[])> GetOnTypeFormattingEditsAsync(
-            string input,
-            char triggerCharacter,
-            int tabSize = 4,
-            bool insertSpaces = true,
-            string fileKind = null,
-            TextEdit[] codeActionEdits = null,
-            bool bypassValidationPasses = false)
-        {
             // Arrange
             fileKind ??= FileKinds.Component;
 
@@ -170,8 +135,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new InvalidOperationException("Could not map from Razor document to generated document");
             }
 
-            var projectedEdits = codeActionEdits;
-            if (projectedEdits is null && languageKind == RazorLanguageKind.CSharp)
+            var projectedEdits = Array.Empty<TextEdit>();
+            if (languageKind == RazorLanguageKind.CSharp)
             {
                 projectedEdits = await GetFormattedCSharpEditsAsync(
                     codeDocument, triggerCharacter, projectedIndex, insertSpaces, tabSize).ConfigureAwait(false);
@@ -189,10 +154,65 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             };
 
             // Act
-            var edits = await formattingService.ApplyFormattedEditsAsync(
-                uri, documentSnapshot, languageKind, projectedEdits, options, CancellationToken.None, bypassValidationPasses: bypassValidationPasses);
+            var edits = await formattingService.FormatOnTypeAsync(uri, documentSnapshot, languageKind, projectedEdits, options, CancellationToken.None);
 
-            return (razorSourceText, edits);
+            // Assert
+            var edited = ApplyEdits(razorSourceText, edits);
+            var actual = edited.ToString();
+
+            new XUnitVerifier().EqualOrDiff(expected, actual);
+        }
+
+        protected async Task RunCodeActionFormattingTestAsync(
+            string input,
+            TextEdit[] codeActionEdits,
+            string expected,
+            int tabSize = 4,
+            bool insertSpaces = true,
+            string fileKind = null)
+        {
+            if (codeActionEdits is null)
+            {
+                throw new NotImplementedException("Code action formatting must provide edits.");
+            }
+
+            // Arrange
+            fileKind ??= FileKinds.Component;
+
+            TestFileMarkupParser.GetPosition(input, out input, out var positionAfterTrigger);
+
+            var razorSourceText = SourceText.From(input);
+            var path = "file:///path/to/Document.razor";
+            var uri = new Uri(path);
+            var (codeDocument, documentSnapshot) = CreateCodeDocumentAndSnapshot(razorSourceText, uri.AbsolutePath, fileKind: fileKind);
+
+            var mappingService = new DefaultRazorDocumentMappingService();
+            var languageKind = mappingService.GetLanguageKind(codeDocument, positionAfterTrigger);
+            if (languageKind == RazorLanguageKind.Html)
+            {
+                throw new NotImplementedException("Code action formatting is not yet supported for HTML in Razor.");
+            }
+
+            if (!mappingService.TryMapToProjectedDocumentPosition(codeDocument, positionAfterTrigger, out _, out var _))
+            {
+                throw new InvalidOperationException("Could not map from Razor document to generated document");
+            }
+
+            var formattingService = CreateFormattingService(codeDocument);
+            var options = new FormattingOptions()
+            {
+                TabSize = tabSize,
+                InsertSpaces = insertSpaces,
+            };
+
+            // Act
+            var edits = await formattingService.FormatCodeActionAsync(uri, documentSnapshot, languageKind, codeActionEdits, options, CancellationToken.None);
+
+            // Assert
+            var edited = ApplyEdits(razorSourceText, edits);
+            var actual = edited.ToString();
+
+            new XUnitVerifier().EqualOrDiff(expected, actual);
         }
 
         protected static TextEdit Edit(int startLine, int startChar, int endLine, int endChar, string newText)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -397,15 +397,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             public bool Called { get; private set; }
 
-            public override Task<TextEdit[]> ApplyFormattedEditsAsync(DocumentUri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options, CancellationToken cancellationToken, bool bypassValidationPasses = false, bool collapseEdits = false)
-            {
-                return Task.FromResult(formattedEdits);
-            }
-
             public override Task<TextEdit[]> FormatAsync(DocumentUri uri, DocumentSnapshot documentSnapshot, OmniSharp.Extensions.LanguageServer.Protocol.Models.Range range, FormattingOptions options, CancellationToken cancellationToken)
             {
                 Called = true;
                 return Task.FromResult(Array.Empty<TextEdit>());
+            }
+
+            public override Task<TextEdit[]> FormatCodeActionAsync(DocumentUri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(formattedEdits);
+            }
+
+            public override Task<TextEdit[]> FormatOnTypeAsync(DocumentUri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(formattedEdits);
+            }
+
+            public override Task<TextEdit[]> FormatSnippetAsync(DocumentUri uri, DocumentSnapshot documentSnapshot, RazorLanguageKind kind, TextEdit[] formattedEdits, FormattingOptions options, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(formattedEdits);
             }
         }
     }


### PR DESCRIPTION
This is almost a draft, because I did most of it during Friday Social Hour on Saturday morning, but at the same time it does work so ¯\\\_(ツ)_/¯

~Includes https://github.com/dotnet/razor-tooling/pull/5753 so just review https://github.com/dotnet/razor-tooling/commit/271e4bbdea88068b0f43b906a8f9e73fa4bc4e12 and https://github.com/dotnet/razor-tooling/commit/26379f036f487c471b0c52ea8547eb1eeccb6dc5~ See note below

In theory this would allow us to get rid of our custom add using code action stuff.