### PR TITLE
Fix Nullable issues and Log Document Sync errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -71,6 +71,17 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+# dotnet_style_allow_multiple_blank_lines_experimental
+dotnet_diagnostic.IDE2000.severity = warning
+# csharp_style_allow_blank_lines_between_consecutive_braces_experimental
+dotnet_diagnostic.IDE2002.severity = warning
+# csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental
+dotnet_diagnostic.IDE2004.severity = warning
+# csharp_style_allow_embedded_statements_on_same_line_experimental
+dotnet_diagnostic.IDE2001.severity = none
+# dotnet_style_allow_statement_immediately_after_block_experimental
+dotnet_diagnostic.IDE2003.severity = suggestion
+
 
 # IDE0058
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,8 @@ insert_final_newline = true
 
 # Dotnet code style settings:
 [*.cs]
+dotnet_style_allow_multiple_blank_lines_experimental = false:warning
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
@@ -81,7 +83,6 @@ dotnet_diagnostic.IDE2004.severity = warning
 dotnet_diagnostic.IDE2001.severity = none
 # dotnet_style_allow_statement_immediately_after_block_experimental
 dotnet_diagnostic.IDE2003.severity = suggestion
-
 
 # IDE0058
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -60,6 +60,10 @@ csharp_style_var_elsewhere = true:warning
 # Disallow throw expressions.
 csharp_style_throw_expression = false:suggestion
 
+# Space settings
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+
 # Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,7 @@ insert_final_newline = true
 
 # Dotnet code style settings:
 [*.cs]
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
 dotnet_style_allow_multiple_blank_lines_experimental = false:warning
 
 # Sort using and Import directives with System.* appearing first
@@ -82,7 +83,7 @@ dotnet_diagnostic.IDE2004.severity = warning
 # csharp_style_allow_embedded_statements_on_same_line_experimental
 dotnet_diagnostic.IDE2001.severity = none
 # dotnet_style_allow_statement_immediately_after_block_experimental
-dotnet_diagnostic.IDE2003.severity = suggestion
+dotnet_diagnostic.IDE2003.severity = warning
 
 # IDE0058
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,9 +35,6 @@ insert_final_newline = true
 
 # Dotnet code style settings:
 [*.cs]
-dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
-dotnet_style_allow_multiple_blank_lines_experimental = false:warning
-
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
@@ -68,22 +65,21 @@ csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_after_colon_in_inheritance_clause = true
 
 # Newline settings
+dotnet_style_allow_multiple_blank_lines_experimental = false:warning
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
-# dotnet_style_allow_multiple_blank_lines_experimental
-dotnet_diagnostic.IDE2000.severity = warning
 # csharp_style_allow_blank_lines_between_consecutive_braces_experimental
 dotnet_diagnostic.IDE2002.severity = warning
 # csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental
 dotnet_diagnostic.IDE2004.severity = warning
 # csharp_style_allow_embedded_statements_on_same_line_experimental
 dotnet_diagnostic.IDE2001.severity = none
-# dotnet_style_allow_statement_immediately_after_block_experimental
-dotnet_diagnostic.IDE2003.severity = warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
 
 # IDE0058
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/src/Razor/Razor.sln
+++ b/src/Razor/Razor.sln
@@ -88,6 +88,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Remo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Remote.Razor.CoreComponents", "src\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj", "{17C4A6DF-3AA5-43FE-8A0E-53DF14340446}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4CAC99E0-6ECE-4264-96C3-AF4EEE7BC9D1}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\.editorconfig = ..\..\.editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             var syntaxTree = context.CodeDocument.GetSyntaxTree();
 
-            if (!position.TryGetAbsoluteIndex(context.SourceText, out var absoluteIndex, Logger))
+            if (!position.TryGetAbsoluteIndex(context.SourceText, Logger, out var absoluteIndex))
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
@@ -70,7 +70,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             var syntaxTree = context.CodeDocument.GetSyntaxTree();
 
-            var absoluteIndex = position.GetAbsoluteIndex(context.SourceText, Logger);
+            if(!position.TryGetAbsoluteIndex(context.SourceText, out var absoluteIndex, Logger))
+            {
+                return false;
+            }
+
             var change = new SourceChange(absoluteIndex, 0, string.Empty);
             var owner = syntaxTree.Root.LocateOwner(change);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
@@ -2,15 +2,19 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Editor.Razor;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
@@ -20,7 +24,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
         public override string TriggerCharacter => "=";
 
