### PR TITLE
Fix CI package restore flakiness (hopefully).

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -89,8 +89,8 @@
     <Tooling_HtmlEditorPackageVersion>16.10.57-preview1</Tooling_HtmlEditorPackageVersion>
     <!-- Several packages share the MS.CA.Testing version -->
     <Tooling_MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.21103.2</Tooling_MicrosoftCodeAnalysisTestingVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.0.0-previews-1-31410-258</MicrosoftVisualStudioShellPackagesVersion>
-    <MicrosoftVisualStudioPackagesVersion>17.0.35-gdeb9415fdc</MicrosoftVisualStudioPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.0.31723.112</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioPackagesVersion>17.0.448</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.1.0-1.21471.13</RoslynPackageVersion>
     <VisualStudioLanguageServerProtocolVersion>17.1.2</VisualStudioLanguageServerProtocolVersion>
   </PropertyGroup>
@@ -118,7 +118,7 @@
     <MicrosoftVisualStudioTextDataPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextDataPackageVersion>
     <MicrosoftVisualStudioTextImplementationPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextImplementationPackageVersion>
     <MicrosoftVisualStudioTextLogicPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextLogicPackageVersion>
-    <MicrosoftVisualStudioThreadingPackageVersion>16.9.45-alpha</MicrosoftVisualStudioThreadingPackageVersion>
+    <MicrosoftVisualStudioThreadingPackageVersion>17.0.63</MicrosoftVisualStudioThreadingPackageVersion>
     <MicrosoftVisualStudioWebPackageVersion>16.10.0-preview-1-31008-014</MicrosoftVisualStudioWebPackageVersion>
     <MicrosoftVisualStudioValidationPackageVersion>17.0.16-alpha</MicrosoftVisualStudioValidationPackageVersion>
     <MicrosoftWebToolsLanguagesHtmlPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesHtmlPackageVersion>

--- a/src/Razor/src/Directory.Build.props
+++ b/src/Razor/src/Directory.Build.props
@@ -11,4 +11,8 @@
     <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingPackageVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -92,7 +92,6 @@ namespace Microsoft.CodeAnalysis.Razor
                 lcts.Token,
                 TaskCreationOptions.None,
                 TaskScheduler.Default).Unwrap();
-            updateTask.ConfigureAwait(false);
             updateItem = new UpdateItem(updateTask, lcts);
             Updates[projectSnapshot.FilePath] = updateItem;
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -23,15 +23,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />
-
     <!--
-      Microsoft.CodeAnalysis.Remote.ServiceHub brings in a transitive dependency to StreamJsonRpc of 2.7.X. We found that in practice this would flakily break our
+      Microsoft.CodeAnalysis.Remote.ServiceHub brings in a transitive dependency to StreamJsonRpc of 2.7.X and Nerdbank.Streams 2.7.74. We found that in practice this would flakily break our
       CI builds here: https://github.com/dotnet/razor-tooling/issues/4327
-      Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin StreamJsonRpc.
+      Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin StreamJsonRpc and Nerdbank.Streams.
     -->
     <PackageReference Include="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="$(Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
+    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkPackageVersion)" />
-    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Microsoft.VisualStudio.LiveShare.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Microsoft.VisualStudio.LiveShare.Razor.csproj
@@ -23,12 +23,13 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
 
     <!--
-      Microsoft.VisualStudio.LanguageServices brings in a transitive dependency to StreamJsonRpc of 2.7.X. We found that in practice this would flakily break our
+      Microsoft.VisualStudio.LanguageServices brings in a transitive dependency to StreamJsonRpc of 2.7.X and Nerdbank.Streams 2.6.81. We found that in practice this would flakily break our
       CI builds here: https://github.com/dotnet/razor-tooling/issues/4327
-      Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin StreamJsonRpc.
+      Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin StreamJsonRpc and Nerdbank.Streams.
     -->
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
+    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/BatchingWorkQueueTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/BatchingWorkQueueTest.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
         {
             public override ValueTask ProcessAsync(CancellationToken cancellationToken)
             {
-                base.ProcessAsync(cancellationToken);
+                _ = base.ProcessAsync(cancellationToken);
                 throw new InvalidOperationException();
             }
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Microsoft.CodeAnalysis.Remote.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Microsoft.CodeAnalysis.Remote.Razor.Test.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Microsoft.VisualStudio.LiveShare.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Microsoft.VisualStudio.LiveShare.Razor.Test.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
-    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
- Unpinned Nerdbank.Streams since it seemed that our restore graph already encompassed coherent nerdbank versions, we were the only ones causing issues.
- Pinned Microsoft.VisualStudio.Threading to 17.0.63 (this is what core editor is pinning too) to avoid all of the various incoherent versions from transient packages floating around. This in turn upgraded some threading analyzers which I had to react to as well.

Fixes #5717