### PR TITLE
Fix publish from breaking Razor component discovery.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
@@ -106,19 +106,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 }
 
                 _logger.LogInformation("Project configuration output path has changed. Stopping existing monitor for project '{0}' so we can restart it with a new directory.", request.ProjectFilePath);
-                entry.Detector.Stop();
+                RemoveMonitor(request.ProjectFilePath);
             }
-            else
-            {
-                var detector = CreateFileChangeDetector();
-                entry = (configurationDirectory, detector);
 
-                if (!_outputPathMonitors.TryAdd(request.ProjectFilePath, entry))
-                {
-                    // There's a concurrent request going on for this specific project. To avoid calling "StartAsync" twice we return early.
-                    // Note: This is an extremely edge case race condition that should in practice never happen due to how long it takes to calculate project state changes
-                    return Unit.Value;
-                }
+            var detector = CreateFileChangeDetector();
+            entry = (configurationDirectory, detector);
+
+            if (!_outputPathMonitors.TryAdd(request.ProjectFilePath, entry))
+            {
+                // There's a concurrent request going on for this specific project. To avoid calling "StartAsync" twice we return early.
+                // Note: This is an extremely edge case race condition that should in practice never happen due to how long it takes to calculate project state changes
+                return Unit.Value;
             }
 
             _logger.LogInformation("Starting new configuration monitor for project '{0}' for directory '{1}'.", request.ProjectFilePath, configurationDirectory);


### PR DESCRIPTION
- So turns out for customers who have moved their `obj` folders out of the solution directory (common for larger apps and done via the MSBuild `BaseIntermediateOutputPath` or `IntermediateOutputPath` property) and then published their app would break our ability to consume future Razor component / project system information. Turns out the `obj` folder + publish combo breaks due to a blatant bug in our `project.razor.json` change detection mechanism. Let me explain: Whenever a project has an `obj` outside of the workspace directory we need to notify the RZLS where to look for said `obj` folder so it can detect `project.razor.json` changes. We do this via a custom endpoint (`razor/monitorProjectConfigurationFilePath`) which takes in a csproj + `project.razor.json` path. So when a user would publish what the IDE would do is move the project to the `Release` configuration to build the app and then immediately move it back to the `Debug` configuration. This in turn would trigger two monitor project configuration file path events because the `Release` config has a different project.razor.json path (`obj/Release/net6.0/project.razor.json`), the two events would be "move to Release folder", "move back to Debug folder". Now the problem is that our caching mechanism in our monitor config endpoint would never update its `project.razor.json` path if it found we were moving from one `project.razor.json` path to another. Therefore, when we initially moved to the "Release" folder it'd start monitoring that folder; however, once we tried to move to the `Debug` folder it would never start a new watcher for the Debug folder; instead it would stop the release folder watching and then sit their twiddling its thumbs :D.
    - Note: You can also reproduce this behavior by manually going to Debug -> Release -> Debug.
- Fix was to make it so when we moved from different `obj` folders to always stop/reconstruct the detectors no matter what.
- Added tests to validate that publish scenarios work as expected.

Fixes #5757