-        public AttributeSnippetOnAutoInsertProvider(TagHelperFactsService tagHelperFactsService)
+        public AttributeSnippetOnAutoInsertProvider(
+            TagHelperFactsService tagHelperFactsService, ILoggerFactory loggerFactory) :
+            base(loggerFactory)
         {
             if (tagHelperFactsService is null)
             {
@@ -30,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             _tagHelperFactsService = tagHelperFactsService;
         }
 
-        public override bool TryResolveInsertion(Position position, FormattingContext context, out TextEdit edit, out InsertTextFormat format)
+        public override bool TryResolveInsertion(Position position, FormattingContext context, [NotNullWhen(true)]out TextEdit? edit, out InsertTextFormat format)
         {
             if (position is null)
             {
@@ -64,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             var syntaxTree = context.CodeDocument.GetSyntaxTree();
 
-            var absoluteIndex = position.GetAbsoluteIndex(context.SourceText);
+            var absoluteIndex = position.GetAbsoluteIndex(context.SourceText, Logger);
             var change = new SourceChange(absoluteIndex, 0, string.Empty);
             var owner = syntaxTree.Root.LocateOwner(change);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AttributeSnippetFormatOnAutoInsertProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -14,8 +16,6 @@ using Microsoft.VisualStudio.Editor.Razor;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
-#nullable enable
-
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
     internal class AttributeSnippetOnAutoInsertProvider : RazorOnAutoInsertProvider
@@ -24,9 +24,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
         public override string TriggerCharacter => "=";
 
-        public AttributeSnippetOnAutoInsertProvider(
-            TagHelperFactsService tagHelperFactsService, ILoggerFactory loggerFactory) :
-            base(loggerFactory)
+        public AttributeSnippetOnAutoInsertProvider(TagHelperFactsService tagHelperFactsService, ILoggerFactory loggerFactory)
+            : base(loggerFactory)
         {
             if (tagHelperFactsService is null)
             {
@@ -36,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             _tagHelperFactsService = tagHelperFactsService;
         }
 
-        public override bool TryResolveInsertion(Position position, FormattingContext context, [NotNullWhen(true)]out TextEdit? edit, out InsertTextFormat format)
+        public override bool TryResolveInsertion(Position position, FormattingContext context, [NotNullWhen(true)] out TextEdit? edit, out InsertTextFormat format)
         {
             if (position is null)
             {
@@ -70,7 +69,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             var syntaxTree = context.CodeDocument.GetSyntaxTree();
 
-            if(!position.TryGetAbsoluteIndex(context.SourceText, out var absoluteIndex, Logger))
+            if (!position.TryGetAbsoluteIndex(context.SourceText, out var absoluteIndex, Logger))
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 return false;
             }
 
-            if (!position.TryGetAbsoluteIndex(context.SourceText, out var afterCloseAngleIndex, Logger))
+            if (!position.TryGetAbsoluteIndex(context.SourceText, Logger, out var afterCloseAngleIndex))
             {
                 format = default;
                 edit = default;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
@@ -42,7 +43,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
         private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
 
-        public AutoClosingTagOnAutoInsertProvider(IOptionsMonitor<RazorLSPOptions> optionsMonitor)
+        public AutoClosingTagOnAutoInsertProvider(IOptionsMonitor<RazorLSPOptions> optionsMonitor, ILoggerFactory loggerFactory)
+            : base(loggerFactory)
         {
             if (optionsMonitor is null)
             {
@@ -73,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 return false;
             }
 
-            var afterCloseAngleIndex = position.GetAbsoluteIndex(context.SourceText);
+            var afterCloseAngleIndex = position.GetAbsoluteIndex(context.SourceText, Logger);
             if (!TryResolveAutoClosingBehavior(context, afterCloseAngleIndex, out var tagName, out var autoClosingBehavior))
             {
                 format = default;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -75,7 +75,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 return false;
             }
 
-            var afterCloseAngleIndex = position.GetAbsoluteIndex(context.SourceText, Logger);
+            if (!position.TryGetAbsoluteIndex(context.SourceText, out var afterCloseAngleIndex, Logger))
+            {
+                format = default;
+                edit = default;
+                return false;
+            }
+
             if (!TryResolveAutoClosingBehavior(context, afterCloseAngleIndex, out var tagName, out var autoClosingBehavior))
             {
                 format = default;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -14,13 +16,14 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
     internal class AutoClosingTagOnAutoInsertProvider : RazorOnAutoInsertProvider
     {
         // From http://dev.w3.org/html5/spec/Overview.html#elements-0
-        private static readonly IReadOnlyList<string> VoidElements = new[]
+        private static readonly IReadOnlyList<string> s_voidElements = new[]
         {
             "area",
             "base",
@@ -56,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
         public override string TriggerCharacter => ">";
 
-        public override bool TryResolveInsertion(Position position, FormattingContext context, out TextEdit edit, out InsertTextFormat format)
+        public override bool TryResolveInsertion(Position position, FormattingContext context, [NotNullWhen(true)] out TextEdit? edit, out InsertTextFormat format)
         {
             if (position is null)
             {
@@ -121,7 +124,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             return true;
         }
 
-        private static bool TryResolveAutoClosingBehavior(FormattingContext context, int afterCloseAngleIndex, out string name, out AutoClosingBehavior autoClosingBehavior)
+        private static bool TryResolveAutoClosingBehavior(FormattingContext context, int afterCloseAngleIndex, [NotNullWhen(true)] out string? name, out AutoClosingBehavior autoClosingBehavior)
         {
             var change = new SourceChange(afterCloseAngleIndex, 0, string.Empty);
             var syntaxTree = context.CodeDocument.GetSyntaxTree();
@@ -181,7 +184,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             return false;
         }
 
-        private static bool TryEnsureOwner_WorkaroundCompilerQuirks(int afterCloseAngleIndex, RazorSyntaxTree syntaxTree, SyntaxNode currentOwner, out SyntaxNode newOwner)
+        private static bool TryEnsureOwner_WorkaroundCompilerQuirks(int afterCloseAngleIndex, RazorSyntaxTree syntaxTree, SyntaxNode currentOwner, [NotNullWhen(true)] out SyntaxNode? newOwner)
         {
             // All of these owner modifications are to account for https://github.com/dotnet/aspnetcore/issues/33919
 
@@ -311,11 +314,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             return true;
         }
 
-        private static AutoClosingBehavior InferAutoClosingBehavior(string name, StringComparer tagNameComparer = null)
+        private static AutoClosingBehavior InferAutoClosingBehavior(string name, StringComparer? tagNameComparer = null)
         {
             tagNameComparer ??= StringComparer.OrdinalIgnoreCase;
 
-            if (VoidElements.Contains(name, tagNameComparer))
+            if (s_voidElements.Contains(name, tagNameComparer))
             {
                 return AutoClosingBehavior.SelfClosing;
             }
@@ -362,8 +365,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             do
             {
-                string potentialStartTagName = null;
-                RazorSyntaxNode endTag = null;
+                string? potentialStartTagName = null;
+                RazorSyntaxNode? endTag = null;
                 if (node is MarkupTagHelperElementSyntax parentTagHelper)
                 {
                     potentialStartTagName = parentTagHelper.StartTag.Name.Content;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/CloseTextTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/CloseTextTagOnAutoInsertProvider.cs
@@ -79,7 +79,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             var syntaxTree = context.CodeDocument.GetSyntaxTree();
 
-            var absoluteIndex = position.GetAbsoluteIndex(context.SourceText, logger) - 1;
+            if (!position.TryGetAbsoluteIndex(context.SourceText, out var absoluteIndex, logger))
+            {
+                return false;
+            }
+            absoluteIndex -= 1;
             var change = new SourceChange(absoluteIndex, 0, string.Empty);
             var owner = syntaxTree.Root.LocateOwner(change);
             if (owner?.Parent != null &&

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/CloseTextTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/CloseTextTagOnAutoInsertProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
         {
             var syntaxTree = context.CodeDocument.GetSyntaxTree();
 
-            if (!position.TryGetAbsoluteIndex(context.SourceText, out var absoluteIndex, logger))
+            if (!position.TryGetAbsoluteIndex(context.SourceText, logger, out var absoluteIndex))
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/CloseTextTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/CloseTextTagOnAutoInsertProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -13,8 +15,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/RazorOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/RazorOnAutoInsertProvider.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/RazorOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/RazorOnAutoInsertProvider.cs
@@ -1,15 +1,32 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
     internal abstract class RazorOnAutoInsertProvider
     {
+        internal readonly ILogger Logger;
+
+        public RazorOnAutoInsertProvider(ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            Logger = loggerFactory.CreateLogger<RazorOnAutoInsertProvider>();
+        }
+
         public abstract string TriggerCharacter { get; }
 
-        public abstract bool TryResolveInsertion(Position position, FormattingContext context, out TextEdit edit, out InsertTextFormat format);
+        public abstract bool TryResolveInsertion(Position position, FormattingContext context, [NotNullWhen(true)] out TextEdit? edit, out InsertTextFormat format);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
             var sourceText = await document.GetTextAsync();
-            if(!request.Position.TryGetAbsoluteIndex(sourceText, _logger, out var hostDocumentIndex))
+            if (!request.Position.TryGetAbsoluteIndex(sourceText, _logger, out var hostDocumentIndex))
             {
                 return new CompletionList(isIncomplete: false);
             }
@@ -335,7 +335,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         internal static bool TryConvert(
             RazorCompletionItem razorCompletionItem,
             IReadOnlyList<ExtendedCompletionItemKinds>? supportedItemKinds,
-            [NotNullWhen(true)]out CompletionItem? completionItem)
+            [NotNullWhen(true)] out CompletionItem? completionItem)
         {
             if (razorCompletionItem is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -180,7 +180,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
             var sourceText = await document.GetTextAsync();
-            var hostDocumentIndex = request.Position.GetAbsoluteIndex(sourceText, _logger);
+            if(!request.Position.TryGetAbsoluteIndex(sourceText, out var hostDocumentIndex, _logger))
+            {
+                return new CompletionList(isIncomplete: false);
+            }
+
             var location = new SourceSpan(hostDocumentIndex, 0);
             var reason = request.Context.TriggerKind switch
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
             var sourceText = await document.GetTextAsync();
-            if(!request.Position.TryGetAbsoluteIndex(sourceText, out var hostDocumentIndex, _logger))
+            if(!request.Position.TryGetAbsoluteIndex(sourceText, _logger, out var hostDocumentIndex))
             {
                 return new CompletionList(isIncomplete: false);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -20,8 +22,6 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
     {
-        private readonly ILogger? _logger;
+        private readonly ILogger _logger;
 
         public DefaultRazorDocumentMappingService(ILoggerFactory loggerFactory) : base()
         {
@@ -33,7 +33,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _logger = loggerFactory.CreateLogger<DefaultRazorDocumentMappingService>();
         }
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        [Obsolete("This only exists to prevent Moq from complaining, use the other constructor.")]
         public DefaultRazorDocumentMappingService() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         public override TextEdit[] GetProjectedDocumentEdits(RazorCodeDocument codeDocument, TextEdit[] edits)
         {
@@ -49,8 +52,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     continue;
                 }
 
-                var startSync = range.Start.TryGetAbsoluteIndex(csharpSourceText, out var startIndex, _logger);
-                var endSync = range.End.TryGetAbsoluteIndex(csharpSourceText, out var endIndex, _logger);
+                var startSync = range.Start.TryGetAbsoluteIndex(csharpSourceText, _logger, out var startIndex);
+                var endSync = range.End.TryGetAbsoluteIndex(csharpSourceText, _logger, out var endIndex);
                 if (startSync is false || endSync is false)
                 {
                     break;
@@ -103,9 +106,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Debug.Assert(lastNewLine == 0 || edit.NewText.Substring(0, lastNewLine - 1).All(c => c == '\r' || c == '\n'), "We are throwing away part of an edit that has more than just empty lines!");
 
                     var proposedRange = new Range(range.End.Line, 0, range.End.Line, range.End.Character);
-                    startSync = proposedRange.Start.TryGetAbsoluteIndex(csharpSourceText, out startIndex);
-                    endSync = proposedRange.End.TryGetAbsoluteIndex(csharpSourceText, out endIndex);
-                    if(startSync is false || endSync is false)
+                    startSync = proposedRange.Start.TryGetAbsoluteIndex(csharpSourceText, _logger, out startIndex);
+                    endSync = proposedRange.End.TryGetAbsoluteIndex(csharpSourceText, _logger, out endIndex);
+                    if (startSync is false || endSync is false)
                     {
                         break;
                     }
@@ -252,13 +255,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return false;
             }
 
-            if (!range.Start.TryGetAbsoluteIndex(sourceText, out var startIndex, _logger) ||
+            if (!range.Start.TryGetAbsoluteIndex(sourceText, _logger, out var startIndex) ||
                 !TryMapToProjectedDocumentPosition(codeDocument, startIndex, out var projectedStart, out var _))
             {
                 return false;
             }
 
-            if (!range.End.TryGetAbsoluteIndex(sourceText, out var endIndex, _logger) ||
+            if (!range.End.TryGetAbsoluteIndex(sourceText, _logger, out var endIndex) ||
                 !TryMapToProjectedDocumentPosition(codeDocument, endIndex, out var projectedEnd, out var _))
             {
                 return false;
@@ -461,14 +464,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
 
-            if (!range.Start.TryGetAbsoluteIndex(csharpSourceText, out var startIndex, _logger) ||
+            if (!range.Start.TryGetAbsoluteIndex(csharpSourceText, _logger, out var startIndex) ||
                 !TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _))
             {
                 return false;
             }
 
 
-            if (!range.End.TryGetAbsoluteIndex(csharpSourceText, out var endIndex, _logger) ||
+            if (!range.End.TryGetAbsoluteIndex(csharpSourceText, _logger, out var endIndex) ||
                 !TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _))
             {
                 return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.Extensions.Logging;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 #nullable enable
@@ -20,6 +21,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
     {
+        private readonly ILogger? _logger;
+
+        public DefaultRazorDocumentMappingService(ILoggerFactory loggerFactory) : base()
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<DefaultRazorDocumentMappingService>();
+        }
+
+        public DefaultRazorDocumentMappingService() { }
+
         public override TextEdit[] GetProjectedDocumentEdits(RazorCodeDocument codeDocument, TextEdit[] edits)
         {
             var projectedEdits = new List<TextEdit>();
@@ -34,8 +49,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     continue;
                 }
 
-                var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText);
-                var endIndex = range.End.GetAbsoluteIndex(csharpSourceText);
+                var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText, _logger);
+                var endIndex = range.End.GetAbsoluteIndex(csharpSourceText, _logger);
                 var mappedStart = TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _);
                 var mappedEnd = TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _);
 
@@ -229,13 +244,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return false;
             }
 
-            var startIndex = range.Start.GetAbsoluteIndex(sourceText);
+            var startIndex = range.Start.GetAbsoluteIndex(sourceText, _logger);
             if (!TryMapToProjectedDocumentPosition(codeDocument, startIndex, out var projectedStart, out var _))
             {
                 return false;
             }
 
-            var endIndex = range.End.GetAbsoluteIndex(sourceText);
+            var endIndex = range.End.GetAbsoluteIndex(sourceText, _logger);
             if (!TryMapToProjectedDocumentPosition(codeDocument, endIndex, out var projectedEnd, out var _))
             {
                 return false;
@@ -437,13 +452,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return false;
             }
 
-            var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText);
+            var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText, _logger);
             if (!TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _))
             {
                 return false;
             }
 
-            var endIndex = range.End.GetAbsoluteIndex(csharpSourceText);
+            var endIndex = range.End.GetAbsoluteIndex(csharpSourceText, _logger);
             if (!TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _))
             {
                 return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -461,14 +461,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
 
-            if (range.Start.TryGetAbsoluteIndex(csharpSourceText, out var startIndex, _logger) ||
+            if (!range.Start.TryGetAbsoluteIndex(csharpSourceText, out var startIndex, _logger) ||
                 !TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _))
             {
                 return false;
             }
 
 
-            if (range.End.TryGetAbsoluteIndex(csharpSourceText, out var endIndex, _logger) ||
+            if (!range.End.TryGetAbsoluteIndex(csharpSourceText, out var endIndex, _logger) ||
                 !TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _))
             {
                 return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -49,8 +49,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     continue;
                 }
 
-                var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText, _logger);
-                var endIndex = range.End.GetAbsoluteIndex(csharpSourceText, _logger);
+                var startSync = range.Start.TryGetAbsoluteIndex(csharpSourceText, out var startIndex, _logger);
+                var endSync = range.End.TryGetAbsoluteIndex(csharpSourceText, out var endIndex, _logger);
+                if (startSync is false || endSync is false)
+                {
+                    break;
+                }
                 var mappedStart = TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _);
                 var mappedEnd = TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _);
 
@@ -99,8 +103,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Debug.Assert(lastNewLine == 0 || edit.NewText.Substring(0, lastNewLine - 1).All(c => c == '\r' || c == '\n'), "We are throwing away part of an edit that has more than just empty lines!");
 
                     var proposedRange = new Range(range.End.Line, 0, range.End.Line, range.End.Character);
-                    startIndex = proposedRange.Start.GetAbsoluteIndex(csharpSourceText);
-                    endIndex = proposedRange.End.GetAbsoluteIndex(csharpSourceText);
+                    startSync = proposedRange.Start.TryGetAbsoluteIndex(csharpSourceText, out startIndex);
+                    endSync = proposedRange.End.TryGetAbsoluteIndex(csharpSourceText, out endIndex);
+                    if(startSync is false || endSync is false)
+                    {
+                        break;
+                    }
                     mappedStart = TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out hostDocumentStart, out _);
                     mappedEnd = TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out hostDocumentEnd, out _);
 
@@ -244,14 +252,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return false;
             }
 
-            var startIndex = range.Start.GetAbsoluteIndex(sourceText, _logger);
-            if (!TryMapToProjectedDocumentPosition(codeDocument, startIndex, out var projectedStart, out var _))
+            if (!range.Start.TryGetAbsoluteIndex(sourceText, out var startIndex, _logger) ||
+                !TryMapToProjectedDocumentPosition(codeDocument, startIndex, out var projectedStart, out var _))
             {
                 return false;
             }
 
-            var endIndex = range.End.GetAbsoluteIndex(sourceText, _logger);
-            if (!TryMapToProjectedDocumentPosition(codeDocument, endIndex, out var projectedEnd, out var _))
+            if (!range.End.TryGetAbsoluteIndex(sourceText, out var endIndex, _logger) ||
+                !TryMapToProjectedDocumentPosition(codeDocument, endIndex, out var projectedEnd, out var _))
             {
                 return false;
             }
@@ -452,14 +460,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return false;
             }
 
-            var startIndex = range.Start.GetAbsoluteIndex(csharpSourceText, _logger);
-            if (!TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _))
+
+            if (range.Start.TryGetAbsoluteIndex(csharpSourceText, out var startIndex, _logger) ||
+                !TryMapFromProjectedDocumentPosition(codeDocument, startIndex, out var hostDocumentStart, out _))
             {
                 return false;
             }
 
-            var endIndex = range.End.GetAbsoluteIndex(csharpSourceText, _logger);
-            if (!TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _))
+
+            if (range.End.TryGetAbsoluteIndex(csharpSourceText, out var endIndex, _logger) ||
+                !TryMapFromProjectedDocumentPosition(codeDocument, endIndex, out var hostDocumentEnd, out _))
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -14,8 +16,6 @@ using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Microsoft.Extensions.Logging;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -21,8 +23,6 @@ using DiagnosticSeverity = OmniSharp.Extensions.LanguageServer.Protocol.Models.D
 using RazorDiagnosticFactory = Microsoft.AspNetCore.Razor.Language.RazorDiagnosticFactory;
 using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
 using SyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -270,6 +270,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             {
                 // C# in a style block causes diagnostics because the HTML background document replaces C# with "~"
                 var owner = syntaxTree.GetOwner(sourceText, d.Range.Start, logger);
+                if (owner is null)
+                {
+                    return false;
+                }
 
                 var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>(
                     n => n.StartTag.Name.Content.Equals("style", StringComparison.Ordinal));
@@ -283,6 +287,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             static bool IsAnyFilteredTooFewElementsError(OmniSharpVSDiagnostic d, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
             {
                 var owner = syntaxTree.GetOwner(sourceText, d.Range.Start, logger);
+                if (owner is null)
+                {
+                    return false;
+                }
+
                 var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
 
                 if (!element.StartTag.Name.Content.Equals("html", StringComparison.Ordinal))
@@ -299,6 +308,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             static bool IsHtmlWithBangAndMatchingTags(OmniSharpVSDiagnostic d, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
             {
                 var owner = syntaxTree.GetOwner(sourceText, d.Range.Start, logger);
+                if (owner is null)
+                {
+                    return false;
+                }
 
                 var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
                 var startNode = element.StartTag;
@@ -325,6 +338,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             static bool IsInvalidNestingWarningWithinComponent(OmniSharpVSDiagnostic d, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
             {
                 var owner = syntaxTree.GetOwner(sourceText, d.Range.Start, logger);
+                if (owner is null)
+                {
+                    return false;
+                }
 
                 var taghelperNode = owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
 
@@ -336,6 +353,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             static bool IsInvalidNestingFromBody(OmniSharpVSDiagnostic d, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
             {
                 var owner = syntaxTree.GetOwner(sourceText, d.Range.Start, logger);
+                if (owner is null)
+                {
+                    return false;
+                }
+
                 var body = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag.Name.Content.Equals("body", StringComparison.Ordinal));
 
                 if (ReferenceEquals(body, owner))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -369,6 +369,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 {
                     return false;
                 }
+
                 return d.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag.Bang != null;
             }
         }
@@ -533,13 +534,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         remappedRange = null;
                         return false;
                     }
+
                     var startLine = sourceText.Lines[startLineIndex];
 
                     // Look for the first non-whitespace character so we're not squiggling random whitespace at the start of the diagnostic
                     var firstNonWhitespaceCharacterOffset = sourceText.GetFirstNonWhitespaceOffset(startLine.Span, out _);
                     var diagnosticStartCharacter = firstNonWhitespaceCharacterOffset ?? 0;
                     var startLinePosition = new Position(startLineIndex, diagnosticStartCharacter);
-
 
                     var endLineIndex = diagnosticRange.End.Line;
                     if (endLineIndex >= sourceText.Lines.Count)
@@ -548,6 +549,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         remappedRange = null;
                         return false;
                     }
+
                     var endLine = sourceText.Lines[endLineIndex];
 
                     // Look for the last non-whitespace character so we're not squiggling random whitespace at the end of the diagnostic

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
             var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
 
-            var startOrEndTag = owner.FirstAncestorOrSelf<RazorSyntaxNode>(n => n is MarkupTagHelperStartTagSyntax || n is MarkupTagHelperEndTagSyntax);
+            var startOrEndTag = owner?.FirstAncestorOrSelf<RazorSyntaxNode>(n => n is MarkupTagHelperStartTagSyntax || n is MarkupTagHelperEndTagSyntax);
             if (startOrEndTag == null)
             {
                 return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 absoluteIndex = -1;
                 return false;
             }
+
             var index = sourceText.Lines.GetPosition(linePosition);
             absoluteIndex = index;
             return true;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Microsoft.AspNetCore.Razor.LanguageServer.RazorLS;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
     internal static class PositionExtensions
     {
-        public static int GetAbsoluteIndex(this Position position, SourceText sourceText, ILogger? logger = null)
+        public static bool TryGetAbsoluteIndex(this Position position, SourceText sourceText, out int absoluteIndex, ILogger? logger = null)
         {
             if (position is null)
             {
@@ -33,10 +33,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                     nameof(sourceText),
                     sourceText.Lines.Count);
                 logger?.LogError(errorMessage);
-                throw new ArgumentOutOfRangeException(nameof(linePosition), errorMessage);
+                absoluteIndex = -1;
+                return false;
             }
             var index = sourceText.Lines.GetPosition(linePosition);
-            return index;
+            absoluteIndex = index;
+            return true;
         }
 
         public static int CompareTo(this Position position, Position other)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Razor.LanguageServer.RazorLS;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 #nullable enable
@@ -12,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
     internal static class PositionExtensions
     {
-        public static int GetAbsoluteIndex(this Position position, SourceText sourceText)
+        public static int GetAbsoluteIndex(this Position position, SourceText sourceText, ILogger? logger = null)
         {
             if (position is null)
             {
@@ -27,8 +28,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
             var linePosition = new LinePosition(position.Line, position.Character);
             if (linePosition.Line >= sourceText.Lines.Count)
             {
-                throw new ArgumentOutOfRangeException(Resources.FormatPositionIndex_Outside_Range(
-                    position.Line, nameof(sourceText), sourceText.Lines.Count));
+                var errorMessage = Resources.FormatPositionIndex_Outside_Range(
+                    position.Line,
+                    nameof(sourceText),
+                    sourceText.Lines.Count);
+                logger?.LogError(errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(linePosition), errorMessage);
             }
             var index = sourceText.Lines.GetPosition(linePosition);
             return index;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
     internal static class PositionExtensions
     {
-        public static bool TryGetAbsoluteIndex(this Position position, SourceText sourceText, out int absoluteIndex, ILogger? logger = null)
+        public static bool TryGetAbsoluteIndex(this Position position, SourceText sourceText, ILogger logger, out int absoluteIndex)
         {
             if (position is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
+#nullable enable
+
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
     internal static class RangeExtensions
@@ -71,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
             return overlapStart.CompareTo(overlapEnd) <= 0;
         }
 
-        public static Range Overlap(this Range range, Range other)
+        public static Range? Overlap(this Range range, Range other)
         {
             if (range is null)
             {
@@ -131,9 +133,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 throw new ArgumentNullException(nameof(sourceText));
             }
 
-            var start = sourceText.Lines[(int)range.Start.Line].Start + (int)range.Start.Character;
-            var end = sourceText.Lines[(int)range.End.Line].Start + (int)range.End.Character;
-            return new TextSpan(start, end - start);
+            var start = sourceText.Lines[range.Start.Line].Start + range.Start.Character;
+            var end = sourceText.Lines[range.End.Line].Start + range.End.Character;
+
+            var length = end - start;
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException($"{range} resolved to a negative length.");
+            }
+
+            return new TextSpan(start, length);
         }
 
         public static bool IsUndefined(this Range range)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,8 +13,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-
-#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            if(!position.TryGetAbsoluteIndex(sourceText, out var absoluteIndex, logger))
+            if (!position.TryGetAbsoluteIndex(sourceText, out var absoluteIndex, logger))
             {
                 return default;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            if (!position.TryGetAbsoluteIndex(sourceText, out var absoluteIndex, logger))
+            if (!position.TryGetAbsoluteIndex(sourceText, logger, out var absoluteIndex))
             {
                 return default;
             }
@@ -118,8 +118,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 throw new ArgumentNullException(nameof(range));
             }
 
-            var startInSync = range.Start.TryGetAbsoluteIndex(sourceText, out var absoluteStartIndex, logger);
-            var endInSync = range.End.TryGetAbsoluteIndex(sourceText, out var absoluteEndIndex, logger);
+            var startInSync = range.Start.TryGetAbsoluteIndex(sourceText, logger, out var absoluteStartIndex);
+            var endInSync = range.End.TryGetAbsoluteIndex(sourceText, logger, out var absoluteEndIndex);
             if (startInSync is false || endInSync is false)
             {
                 return default;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
@@ -9,7 +9,10 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
@@ -58,7 +61,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
             return statements;
         }
 
-        public static SyntaxNode GetOwner(this RazorSyntaxTree syntaxTree, SourceText sourceText, Position position)
+        public static SyntaxNode GetOwner(
+            this RazorSyntaxTree syntaxTree,
+            SourceText sourceText,
+            Position position,
+            ILogger logger)
         {
             if (syntaxTree is null)
             {
@@ -75,13 +82,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 throw new ArgumentNullException(nameof(position));
             }
 
-            var absoluteIndex = position.GetAbsoluteIndex(sourceText);
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            var absoluteIndex = position.GetAbsoluteIndex(sourceText, logger);
             var change = new SourceChange(absoluteIndex, 0, string.Empty);
             var owner = syntaxTree.Root.LocateOwner(change);
             return owner;
         }
 
-        public static SyntaxNode GetOwner(this RazorSyntaxTree syntaxTree, SourceText sourceText, Range range)
+        public static SyntaxNode GetOwner(
+            this RazorSyntaxTree syntaxTree,
+            SourceText sourceText,
+            Range range,
+            ILogger logger)
         {
             if (syntaxTree is null)
             {
@@ -98,8 +114,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 throw new ArgumentNullException(nameof(range));
             }
 
-            var absoluteStartIndex = range.Start.GetAbsoluteIndex(sourceText);
-            var absoluteEndIndex = range.End.GetAbsoluteIndex(sourceText);
+            var absoluteStartIndex = range.Start.GetAbsoluteIndex(sourceText, logger);
+            var absoluteEndIndex = range.End.GetAbsoluteIndex(sourceText, logger);
             var length = absoluteEndIndex - absoluteStartIndex;
             var change = new SourceChange(absoluteStartIndex, length, string.Empty);
             var owner = syntaxTree.Root.LocateOwner(change);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -225,9 +225,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
-            if(!request.Position.TryGetAbsoluteIndex(sourceText, out var hostDocumentIndex, _logger))
+            if (!request.Position.TryGetAbsoluteIndex(sourceText, out var hostDocumentIndex, _logger))
             {
-                return null;    
+                return null;
             }
 
             var triggerCharacterKind = _razorDocumentMappingService.GetLanguageKind(codeDocument, hostDocumentIndex);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
-            if (!request.Position.TryGetAbsoluteIndex(sourceText, out var hostDocumentIndex, _logger))
+            if (!request.Position.TryGetAbsoluteIndex(sourceText, _logger, out var hostDocumentIndex))
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
-            var hostDocumentIndex = request.Position.GetAbsoluteIndex(sourceText);
+            var hostDocumentIndex = request.Position.GetAbsoluteIndex(sourceText, _logger);
             var triggerCharacterKind = _razorDocumentMappingService.GetLanguageKind(codeDocument, hostDocumentIndex);
             if (triggerCharacterKind is not RazorLanguageKind.CSharp)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -225,7 +225,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
-            var hostDocumentIndex = request.Position.GetAbsoluteIndex(sourceText, _logger);
+            if(!request.Position.TryGetAbsoluteIndex(sourceText, out var hostDocumentIndex, _logger))
+            {
+                return null;    
+            }
+
             var triggerCharacterKind = _razorDocumentMappingService.GetLanguageKind(codeDocument, hostDocumentIndex);
             if (triggerCharacterKind is not RazorLanguageKind.CSharp)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
@@ -236,6 +236,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                         return;
                     }
                 }
+
                 ResultsReady?.Invoke(this, args);
             }
 
@@ -263,6 +264,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                             _currentParcelCancelSource.Dispose();
                             _currentParcelCancelSource = null;
                         }
+
                         _cancelSource.Dispose();
                         _hasParcel.Dispose();
                         _hasParcel = null;
@@ -354,6 +356,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                                         }
                                     }
                                 }
+
                                 if (args != null)
                                 {
                                     _main.ReturnParcel(args);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorProjectChangePublisher.cs
@@ -177,6 +177,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                         // less aggressive and do a delayed publish.
                         EnqueuePublish(args.Newer);
                     }
+
                     break;
                 case ProjectChangeKind.DocumentRemoved:
                 case ProjectChangeKind.DocumentAdded:
@@ -187,6 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                         // we enqueue publishes and then publish the latest project after a delay.
                         EnqueuePublish(args.Newer);
                     }
+
                     break;
 
                 case ProjectChangeKind.ProjectAdded:
@@ -195,6 +197,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     {
                         ImmediatePublish(args.Newer);
                     }
+
                     break;
 
                 case ProjectChangeKind.ProjectRemoved:
@@ -253,7 +256,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     // If we don't track the value in PublishFilePathMappings that means it's already been removed, do nothing.
                     return;
                 }
-
 
                 lock (_pendingProjectPublishesLock)
                 {
@@ -339,6 +341,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     _documentsProcessed = true;
                 }
             }
+
             if (status is null)
             {
                 return true;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -950,6 +950,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         break;
                     }
                 }
+
                 var nonTabIndentation = wordStart - firstNonTab;
                 var leadingIndentation = leadingTabs * formattingOptions.TabSize;
                 var baseIndentation = leadingIndentation + nonTabIndentation;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProgressListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProgressListener.cs
@@ -118,7 +118,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             _ = CompleteAfterDelayAsync(token, request.DelayAfterLastNotifyAsync, linkedCTS); // Fire and forget
 
-
             async Task CompleteAfterDelayAsync(string token, Func<CancellationToken, Task> delayAfterLastNotifyAsync, CancellationTokenSource cts)
             {
                 try

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -155,7 +155,7 @@
       <!-- End HTML specific colorization -->
 
       <!-- Begin C# specific colorization -->
-<!--
+
       <dict>
         <key>scope</key>
         <string>variable</string>
@@ -235,8 +235,6 @@
           <string>parameter name</string>
         </dict>
       </dict>
-      </dict>
--->
 
       <!-- End C# specific colorization -->
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -155,7 +155,7 @@
       <!-- End HTML specific colorization -->
 
       <!-- Begin C# specific colorization -->
-
+<!--
       <dict>
         <key>scope</key>
         <string>variable</string>
@@ -235,6 +235,8 @@
           <string>parameter name</string>
         </dict>
       </dict>
+      </dict>
+-->
 
       <!-- End C# specific colorization -->
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AttributeSnippetFormatOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AttributeSnippetFormatOnAutoInsertProviderTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AttributeSnippetFormatOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AttributeSnippetFormatOnAutoInsertProviderTest.cs
@@ -121,7 +121,7 @@ tagHelpers: TagHelpers);
 
         internal override RazorOnAutoInsertProvider CreateProvider()
         {
-            var provider = new AttributeSnippetOnAutoInsertProvider(new DefaultTagHelperFactsService());
+            var provider = new AttributeSnippetOnAutoInsertProvider(new DefaultTagHelperFactsService(), LoggerFactory);
             return provider;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -718,7 +718,7 @@ expected: @"
             var optionsMonitor = new Mock<IOptionsMonitor<RazorLSPOptions>>(MockBehavior.Strict);
             optionsMonitor.SetupGet(o => o.CurrentValue).Returns(Options);
 
-            var provider = new AutoClosingTagOnAutoInsertProvider(optionsMonitor.Object);
+            var provider = new AutoClosingTagOnAutoInsertProvider(optionsMonitor.Object, LoggerFactory);
             return provider;
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/CloseTextTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/CloseTextTagOnAutoInsertProviderTest.cs
@@ -41,7 +41,7 @@ expected: @"
         {
             var optionsMonitor = new Mock<IOptionsMonitor<RazorLSPOptions>>(MockBehavior.Strict);
             optionsMonitor.SetupGet(o => o.CurrentValue).Returns(RazorLSPOptions.Default);
-            var provider = new CloseTextTagOnAutoInsertProvider(optionsMonitor.Object);
+            var provider = new CloseTextTagOnAutoInsertProvider(optionsMonitor.Object, LoggerFactory);
 
             return provider;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/CloseTextTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/CloseTextTagOnAutoInsertProviderTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     {
         public OnAutoInsertEndpointTest()
         {
-            EmptyDocumentResolver = Mock.Of<DocumentResolver>(r => r.TryResolveDocument(It.IsAny<string>(), out It.Ref<DocumentSnapshot>.IsAny) == false, MockBehavior.Strict);
+            EmptyDocumentResolver = Mock.Of<DocumentResolver>(r => r.TryResolveDocument(It.IsAny<string>(), out It.Ref<DocumentSnapshot?>.IsAny) == false, MockBehavior.Strict);
         }
 
         private DocumentResolver EmptyDocumentResolver { get; }
@@ -256,14 +258,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             public bool Called { get; private set; }
 
-            public TextEdit ResolvedTextEdit { get; set; }
+            public TextEdit? ResolvedTextEdit { get; set; }
 
             public override string TriggerCharacter { get; }
 
             public override bool TryResolveInsertion(Position position, FormattingContext context, out TextEdit edit, out InsertTextFormat format)
             {
                 Called = true;
-                edit = ResolvedTextEdit;
+                Assert.NotNull(ResolvedTextEdit);
+                edit = ResolvedTextEdit!;
                 format = default;
                 return _canResolve;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -262,7 +262,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             public override string TriggerCharacter { get; }
 
-            public override bool TryResolveInsertion(Position position, FormattingContext context, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TextEdit? edit, out InsertTextFormat format)
+            // Disabling because [NotNullWhen] is available in two Assemblies and causes warnings
+#pragma warning disable CS8765 // Nullability of type of parameter doesn't match overridden member (possibly because of nullability attributes).
+            public override bool TryResolveInsertion(Position position, FormattingContext context, out TextEdit? edit, out InsertTextFormat format)
+#pragma warning restore CS8765 // Nullability of type of parameter doesn't match overridden member (possibly because of nullability attributes).
             {
                 Called = true;
                 edit = ResolvedTextEdit!;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -262,10 +262,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             public override string TriggerCharacter { get; }
 
-            public override bool TryResolveInsertion(Position position, FormattingContext context, out TextEdit edit, out InsertTextFormat format)
+            public override bool TryResolveInsertion(Position position, FormattingContext context, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TextEdit? edit, out InsertTextFormat format)
             {
                 Called = true;
-                Assert.NotNull(ResolvedTextEdit);
                 edit = ResolvedTextEdit!;
                 format = default;
                 return _canResolve;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
@@ -35,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument();
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
-            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
+            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
             var endpoint = new OnAutoInsertEndpoint(LegacyDispatcher, documentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
@@ -63,11 +64,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument();
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
-            var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: false)
+            var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: false, LoggerFactory)
             {
                 ResolvedTextEdit = new TextEdit()
             };
-            var insertProvider2 = new TestOnAutoInsertProvider(">", canResolve: true)
+            var insertProvider2 = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory)
             {
                 ResolvedTextEdit = new TextEdit()
             };
@@ -100,11 +101,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument();
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
-            var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true)
+            var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory)
             {
                 ResolvedTextEdit = new TextEdit()
             };
-            var insertProvider2 = new TestOnAutoInsertProvider(">", canResolve: true)
+            var insertProvider2 = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory)
             {
                 ResolvedTextEdit = new TextEdit()
             };
@@ -137,8 +138,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument();
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
-            var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true);
-            var insertProvider2 = new TestOnAutoInsertProvider("<", canResolve: true);
+            var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
+            var insertProvider2 = new TestOnAutoInsertProvider("<", canResolve: true, LoggerFactory);
             var endpoint = new OnAutoInsertEndpoint(LegacyDispatcher, documentResolver, new[] { insertProvider1, insertProvider2 }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
@@ -164,7 +165,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_DocumentNotFound_ReturnsNull()
         {
             // Arrange
-            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
+            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
             var endpoint = new OnAutoInsertEndpoint(LegacyDispatcher, EmptyDocumentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var uri = new Uri("file://path/test.razor");
             var @params = new OnAutoInsertParams()
@@ -194,7 +195,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             codeDocument.SetUnsupported();
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
-            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
+            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
             var endpoint = new OnAutoInsertEndpoint(LegacyDispatcher, documentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
@@ -222,7 +223,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument();
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
-            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: false);
+            var insertProvider = new TestOnAutoInsertProvider(">", canResolve: false, LoggerFactory);
             var endpoint = new OnAutoInsertEndpoint(LegacyDispatcher, documentResolver, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
             var @params = new OnAutoInsertParams()
             {
@@ -247,7 +248,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             private readonly bool _canResolve;
 
-            public TestOnAutoInsertProvider(string triggerCharacter, bool canResolve)
+            public TestOnAutoInsertProvider(string triggerCharacter, bool canResolve, ILoggerFactory loggerFactory) : base(loggerFactory)
             {
                 TriggerCharacter = triggerCharacter;
                 _canResolve = canResolve;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,8 +21,6 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-#nullable enable
-
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         public ExtractToCodeBehindCodeActionResolverTest()
         {
             _emptyDocumentResolver = new Mock<DocumentResolver>(MockBehavior.Strict).Object;
-            Mock.Get(_emptyDocumentResolver).Setup(r => r.TryResolveDocument(It.IsAny<string>(), out It.Ref<DocumentSnapshot>.IsAny)).Returns(false);
+            Mock.Get(_emptyDocumentResolver).Setup(r => r.TryResolveDocument(It.IsAny<string>(), out It.Ref<DocumentSnapshot?>.IsAny)).Returns(false);
 
             var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
             Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>())).Verifiable();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -14,9 +14,12 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
+
+#nullable enable
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -24,10 +27,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
     {
         private readonly DocumentResolver _emptyDocumentResolver;
 
+        private readonly ILogger _logger;
+
         public ExtractToCodeBehindCodeActionResolverTest()
         {
             _emptyDocumentResolver = new Mock<DocumentResolver>(MockBehavior.Strict).Object;
             Mock.Get(_emptyDocumentResolver).Setup(r => r.TryResolveDocument(It.IsAny<string>(), out It.Ref<DocumentSnapshot>.IsAny)).Returns(false);
+
+            var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
+            Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>())).Verifiable();
+            Mock.Get(logger).Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(false);
+
+            _logger = logger;
         }
 
         [Fact]
@@ -129,19 +140,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             // Assert
             Assert.NotNull(workspaceEdit);
             Assert.NotNull(workspaceEdit.DocumentChanges);
-            Assert.Equal(3, workspaceEdit.DocumentChanges.Count());
+            Assert.Equal(3, workspaceEdit.DocumentChanges!.Count());
 
-            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var documentChanges = workspaceEdit.DocumentChanges!.ToArray();
             var createFileChange = documentChanges[0];
             Assert.True(createFileChange.IsCreateFile);
 
             var editCodeDocumentChange = documentChanges[1];
-            var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit.Edits.First();
-            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText()));
-            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText()));
+            Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
+            var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
+            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
+            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
 
             var editCodeBehindChange = documentChanges[2];
-            var editCodeBehindEdit = editCodeBehindChange.TextDocumentEdit.Edits.First();
+            Assert.NotNull(editCodeBehindChange.TextDocumentEdit);
+            var editCodeBehindEdit = editCodeBehindChange.TextDocumentEdit!.Edits.First();
             Assert.Contains("public partial class Test", editCodeBehindEdit.NewText, StringComparison.Ordinal);
             Assert.Contains("private var x = 1", editCodeBehindEdit.NewText, StringComparison.Ordinal);
             Assert.Contains("namespace test.Pages", editCodeBehindEdit.NewText, StringComparison.Ordinal);
@@ -173,19 +186,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             // Assert
             Assert.NotNull(workspaceEdit);
             Assert.NotNull(workspaceEdit.DocumentChanges);
-            Assert.Equal(3, workspaceEdit.DocumentChanges.Count());
+            Assert.Equal(3, workspaceEdit.DocumentChanges!.Count());
 
-            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var documentChanges = workspaceEdit.DocumentChanges!.ToArray();
             var createFileChange = documentChanges[0];
             Assert.True(createFileChange.IsCreateFile);
 
             var editCodeDocumentChange = documentChanges[1];
-            var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit.Edits.First();
-            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText()));
-            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText()));
+            Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
+            var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
+            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
+            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
 
             var editCodeBehindChange = documentChanges[2];
-            var editCodeBehindEdit = editCodeBehindChange.TextDocumentEdit.Edits.First();
+            Assert.NotNull(editCodeBehindChange.TextDocumentEdit);
+            var editCodeBehindEdit = editCodeBehindChange.TextDocumentEdit!.Edits.First();
             Assert.Contains("public partial class Test", editCodeBehindEdit.NewText, StringComparison.Ordinal);
             Assert.Contains("private var x = 1", editCodeBehindEdit.NewText, StringComparison.Ordinal);
             Assert.Contains("namespace test.Pages", editCodeBehindEdit.NewText, StringComparison.Ordinal);
@@ -217,19 +232,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             // Assert
             Assert.NotNull(workspaceEdit);
             Assert.NotNull(workspaceEdit.DocumentChanges);
-            Assert.Equal(3, workspaceEdit.DocumentChanges.Count());
+            Assert.Equal(3, workspaceEdit.DocumentChanges!.Count());
 
-            var documentChanges = workspaceEdit.DocumentChanges.ToArray();
+            var documentChanges = workspaceEdit.DocumentChanges!.ToArray();
             var createFileChange = documentChanges[0];
             Assert.True(createFileChange.IsCreateFile);
 
             var editCodeDocumentChange = documentChanges[1];
-            var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit.Edits.First();
-            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText()));
-            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText()));
+            Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
+            var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
+            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
+            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
 
             var editCodeBehindChange = documentChanges[2];
