### PR TITLE
Revert "Call AdviseRunningDocTableEvents on UI thread. (#5783)"

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -53,14 +52,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _runningDocumentTable = (IVsRunningDocumentTable4)runningDocumentTable;
             _editorAdaptersFactory = editorAdaptersFactory;
 
-            // Need to grab running doc-table events but that requires the UI thread.
-            joinableTaskContext.Factory.Run(async () =>
-            {
-                await joinableTaskContext.Factory.SwitchToMainThreadAsync();
-
-                var hr = runningDocumentTable.AdviseRunningDocTableEvents(new RunningDocumentTableEventSink(this), out _);
-                Marshal.ThrowExceptionForHR(hr);
-            });
+            var hr = runningDocumentTable.AdviseRunningDocTableEvents(new RunningDocumentTableEventSink(this), out _);
+            Marshal.ThrowExceptionForHR(hr);
 
             _documentsByCookie = new Dictionary<uint, List<DocumentKey>>();
             _cookiesByDocument = new Dictionary<DocumentKey, uint>();


### PR DESCRIPTION
This reverts commit 1f785f416ceb72b632a0568353b16c8a4fc433f9.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1447620