### PR TITLE
Upgrade yarn source build tools to 122.10

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -9,6 +9,6 @@
 
       This is not needed in source build.
     -->
-    <PackageReference Condition="'$(DotNetBuildFromSource)' != 'true'" Include="Yarn.MSBuild" Version="1.21.1" />
+    <PackageReference Condition="'$(DotNetBuildFromSource)' != 'true'" Include="Yarn.MSBuild" Version="1.22.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Last attempt at fixing yarn looks like it brought forward another yarn issue. Hopefully this time fixes all of the component governance pain points?

Fixes
- https://dnceng.visualstudio.com/internal/_componentGovernance/dotnet-razor-tooling/alert/6199209?typeId=6437627
- https://dnceng.visualstudio.com/internal/_componentGovernance/dotnet-razor-tooling/alert/6199210?typeId=6437627
- https://dnceng.visualstudio.com/internal/_componentGovernance/dotnet-razor-tooling/alert/6199211?typeId=6437627