-            var editCodeBehindEdit = editCodeBehindChange.TextDocumentEdit.Edits.First();
+            Assert.NotNull(editCodeBehindChange.TextDocumentEdit);
+            var editCodeBehindEdit = editCodeBehindChange.TextDocumentEdit!.Edits.First();
             Assert.Contains("using System.Diagnostics", editCodeBehindEdit.NewText, StringComparison.Ordinal);
             Assert.Contains("public partial class Test", editCodeBehindEdit.NewText, StringComparison.Ordinal);
             Assert.Contains("private var x = 1", editCodeBehindEdit.NewText, StringComparison.Ordinal);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -149,9 +149,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
             var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
-            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeStart, _logger));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeStart));
             Assert.Equal(actionParams.RemoveStart, removeStart);
-            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeEnd, _logger));
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeEnd));
             Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];
@@ -197,9 +197,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
             var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
-            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeStart, _logger));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeStart));
             Assert.Equal(actionParams.RemoveStart, removeStart);
-            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeEnd, _logger));
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeEnd));
             Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];
@@ -245,9 +245,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
             var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
-            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeStart, _logger));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeStart));
             Assert.Equal(actionParams.RemoveStart, removeStart);
-            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeEnd, _logger));
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeEnd));
             Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -149,8 +149,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
             var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
