### PR TITLE
Call AdviseRunningDocTableEvents on UI thread.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
@@ -53,11 +53,12 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _runningDocumentTable = (IVsRunningDocumentTable4)runningDocumentTable;
             _editorAdaptersFactory = editorAdaptersFactory;
 
-            joinableTaskContext.Factory.Run(() =>
+            joinableTaskContext.Factory.Run(async () =>
             {
+                await joinableTaskContext.Factory.SwitchToMainThreadAsync();
+
                 var hr = runningDocumentTable.AdviseRunningDocTableEvents(new RunningDocumentTableEventSink(this), out _);
                 Marshal.ThrowExceptionForHR(hr);
-                return Task.CompletedTask;
             });
 
             _documentsByCookie = new Dictionary<uint, List<DocumentKey>>();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -52,8 +53,12 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _runningDocumentTable = (IVsRunningDocumentTable4)runningDocumentTable;
             _editorAdaptersFactory = editorAdaptersFactory;
 
-            var hr = runningDocumentTable.AdviseRunningDocTableEvents(new RunningDocumentTableEventSink(this), out _);
-            Marshal.ThrowExceptionForHR(hr);
+            joinableTaskContext.Factory.Run(() =>
+            {
+                var hr = runningDocumentTable.AdviseRunningDocTableEvents(new RunningDocumentTableEventSink(this), out _);
+                Marshal.ThrowExceptionForHR(hr);
+                return Task.CompletedTask;
+            });
 
             _documentsByCookie = new Dictionary<uint, List<DocumentKey>>();
             _cookiesByDocument = new Dictionary<DocumentKey, uint>();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
@@ -53,6 +53,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _runningDocumentTable = (IVsRunningDocumentTable4)runningDocumentTable;
             _editorAdaptersFactory = editorAdaptersFactory;
 
+            // Need to grab running doc-table events but that requires the UI thread.
             joinableTaskContext.Factory.Run(async () =>
             {
                 await joinableTaskContext.Factory.SwitchToMainThreadAsync();


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1441597

@mgoertz-msft I wasn't actually able to reproduce the issue in the work item but not calling Advise on a background thread is ultimately the right thing to do. Therefore, pushing this codechange given the comments in the associated issue