### PR TITLE
Support going to the definition of a property attribute directly

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -256,8 +256,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             // If we're on an attribute then just validate against the attribute name
             if (owner.Parent is MarkupTagHelperAttributeSyntax attribute)
             {
+                // Normal attribute, ie <Component attribute=value />
                 name = attribute.Name;
                 propertyName = attribute.TagHelperAttributeInfo.Name;
+            }
+            else if (owner.Parent is MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute)
+            {
+                // Minimized attribute, ie <Component attribute />
+                name = minimizedAttribute.Name;
+                propertyName = minimizedAttribute.TagHelperAttributeInfo.Name;
             }
 
             if (!name.Span.Contains(location.AbsoluteIndex))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+//using Castle.Core.Logging;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.Editor.Razor;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -197,6 +200,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         internal HtmlFactsService HtmlFactsService { get; }
 
         protected TagHelperFactsService TagHelperFactsService { get; }
+
+        protected ILogger Logger { get; } = NullLogger.Instance;
 
         internal static RazorCodeDocument CreateCodeDocument(string text, params TagHelperDescriptor[] tagHelpers)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -4,9 +4,14 @@
 #nullable disable
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -34,13 +39,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 2);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
-            Assert.Equal("test1", binding.TagName);
-            var descriptor = Assert.Single(binding.Descriptors);
             Assert.Equal("Test1TagHelper", descriptor.Name);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -51,14 +55,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 2);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
-            Assert.Equal("Component1", binding.TagName);
-            Assert.Collection(binding.Descriptors,
-                d => Assert.Equal("Component1TagHelper", d.Name),
-                d => Assert.Equal("TestDirectiveAttribute", d.Name));
+            Assert.Equal("Component1TagHelper", descriptor.Name);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -69,14 +71,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 35);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
-            Assert.Equal("Component1", binding.TagName);
-            Assert.Collection(binding.Descriptors,
-                d => Assert.Equal("Component1TagHelper", d.Name),
-                d => Assert.Equal("TestDirectiveAttribute", d.Name));
+            Assert.Equal("Component1TagHelper", descriptor.Name);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -87,11 +87,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 14);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -102,11 +103,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 24);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -117,11 +119,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 18);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -132,11 +135,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 29);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -154,15 +158,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 2);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
-            Assert.Equal("Component1", binding.TagName);
-            Assert.Collection(binding.Descriptors,
-                d => Assert.Equal("Component1TagHelper", d.Name),
-                d => Assert.Equal("TestDirectiveAttribute", d.Name),
-                d => Assert.Equal("MinimizedDirectiveAttribute", d.Name));
+            Assert.Equal("Component1TagHelper", descriptor.Name);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -180,13 +181,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 2);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
-            Assert.Equal("Component1", binding.TagName);
-            var descriptor = Assert.Single(binding.Descriptors);
             Assert.Equal("Component1TagHelper", descriptor.Name);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -205,14 +205,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 2);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
-            Assert.Equal("Component1", binding.TagName);
-            Assert.Collection(binding.Descriptors,
-                d => Assert.Equal("Component1TagHelper", d.Name),
-                d => Assert.Equal("TestDirectiveAttribute", d.Name));
+            Assert.Equal("Component1TagHelper", descriptor.Name);
+            Assert.Null(attributeDescriptor);
         }
 
         [Fact]
@@ -224,11 +222,121 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var position = new Position(1, 6);
 
             // Act
-            var binding = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
                 documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