-            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
-            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeStart, _logger));
+            Assert.Equal(actionParams.RemoveStart, removeStart);
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeEnd, _logger));
+            Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];
             Assert.NotNull(editCodeBehindChange.TextDocumentEdit);
@@ -195,8 +197,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
             var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
-            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
-            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeStart, _logger));
+            Assert.Equal(actionParams.RemoveStart, removeStart);
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeEnd, _logger));
+            Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];
             Assert.NotNull(editCodeBehindChange.TextDocumentEdit);
@@ -241,8 +245,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.NotNull(editCodeDocumentChange.TextDocumentEdit);
             var editCodeDocumentEdit = editCodeDocumentChange.TextDocumentEdit!.Edits.First();
-            Assert.Equal(actionParams.RemoveStart, editCodeDocumentEdit.Range.Start.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
-            Assert.Equal(actionParams.RemoveEnd, editCodeDocumentEdit.Range.End.GetAbsoluteIndex(codeDocument.GetSourceText(), _logger));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeStart, _logger));
+            Assert.Equal(actionParams.RemoveStart, removeStart);
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), out var removeEnd, _logger));
+            Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];
             Assert.NotNull(editCodeBehindChange.TextDocumentEdit);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,7 +24,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public DefaultRazorDocumentMappingServiceTest()
         {
             var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
-            Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>())).Verifiable();
+            Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>())).Verifiable();
             Mock.Get(logger).Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(false);
             LoggerFactory = Mock.Of<ILoggerFactory>(factory => factory.CreateLogger(It.IsAny<string>()) == logger, MockBehavior.Strict);
         }
