### PR TITLE
Disable C# classification from TextMate

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -170,6 +170,7 @@
         </dict>
       </dict>
 
+      <!-- Classification removed temporarily due to https://github.com/dotnet/razor-tooling/issues/5614 -->
       <!-- <a> [href]="Hello"> -->
       <!-- <dict>
         <key>scope</key>
@@ -181,6 +182,7 @@
         </dict>
       </dict> -->
 
+      <!-- Classification removed temporarily due to https://github.com/dotnet/razor-tooling/issues/5614 -->
       <!-- <a> href=["Hello"]> -->
       <!-- <dict>
         <key>scope</key>
@@ -215,6 +217,7 @@
         </dict>
       </dict>
 
+      <!-- Classification removed temporarily due to https://github.com/dotnet/razor-tooling/issues/5614 -->
       <!-- <dict>
         <key>scope</key>
         <string>storage.type.cs, entity.name.type.class.cs</string>
@@ -234,7 +237,7 @@
           <string>method name</string>
         </dict>
       </dict>
-
+      <!-- Classification removed temporarily due to https://github.com/dotnet/razor-tooling/issues/5614 -->
       <!-- <dict>
         <key>scope</key>
         <string>variable.other.object.cs, entity.name.variable.local.cs</string>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -29,6 +29,56 @@
         </dict>
       </dict>
 
+      <dict>
+        <key>scope</key>
+        <string>variable</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>Identifier</string>
+        </dict>
+      </dict>
+
+      <dict>
+        <key>scope</key>
+        <string>keyword.control.conditional, keyword.control.loop, keyword.control.flow</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>keyword - control</string>
+        </dict>
+      </dict>
+
+      <dict>
+        <key>scope</key>
+        <string>entity.name.label</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>parameter name</string>
+        </dict>
+      </dict>
+
+      <dict>
+        <key>scope</key>
+        <string>entity.name.variable.parameter</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>parameter name</string>
+        </dict>
+      </dict>
+
+      <dict>
+        <key>scope</key>
+        <string>constant.language, variable.language</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>Keyword</string>
+        </dict>
+      </dict>
+
       <!-- End General -->
 
       <!-- Begin Razor specific colorization -->
@@ -154,55 +204,10 @@
 
       <!-- End HTML specific colorization -->
 
-      <!-- Begin Generic colorization -->
-      <!-- These can apply to many different languages -->
-
-      <dict>
-        <key>scope</key>
-        <string>variable</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>Identifier</string>
-        </dict>
-      </dict>
-
-      <dict>
-        <key>scope</key>
-        <string>keyword.control.conditional, keyword.control.loop, keyword.control.flow</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>keyword - control</string>
-        </dict>
-      </dict>
-
-      <dict>
-        <key>scope</key>
-        <string>entity.name.label</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>parameter name</string>
-        </dict>
-      </dict>
-
-      <dict>
-        <key>scope</key>
-        <string>entity.name.variable.parameter</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>parameter name</string>
-        </dict>
-      </dict>
-
-      <!-- End  Generic colorization -->
-
       <!-- Begin C# specific colorization -->
       <dict>
         <key>scope</key>
-        <string>constant.language, variable.language, storage.modifier.cs, keyword.type.cs, keyword.other.using.cs, keyword.other.await.cs, keyword.other.var.cs</string>
+        <string>storage.modifier.cs, keyword.type.cs, keyword.other.using.cs, keyword.other.await.cs, keyword.other.var.cs</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -154,8 +154,9 @@
 
       <!-- End HTML specific colorization -->
 
-      <!-- Begin C# specific colorization -->
-<!--
+      <!-- Begin Generic colorization -->
+      <!-- These can apply to many different languages -->
+
       <dict>
         <key>scope</key>
         <string>variable</string>
@@ -163,46 +164,6 @@
         <dict>
           <key>vsclassificationtype</key>
           <string>Identifier</string>
-        </dict>
-      </dict>
-
-      <dict>
-        <key>scope</key>
-        <string>constant.language, variable.language, storage.modifier.cs, keyword.type.cs, keyword.other.using.cs, keyword.other.await.cs, keyword.other.var.cs</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>Keyword</string>
-        </dict>
-      </dict>
-
-      <dict>
-        <key>scope</key>
-        <string>storage.type.cs, entity.name.type.class.cs</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>class name</string>
-        </dict>
-      </dict>
-
-      <dict>
-        <key>scope</key>
-        <string>entity.name.function.cs</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>method name</string>
-        </dict>
-      </dict>
-
-      <dict>
-        <key>scope</key>
-        <string>variable.other.object.cs, entity.name.variable.local.cs</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>local name</string>
         </dict>
       </dict>
 
@@ -235,8 +196,49 @@
           <string>parameter name</string>
         </dict>
       </dict>
+
+      <!-- End  Generic colorization -->
+
+      <!-- Begin C# specific colorization -->
+      <dict>
+        <key>scope</key>
+        <string>constant.language, variable.language, storage.modifier.cs, keyword.type.cs, keyword.other.using.cs, keyword.other.await.cs, keyword.other.var.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>Keyword</string>
+        </dict>
       </dict>
--->
+
+      <!-- <dict>
+        <key>scope</key>
+        <string>storage.type.cs, entity.name.type.class.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>class name</string>
+        </dict>
+      </dict> -->
+
+      <dict>
+        <key>scope</key>
+        <string>entity.name.function.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>method name</string>
+        </dict>
+      </dict>
+
+      <!-- <dict>
+        <key>scope</key>
+        <string>variable.other.object.cs, entity.name.variable.local.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>local name</string>
+        </dict>
+      </dict> -->
 
       <!-- End C# specific colorization -->
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -155,7 +155,7 @@
       <!-- End HTML specific colorization -->
 
       <!-- Begin C# specific colorization -->
-
+<!--
       <dict>
         <key>scope</key>
         <string>variable</string>
@@ -235,6 +235,8 @@
           <string>parameter name</string>
         </dict>
       </dict>
+      </dict>
+-->
 
       <!-- End C# specific colorization -->
 


### PR DESCRIPTION
### Summary of the changes
 - Disable colorization for C# classifications because they are "bleeding" in some cases.

Temporary fix for https://github.com/dotnet/razor-tooling/issues/5614 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1426196/. Long term fix is that colors should be explicitly defined for default classifications and then this should be reverted.