### PR TITLE
Map SelectionRange for CodeActions requests

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -249,7 +249,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return Array.Empty<RazorCodeAction>();
             }
 
-            var newRequest = context.Request with { Range = projectedRange };
+            var newContext = context.Request.Context;
+            if (context.Request.Context is OmniSharpVSCodeActionContext omniSharpContext &&
+                omniSharpContext.SelectionRange is not null &&
+                 _documentMappingService.TryMapToProjectedDocumentRange(
+                    context.CodeDocument,
+                    omniSharpContext.SelectionRange,
+                    out var selectionRange))
+            {
+                newContext = omniSharpContext with
+                {
+                    SelectionRange = selectionRange
+                };
+            }
+
+            var newRequest = context.Request with { Range = projectedRange, Context = newContext };
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var newContext = context.Request.Context;
             if (context.Request.Context is OmniSharpVSCodeActionContext omniSharpContext &&
                 omniSharpContext.SelectionRange is not null &&
-                 _documentMappingService.TryMapToProjectedDocumentRange(
+                _documentMappingService.TryMapToProjectedDocumentRange(
                     context.CodeDocument,
                     omniSharpContext.SelectionRange,
                     out var selectionRange))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -21,6 +21,7 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 using OmniSharp.Extensions.JsonRpc;
 using Xunit;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -641,6 +642,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
                 Range = initialRange,
                 Context = new OmniSharpVSCodeActionContext()
+                {
+                    SelectionRange = initialRange
+                }
             };
 
             var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, default);
@@ -650,6 +654,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             // Assert
             Assert.Single(results);
+            var diagnostics = results.Single().Diagnostics.ToArray();
+            Assert.Equal(2, diagnostics.Length);
+
+            // Diagnostic ranges contain the projected range for
+            // 1. Range
+            // 2. SelectionRange
+            //
+            // This helps verify that the CodeActionEndpoint is mapping the
+            // ranges correctly using the mapping service
+            Assert.Equal(projectedRange, diagnostics[0].Range);
+            Assert.Equal(projectedRange, diagnostics[1].Range);
         }
 
         private static DefaultRazorDocumentMappingService CreateDocumentMappingService(Range projectedRange = null)
@@ -663,16 +678,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         private static ClientNotifierServiceBase CreateLanguageServer()
         {
-            var response = Mock.Of<IResponseRouterReturns>(
-                r => r.Returning<RazorCodeAction[]>(It.IsAny<CancellationToken>()) == Task.FromResult(new[]
-                {
-                    new RazorCodeAction() { Data = JToken.FromObject(new { CustomTags = new[] { "CodeActionName" } }) }
-                })
-            , MockBehavior.Strict);
-            var languageServer = Mock.Of<ClientNotifierServiceBase>(
-                l => l.SendRequestAsync(LanguageServerConstants.RazorProvideCodeActionsEndpoint, It.IsAny<CodeActionParams>()) == Task.FromResult(response)
-            , MockBehavior.Strict);
-            return languageServer;
+            return new MockLanguageServer();
         }
 
         private static DocumentResolver CreateDocumentResolver(string documentPath, RazorCodeDocument codeDocument)