@@ -371,17 +373,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 });
 
             // Act
-            var result = service.TryMapToProjectedDocumentPosition(
+            if (service.TryMapToProjectedDocumentPosition(
                 codeDoc,
                 16,
                 out var projectedPosition,
-                out var projectedPositionIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(2, projectedPosition.Line);
-            Assert.Equal(0, projectedPosition.Character);
-            Assert.Equal(11, projectedPositionIndex);
+                out var projectedPositionIndex))
+            {
+                Assert.Equal(2, projectedPosition.Line);
+                Assert.Equal(0, projectedPosition.Character);
+                Assert.Equal(11, projectedPositionIndex);
+            }
+            else
+            {
+                Assert.False(true, $"{service.TryMapToProjectedDocumentPosition} should have returned true");
+            }
         }
 
         [Fact]
@@ -397,18 +402,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
                 });
 
-            // Act
-            var result = service.TryMapToProjectedDocumentPosition(
+            // Act & Assert
+            if (service.TryMapToProjectedDocumentPosition(
                 codeDoc,
                 28,
                 out var projectedPosition,
-                out var projectedPositionIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(3, projectedPosition.Line);
-            Assert.Equal(2, projectedPosition.Character);
-            Assert.Equal(23, projectedPositionIndex);
+                out var projectedPositionIndex))
+            {
+                Assert.Equal(3, projectedPosition.Line);
+                Assert.Equal(2, projectedPosition.Character);
+                Assert.Equal(23, projectedPositionIndex);
+            }
+            else
+            {
+                Assert.False(true, "TryMapToProjectedDocumentPosition should have been true");
+            }
         }
 
         [Fact]