+            Assert.Null(attributeDescriptor);
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_PropertyAttribute()
+        {
+
+            // Arrange
+            var content = @"@addTagHelper *, TestAssembly
+<Component1 bool-val=""true""></Component1>
+@code {
+    public void Increment()
+    {
+    }
+}";
+            SetupDocument(out var codeDocument, out var documentSnapshot, content);
+            var position = new Position(1, 14);
+
+            // Act
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+                documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("Component1TagHelper", descriptor.Name);
+            Assert.NotNull(attributeDescriptor);
+            Assert.Equal("BoolVal", attributeDescriptor.GetPropertyName());
+        }
+
+        [Fact]
+        public async Task GetNavigatePositionAsync_TagHelperProperty_CorrectRange1()
+        {
+            // Arrange
+            var content = @"
+
+<div>@Title</div>
+
+@code
+{
+    [Parameter]
+    public string NotTitle { get; set; }
+
+    [Parameter]
+    public string [|Title|] { get; set; }
+}
+";
+            TestFileMarkupParser.GetSpan(content, out content, out var selection);
+
+            SetupDocument(out var codeDocument, out _, content);
+            var expectedRange = selection.AsRange(codeDocument.GetSourceText());
+
+            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
+
+            // Act II
+            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, CancellationToken.None).ConfigureAwait(false);
+            Assert.NotNull(range);
+            Assert.Equal(expectedRange, range);
+        }
+
+        [Fact]
+        public async Task GetNavigatePositionAsync_TagHelperProperty_CorrectRange2()
+        {
+            // Arrange
+            var content = @"
+
+<div>@Title</div>
+
+@code
+{
+    [Microsoft.AspNetCore.Components.Parameter]
+    public string [|Title|] { get; set; }
+}
+";
+            TestFileMarkupParser.GetSpan(content, out content, out var selection);
+
+            SetupDocument(out var codeDocument, out _, content);
+            var expectedRange = selection.AsRange(codeDocument.GetSourceText());
+
+            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
+
+            // Act II
+            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, CancellationToken.None).ConfigureAwait(false);
+            Assert.NotNull(range);
+            Assert.Equal(expectedRange, range);
+        }
+
+        [Fact]
+        public async Task GetNavigatePositionAsync_TagHelperProperty_CorrectRange3()
+        {
+            // Arrange
+            var content = @"
+
+<div>@Title</div>
+
+@code
+{
+    [Components.ParameterAttribute]
+    public string [|Title|] { get; set; }
+}
+";
+            TestFileMarkupParser.GetSpan(content, out content, out var selection);
+
+            SetupDocument(out var codeDocument, out _, content);
+            var expectedRange = selection.AsRange(codeDocument.GetSourceText());
+
+            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
+
+            // Act II
+            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, CancellationToken.None).ConfigureAwait(false);
+            Assert.NotNull(range);
+            Assert.Equal(expectedRange, range);
         }
 
         private void SetupDocument(out Language.RazorCodeDocument codeDocument, out DocumentSnapshot documentSnapshot, string content = DefaultContent)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -256,6 +256,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
         }
 
         [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_MinimizedPropertyAttribute()
+        {
+
+            // Arrange
+            var content = @"@addTagHelper *, TestAssembly
+<Component1 bool-val></Component1>
+@code {
+    public void Increment()
+    {
+    }
+}";
+            SetupDocument(out var codeDocument, out var documentSnapshot, content);
+            var position = new Position(1, 14);
+
+            // Act
+            var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
+                documentSnapshot, codeDocument, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint")).ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal("Component1TagHelper", descriptor.Name);
+            Assert.NotNull(attributeDescriptor);
+            Assert.Equal("BoolVal", attributeDescriptor.GetPropertyName());
+        }
+
+        [Fact]
         public async Task GetNavigatePositionAsync_TagHelperProperty_CorrectRange1()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
 
             // Act II
-            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, CancellationToken.None).ConfigureAwait(false);
+            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, Logger, CancellationToken.None).ConfigureAwait(false);
             Assert.NotNull(range);
             Assert.Equal(expectedRange, range);
         }
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
 
             // Act II
-            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, CancellationToken.None).ConfigureAwait(false);
+            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, Logger, CancellationToken.None).ConfigureAwait(false);
             Assert.NotNull(range);
             Assert.Equal(expectedRange, range);
         }
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
 
             // Act II
-            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, CancellationToken.None).ConfigureAwait(false);
+            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, Logger, CancellationToken.None).ConfigureAwait(false);
             Assert.NotNull(range);
             Assert.Equal(expectedRange, range);
         }
@@ -365,11 +365,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
 
             // Act II
-            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, CancellationToken.None).ConfigureAwait(false);
+            var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, Logger, CancellationToken.None).ConfigureAwait(false);
             Assert.NotNull(range);
             Assert.Equal(expectedRange, range);
         }
-
 
         private void SetupDocument(out Language.RazorCodeDocument codeDocument, out DocumentSnapshot documentSnapshot, string content = DefaultContent)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/5856

![RazorGTDAttribute](https://user-images.githubusercontent.com/754264/146492982-21bbdd08-b659-4703-b989-e36d6d9dd657.gif)