### PR TITLE
Update runtime/package versions for Blazor debugging

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -12,8 +12,8 @@
     "vscode": "^1.52.0"
   },
   "icon": "images/blazorIcon.png",
-  "dotnetRuntimeVersion": "5.0",
-  "debugProxyVersion": "5.0.2",
+  "dotnetRuntimeVersion": "6.0",
+  "debugProxyVersion": "6.0.0",
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
### Summary of the changes
 - Update Blazor debugging extension to download 6.0 runtime
 - Update Blazor debugging extension to use latest NuGet package

Fixes: https://github.com/dotnet/razor-tooling/issues/5780