@@ -424,18 +432,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
                 });
 
-            // Act
-            var result = service.TryMapToProjectedDocumentPosition(
+            // Act & Assert
+            if (service.TryMapToProjectedDocumentPosition(
                 codeDoc,
                 35,
                 out var projectedPosition,
-                out var projectedPositionIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(3, projectedPosition.Line);
-            Assert.Equal(9, projectedPosition.Character);
-            Assert.Equal(30, projectedPositionIndex);
+                out var projectedPositionIndex))
+            {
+                Assert.Equal(3, projectedPosition.Line);
+                Assert.Equal(9, projectedPosition.Character);
+                Assert.Equal(30, projectedPositionIndex);
+            }
+            else
+            {
+                Assert.True(false, "TryMapToProjectedDocumentPosition should have returned true");
+            }
         }
 
         [Fact]
@@ -474,18 +485,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
                 });
 
-            // Act
-            var result = service.TryMapFromProjectedDocumentPosition(
+            // Act & Assert
+            if (service.TryMapFromProjectedDocumentPosition(
                 codeDoc,
                 11, // @{|
                 out var hostDocumentPosition,
-                out var hostDocumentIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(1, hostDocumentPosition.Line);
-            Assert.Equal(9, hostDocumentPosition.Character);
-            Assert.Equal(16, hostDocumentIndex);
+                out var hostDocumentIndex))
+            {
+                Assert.Equal(1, hostDocumentPosition.Line);
+                Assert.Equal(9, hostDocumentPosition.Character);
+                Assert.Equal(16, hostDocumentIndex);
+            }
+            else
+            {
+                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+            }
         }
 
         [Fact]