@@ -749,6 +755,83 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             public override Task<IReadOnlyList<RazorCodeAction>> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
             {
                 return Task.FromResult<IReadOnlyList<RazorCodeAction>>(null);
+            }
+        }
+
+        private class MockLanguageServer : ClientNotifierServiceBase
+        {
+            public override InitializeParams ClientSettings => throw new NotImplementedException();
+
+            public override Task OnStarted(ILanguageServer server, CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public override Task<IResponseRouterReturns> SendRequestAsync(string method)
+            {
+                if (method != LanguageServerConstants.RazorProvideCodeActionsEndpoint)
+                {
+                    throw new InvalidOperationException($"Unexpected method {method}");
+                }
+
+                return Task.FromResult<IResponseRouterReturns>(new MockResponseRouterReturns(null));
+            }
+
+            public override Task<IResponseRouterReturns> SendRequestAsync<T>(string method, T @params)
+            {
+                if (method != LanguageServerConstants.RazorProvideCodeActionsEndpoint)
+                {
+                    throw new InvalidOperationException($"Unexpected method {method}");
+                }
+
+                if (@params is not CodeActionParams codeActionParams || codeActionParams.Context is not OmniSharpVSCodeActionContext codeActionContext)
+                {
+                    throw new InvalidOperationException(@params.GetType().FullName);
+                }
+
+                // Create a code action specifically with diagnostics that
+                // contain the contextual information for it's creation. This is
+                // a hacky way to verify that data transmitted to the language server
+                // is correct rather than providing specific test hooks in the CodeActionEndpoint
+                var result = new[]
+                {
+                    new RazorCodeAction()
+                    {
+                        Data = JToken.FromObject(new { CustomTags = new object[] { "CodeActionName" } }),
+                        Diagnostics = new[]
+                        {
+                            new Diagnostic()
+                            {
+                                Range = codeActionParams.Range,
+                                Message = "Range"
+                            },
+                            new Diagnostic()
+                            {
+                                Range = codeActionContext.SelectionRange,
+                                Message = "Selection Range"
+                            }
+                        }
+                    }
+                };
+
+                return Task.FromResult<IResponseRouterReturns>(new MockResponseRouterReturns(result));
+            }
+
+            private class MockResponseRouterReturns : IResponseRouterReturns
+            {
+                private readonly object _result;
+
+                public MockResponseRouterReturns(object result)
+                {
+                    _result = result;
+                }
+
+                public Task<Response> Returning<Response>(CancellationToken cancellationToken)
+                {
+                    return Task.FromResult((Response)_result);
+                }
+
+                public Task ReturningVoid(CancellationToken cancellationToken)
+                {
+                    return Task.CompletedTask;
+                }
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -678,7 +678,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         private static ClientNotifierServiceBase CreateLanguageServer()
         {
-            return new MockLanguageServer();
+            return new TestLanguageServer();
         }
 
         private static DocumentResolver CreateDocumentResolver(string documentPath, RazorCodeDocument codeDocument)
@@ -758,7 +758,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             }
         }
 
-        private class MockLanguageServer : ClientNotifierServiceBase
+        private class TestLanguageServer : ClientNotifierServiceBase
         {
             public override InitializeParams ClientSettings => throw new NotImplementedException();
 
@@ -771,7 +771,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     throw new InvalidOperationException($"Unexpected method {method}");
                 }
 
-                return Task.FromResult<IResponseRouterReturns>(new MockResponseRouterReturns(null));
+                return Task.FromResult<IResponseRouterReturns>(new TestResponseRouterReturns(null));
             }
 
             public override Task<IResponseRouterReturns> SendRequestAsync<T>(string method, T @params)
@@ -811,14 +811,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     }
                 };
 
-                return Task.FromResult<IResponseRouterReturns>(new MockResponseRouterReturns(result));
+                return Task.FromResult<IResponseRouterReturns>(new TestResponseRouterReturns(result));
             }
 
-            private class MockResponseRouterReturns : IResponseRouterReturns
+            private class TestResponseRouterReturns : IResponseRouterReturns
             {
                 private readonly object _result;
 
-                public MockResponseRouterReturns(object result)
+                public TestResponseRouterReturns(object result)
                 {
                     _result = result;
                 }


### PR DESCRIPTION
If a SelectionRange is provided it's required that the range
should also be mapped correctly before sending off the request
for code actions. This context is used for cases where code action
ordering is ordered and the original range may not actually be
equal to the SelectionRange. Both are needed to correctly provide
the right code fixes and/or refactorings and in the right order
from Roslyn

### Summary of the changes
 - Map SelectionRange when available


Fixes:  #5822 
