### PR TITLE
Allow implicit expression breakpoints for CSHTML files.

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Debugging
     {
         public DefaultRazorBreakpointResolverTest()
         {
+            CSHTMLDocumentUri = new Uri("file://C:/path/to/file.cshtml", UriKind.Absolute);
             DocumentUri = new Uri("file://C:/path/to/file.razor", UriKind.Absolute);
             CSharpDocumentUri = new Uri(DocumentUri.OriginalString + ".g.cs", UriKind.Absolute);
 
@@ -49,6 +50,8 @@ $@"public class SomeRazorFile
         private ITextBuffer CSharpTextBuffer { get; }
 
         private Uri DocumentUri { get; }
+
+        private Uri CSHTMLDocumentUri { get; }
 
         private Uri CSharpDocumentUri { get; }
 
@@ -195,6 +198,26 @@ $@"public class SomeRazorFile
         }
 
         [Fact]
+        public void GetMappingBehavior_CSHTML()
+        {
+            // Act
+            var result = DefaultRazorBreakpointResolver.GetMappingBehavior(CSHTMLDocumentUri);
+
+            // Assert
+            Assert.Equal(LanguageServerMappingBehavior.Inclusive, result);
+        }
+
+        [Fact]
+        public void GetMappingBehavior_Razor()
+        {
+            // Act
+            var result = DefaultRazorBreakpointResolver.GetMappingBehavior(DocumentUri);
+
+            // Assert
+            Assert.Equal(LanguageServerMappingBehavior.Strict, result);
+        }
+
+        [Fact]
         public async Task TryResolveBreakpointRangeAsync_MappableCSharpBreakpointLocation_ReturnsHostBreakpointLocation()
         {
             // Arrange
@@ -265,7 +288,7 @@ $@"public class SomeRazorFile
             if (documentMappingProvider is null)
             {
                 documentMappingProvider = new Mock<LSPDocumentMappingProvider>(MockBehavior.Strict).Object;
-                Mock.Get(documentMappingProvider).Setup(p => p.MapToDocumentRangesAsync(It.IsAny<RazorLanguageKind>(), It.IsAny<Uri>(), It.IsAny<Range[]>(), CancellationToken.None))
+                Mock.Get(documentMappingProvider).Setup(p => p.MapToDocumentRangesAsync(It.IsAny<RazorLanguageKind>(), It.IsAny<Uri>(), It.IsAny<Range[]>(), LanguageServerMappingBehavior.Strict, CancellationToken.None))
                     .Returns(Task.FromResult<RazorMapToDocumentRangesResponse>(null));
             }
 


### PR DESCRIPTION
- Razor files generate code in a "loosely" debuggable way. For instance if you were to do the following in a cshtml file: `@DateTime.Now` it would render as:
    ```C#
    #line 123 "C:/path/to/abc.cshtml"
    __o = DateTime.Now;

    #line default
    ```
    This in turn results in a breakpoint span encompassing `|__o = DateTime.Now;|`. Problem is that if we're doing "strict" mapping Razor only maps `DateTime.Now` so mapping would fail because C# also sees the `__o` portion. Therefore in cshtml scenarios we can fall back to inclusive mapping which allows C# mappings that intersect to be acceptable mapping locations.
    In Blazor this isn't an issue because `@DateTime.Now` renders as:
    ```C#
    __o =
    #line 123 "C:/path/to/abc.razor"
    DateTime.Now

    #line default
    ;
    ```
- To avoid mocking more of the world in our pre-existing tests I exposed our new "mapping behavior resolver method" and unit tested that individually.

### Before
(Breakpoints were never set)

### After
![image](https://i.imgur.com/vdrk6HT.gif)

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1370847