@@ -501,18 +515,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
                 });
 
-            // Act
-            var result = service.TryMapFromProjectedDocumentPosition(
+            // Act & Assert
+            if (service.TryMapFromProjectedDocumentPosition(
                 codeDoc,
                 21, // |var def
                 out var hostDocumentPosition,
-                out var hostDocumentIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(2, hostDocumentPosition.Line);
-            Assert.Equal(0, hostDocumentPosition.Character);
-            Assert.Equal(26, hostDocumentIndex);
+                out var hostDocumentIndex))
+            {
+                Assert.Equal(2, hostDocumentPosition.Line);
+                Assert.Equal(0, hostDocumentPosition.Character);
+                Assert.Equal(26, hostDocumentIndex);
+            }
+            else
+            {
+                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+            }
         }
 
         [Fact]
@@ -528,18 +545,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
                 });
 
-            // Act
-            var result = service.TryMapFromProjectedDocumentPosition(
+            // Act & Assert
+            if (service.TryMapFromProjectedDocumentPosition(
                 codeDoc,
                 30, // def; |}
                 out var hostDocumentPosition,
-                out var hostDocumentIndex);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(2, hostDocumentPosition.Line);
-            Assert.Equal(9, hostDocumentPosition.Character);
-            Assert.Equal(35, hostDocumentIndex);
+                out var hostDocumentIndex))
+            {
+                Assert.Equal(2, hostDocumentPosition.Line);
+                Assert.Equal(9, hostDocumentPosition.Character);
+                Assert.Equal(35, hostDocumentIndex);
+            }
+            else
+            {
+                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+            }
         }
 
         [Fact]
@@ -556,18 +576,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 });
             var range = new Range(new Position(1, 10), new Position(1, 13));
 
-            // Act
-            var result = service.TryMapToProjectedDocumentRange(
+            // Act & Assert
+            if (service.TryMapToProjectedDocumentRange(
                 codeDoc,
                 range, // |var| abc
-                out var projectedRange);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(2, projectedRange.Start.Line);
-            Assert.Equal(1, projectedRange.Start.Character);
-            Assert.Equal(2, projectedRange.End.Line);
-            Assert.Equal(4, projectedRange.End.Character);
+                out var projectedRange))
+            {
+                Assert.Equal(2, projectedRange.Start.Line);
+                Assert.Equal(1, projectedRange.Start.Character);
+                Assert.Equal(2, projectedRange.End.Line);
+                Assert.Equal(4, projectedRange.End.Character);
+            }
+            else
+            {
+                Assert.False(true, $"{service.TryMapToProjectedDocumentRange} should have returned true");
+            }
         }
 
         [Fact]
@@ -874,7 +897,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Equal(RazorLanguageKind.Html, languageKind);
         }
 
-        private static (IReadOnlyList<ClassifiedSpanInternal> classifiedSpans, IReadOnlyList<TagHelperSpanInternal> tagHelperSpans) GetClassifiedSpans(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+        private static (IReadOnlyList<ClassifiedSpanInternal> classifiedSpans, IReadOnlyList<TagHelperSpanInternal> tagHelperSpans) GetClassifiedSpans(string text, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null)
         {
             var codeDocument = CreateCodeDocument(text, tagHelpers);
             var syntaxTree = codeDocument.GetSyntaxTree();
@@ -883,7 +906,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return (classifiedSpans, tagHelperSpans);
         }
 
-        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null)
         {
             tagHelpers ??= Array.Empty<TagHelperDescriptor>();
             var sourceDocument = TestRazorSourceDocument.Create(text);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -952,7 +954,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
             // Assert
             var returnedDiagnostic = Assert.Single(response.Diagnostics);
-            Assert.Equal(HtmlErrorCodes.MissingEndTagErrorCode, returnedDiagnostic.Code.Value.String);
+            Assert.NotNull(returnedDiagnostic.Code);
+            Assert.Equal(HtmlErrorCodes.MissingEndTagErrorCode, returnedDiagnostic.Code!.Value.String);
         }
 
         [Fact]
@@ -1011,7 +1014,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
             // Assert
             var diagnostic = Assert.Single(response.Diagnostics);
-            Assert.Equal(HtmlErrorCodes.UnexpectedEndTagErrorCode, diagnostic.Code.Value.String);
+            Assert.NotNull(diagnostic.Code);
+            Assert.Equal(HtmlErrorCodes.UnexpectedEndTagErrorCode, diagnostic.Code!.Value.String);
         }
 
         [Fact]
@@ -1110,7 +1114,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             return documentResolver.Object;
         }
 
-        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null, string kind = null)
+        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null, string? kind = null)
         {
             tagHelpers ??= Array.Empty<TagHelperDescriptor>();
             var sourceDocument = TestRazorSourceDocument.Create(text);
@@ -1123,7 +1127,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             string razorSource,
             string projectedCSharpSource,
             IEnumerable<SourceMapping> sourceMappings,
-            IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+            IReadOnlyList<TagHelperDescriptor>? tagHelpers = null)
         {
             var codeDocument = CreateCodeDocument(razorSource, tagHelpers);
             var csharpDocument = RazorCSharpDocument.Create(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 .Returns(true);
 
             DocumentVersionCache = documentVersionCache.Object;
-            MappingService = new DefaultRazorDocumentMappingService();
+            MappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
         }
 
         private DocumentVersionCache DocumentVersionCache { get; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
@@ -118,7 +118,7 @@ public class Foo { }
 
         private FormattingContentValidationPass GetPass()
         {
-            var mappingService = new DefaultRazorDocumentMappingService();
+            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
 
             var client = Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict);
             var pass = new FormattingContentValidationPass(mappingService, FilePathNormalizer, client, LoggerFactory)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -129,7 +131,7 @@ public class Foo { }
             return pass;
         }
 
-        private static FormattingContext CreateFormattingContext(SourceText source, int tabSize = 4, bool insertSpaces = true, string fileKind = null)
+        private static FormattingContext CreateFormattingContext(SourceText source, int tabSize = 4, bool insertSpaces = true, string? fileKind = null)
         {
             var path = "file:///path/to/document.razor";
             var uri = new Uri(path);
@@ -144,7 +146,7 @@ public class Foo { }
             return context;
         }
 
-        private static (RazorCodeDocument, DocumentSnapshot) CreateCodeDocumentAndSnapshot(SourceText text, string path, IReadOnlyList<TagHelperDescriptor> tagHelpers = null, string fileKind = default)
+        private static (RazorCodeDocument, DocumentSnapshot) CreateCodeDocumentAndSnapshot(SourceText text, string path, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null, string? fileKind = default)
         {
             fileKind ??= FileKinds.Component;
             tagHelpers ??= Array.Empty<TagHelperDescriptor>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -136,7 +138,7 @@ public class Foo { }
             return pass;
         }
 
-        private static FormattingContext CreateFormattingContext(SourceText source, int tabSize = 4, bool insertSpaces = true, string fileKind = null)
+        private static FormattingContext CreateFormattingContext(SourceText source, int tabSize = 4, bool insertSpaces = true, string? fileKind = null)
         {
             var path = "file:///path/to/document.razor";
             var uri = new Uri(path);
@@ -151,7 +153,7 @@ public class Foo { }
             return context;
         }
 
-        private static (RazorCodeDocument, DocumentSnapshot) CreateCodeDocumentAndSnapshot(SourceText text, string path, IReadOnlyList<TagHelperDescriptor> tagHelpers = null, string fileKind = default)
+        private static (RazorCodeDocument, DocumentSnapshot) CreateCodeDocumentAndSnapshot(SourceText text, string path, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null, string? fileKind = default)
         {
             fileKind ??= FileKinds.Component;
             tagHelpers ??= Array.Empty<TagHelperDescriptor>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
@@ -125,7 +125,7 @@ public class Foo { }
 
         private FormattingDiagnosticValidationPass GetPass()
         {
-            var mappingService = new DefaultRazorDocumentMappingService();
+            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
 
             var client = Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict);
             var pass = new FormattingDiagnosticValidationPass(mappingService, FilePathNormalizer, client, LoggerFactory)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri(path);
             var (codeDocument, documentSnapshot) = CreateCodeDocumentAndSnapshot(razorSourceText, uri.AbsolutePath, fileKind: fileKind);
 
-            var mappingService = new DefaultRazorDocumentMappingService();
+            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var languageKind = mappingService.GetLanguageKind(codeDocument, positionAfterTrigger);
 
             if (!mappingService.TryMapToProjectedDocumentPosition(codeDocument, positionAfterTrigger, out _, out var projectedIndex))
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         private RazorFormattingService CreateFormattingService(RazorCodeDocument codeDocument)
         {
-            var mappingService = new DefaultRazorDocumentMappingService();
+            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
 
             var client = new FormattingLanguageServerClient();
             client.AddCodeDocument(codeDocument);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -52,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             LoggerFactory = new FormattingTestLoggerFactory(output);
         }
 
-        public static string TestProjectPath { get; private set; }
+        public static string? TestProjectPath { get; private set; }
 
         protected FilePathNormalizer FilePathNormalizer { get; }
 
@@ -61,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         // Used by the test framework to set the 'base' name for test files.
         public static string FileName
         {
-            get { return s_fileName.Value; }
+            get { return s_fileName.Value!; }
             set { s_fileName.Value = value; }
         }
 
@@ -70,8 +72,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             string expected,
             int tabSize = 4,
             bool insertSpaces = true,
-            string fileKind = null,
-            IReadOnlyList<TagHelperDescriptor> tagHelpers = null,
+            string? fileKind = null,
+            IReadOnlyList<TagHelperDescriptor>? tagHelpers = null,
             bool useSourceTextDiffer = false)
         {
             // Arrange
@@ -115,7 +117,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             char triggerCharacter,
             int tabSize = 4,
             bool insertSpaces = true,
-            string fileKind = null)
+            string? fileKind = null)
         {
             // Arrange
             fileKind ??= FileKinds.Component;
@@ -176,7 +178,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             string expected,
             int tabSize = 4,
             bool insertSpaces = true,
-            string fileKind = null)
+            string? fileKind = null)
         {
             if (codeActionEdits is null)
             {
@@ -289,7 +291,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             return source.WithChanges(changes);
         }
 
-        private static (RazorCodeDocument, DocumentSnapshot) CreateCodeDocumentAndSnapshot(SourceText text, string path, IReadOnlyList<TagHelperDescriptor> tagHelpers = null, string fileKind = default)
+        private static (RazorCodeDocument, DocumentSnapshot) CreateCodeDocumentAndSnapshot(SourceText text, string path, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null, string? fileKind = default)
         {
             fileKind ??= FileKinds.Component;
             tagHelpers ??= Array.Empty<TagHelperDescriptor>();
@@ -349,12 +351,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var assemblyName = typeof(FormattingTestBase).Assembly.GetName().Name;
-            var projectDirectory = Path.Combine(repoRoot, "src", "Razor", "test", assemblyName);
+            var projectDirectory = Path.Combine(repoRoot, "src", "Razor", "test", assemblyName!);
 
             return projectDirectory;
         }
 
-        private static string SearchUp(string baseDirectory, string fileName)
+        private static string? SearchUp(string baseDirectory, string fileName)
         {
             var directoryInfo = new DirectoryInfo(baseDirectory);
             do
@@ -367,7 +369,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
                 directoryInfo = directoryInfo.Parent;
             }
-            while (directoryInfo.Parent != null);
+            while (directoryInfo?.Parent != null);
 
             return null;
         }
@@ -380,7 +382,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 current = current.Parent;
             }
-            var tagHelperFilePath = Path.Combine(current.FullName, testFileName);
+            var tagHelperFilePath = Path.Combine(current!.FullName, testFileName);
             var buffer = File.ReadAllBytes(tagHelperFilePath);
             var serializer = new JsonSerializer();
             serializer.Converters.Add(new TagHelperDescriptorJsonConverter());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -195,7 +195,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri(path);
             var (codeDocument, documentSnapshot) = CreateCodeDocumentAndSnapshot(razorSourceText, uri.AbsolutePath, fileKind: fileKind);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var mappingService = new DefaultRazorDocumentMappingService();
+#pragma warning restore CS0618 // Type or member is obsolete
             var languageKind = mappingService.GetLanguageKind(codeDocument, positionAfterTrigger);
             if (languageKind == RazorLanguageKind.Html)
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorFormattingEndpoint(
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorFormattingEndpoint(
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.AbsolutePath, codeDocument);
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorFormattingEndpoint(
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
             var endpoint = new RazorFormattingEndpoint(
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Arrange
             var uri = new Uri("file://path/test.razor");
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
             var endpoint = new RazorFormattingEndpoint(
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver("file://path/testDifferentFile.razor", codeDocument);
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorFormattingEndpoint(
@@ -192,7 +192,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorFormattingEndpoint(
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorFormattingEndpoint(
@@ -326,7 +326,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var formattingService = new TestRazorFormattingService();
-            var documentMappingService = new DefaultRazorDocumentMappingService();
+            var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var adhocWorkspaceFactory = TestAdhocWorkspaceFactory.Instance;
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorFormattingEndpoint(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingEndpointTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -27,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     {
         public RazorFormattingEndpointTest()
         {
-            EmptyDocumentResolver = Mock.Of<DocumentResolver>(r => r.TryResolveDocument(It.IsAny<string>(), out It.Ref<DocumentSnapshot>.IsAny) == false, MockBehavior.Strict);
+            EmptyDocumentResolver = Mock.Of<DocumentResolver>(r => r.TryResolveDocument(It.IsAny<string>(), out It.Ref<DocumentSnapshot?>.IsAny) == false, MockBehavior.Strict);
         }
 
         private DocumentResolver EmptyDocumentResolver { get; }
@@ -344,7 +346,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             // Assert
             Assert.NotNull(result);
-            Assert.Collection(Iterate(result.GetEnumerator()),
+            Assert.Collection(Iterate(result!.GetEnumerator()),
                 edit => Assert.Equal(edit, new TextEdit { NewText = "   ", Range = new Range { Start = new Position { Line = 2, Character = 1 }, End = new Position { Line = 2, Character = 1 } } }),
                 edit => Assert.Equal(edit, new TextEdit { NewText = " ", Range = new Range { Start = new Position { Line = 2, Character = 3 }, End = new Position { Line = 2, Character = 3 } } }),
                 edit => Assert.Equal(edit, new TextEdit { NewText = " ", Range = new Range { Start = new Position { Line = 2, Character = 9 }, End = new Position { Line = 2, Character = 9 } } }),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -66,7 +68,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var response = await Task.Run(() => languageEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Equal(expectedRange, response.Ranges[0]);
+            Assert.NotNull(response);
+            Assert.Equal(expectedRange, response!.Ranges[0]);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
@@ -96,7 +99,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var response = await Task.Run(() => languageEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Equal(RangeExtensions.UndefinedRange, response.Ranges[0]);
+            Assert.NotNull(response);
+            Assert.Equal(RangeExtensions.UndefinedRange, response!.Ranges[0]);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
@@ -126,7 +130,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var response = await Task.Run(() => languageEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Equal(RangeExtensions.UndefinedRange, response.Ranges[0]);
+            Assert.NotNull(response);
+            Assert.Equal(RangeExtensions.UndefinedRange, response!.Ranges[0]);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
@@ -156,7 +161,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var response = await Task.Run(() => languageEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Equal(RangeExtensions.UndefinedRange, response.Ranges[0]);
+            Assert.NotNull(response);
+            Assert.Equal(RangeExtensions.UndefinedRange, response!.Ranges[0]);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
@@ -179,7 +185,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var response = await Task.Run(() => languageEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Equal(request.ProjectedRanges[0], response.Ranges[0]);
+            Assert.NotNull(response);
+            Assert.Equal(request.ProjectedRanges[0], response!.Ranges[0]);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
@@ -202,7 +209,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var response = await Task.Run(() => languageEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Equal(request.ProjectedRanges[0], response.Ranges[0]);
+            Assert.NotNull(response);
+            Assert.Equal(request.ProjectedRanges[0], response!.Ranges[0]);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
@@ -233,7 +241,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var response = await Task.Run(() => languageEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Equal(RangeExtensions.UndefinedRange, response.Ranges[0]);
+            Assert.NotNull(response);
+            Assert.Equal(RangeExtensions.UndefinedRange, response!.Ranges[0]);
             Assert.Equal(1337, response.HostDocumentVersion);
         }
 
@@ -355,7 +364,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return documentResolver.Object;
         }
 
-        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null)
         {
             tagHelpers ??= Array.Empty<TagHelperDescriptor>();
             var sourceDocument = TestRazorSourceDocument.Create(text);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Returns(true);
 
             DocumentVersionCache = documentVersionCache.Object;
-            MappingService = new DefaultRazorDocumentMappingService();
+            MappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
         }
 
         private DocumentVersionCache DocumentVersionCache { get; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Intermediate/IntermediateNodeAssert.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Intermediate/IntermediateNodeAssert.cs
@@ -300,6 +300,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
                     Assert.Equal(TokenKind.CSharp, token.Kind);
                     content.Append(token.Content);
                 }
+
                 Assert.Equal("EndContext();", content.ToString());
             }
             catch (XunitException e)


### PR DESCRIPTION
### Summary of the changes
 - We were throwing a Null-Ref in some scenarios so I turned on `#nullable enable` for the offending area and the areas it touched.
 - Log an error and return false in cases where Document is out of sync.
 - Unfortunately these were both very popular methods, so between the mandatory changes and "I touched this so I need to turn nullable on" a lot of files were modified.

Fixes: Items 2 and 3 from https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1435565?src=WorkItemMention&src-action=artifact_link#2937098.