### PR TITLE
Lazy load, and clean up, portions of FormattingContext

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             var uri = request.TextDocument.Uri;
             var position = request.Position;
 
-            using (var formattingContext = FormattingContext.Create(uri, document, codeDocument, request.Options, _workspaceFactory))
+            using (var formattingContext = FormattingContext.Create(uri, document, codeDocument, request.Options, _workspaceFactory, isFormatOnType: false, automaticallyAddUsings: false))
             {
                 for (var i = 0; i < applicableProviders.Count; i++)
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -74,10 +74,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             // Next, collect all the line starts that start in C# context
+            var indentations = context.GetIndentations();
             var lineStartMap = new Dictionary<int, int>();
             for (var i = range.Start.Line; i <= range.End.Line; i++)
             {
-                if (context.Indentations[i].EmptyOrWhitespaceLine)
+                if (indentations[i].EmptyOrWhitespaceLine)
                 {
                     // We should remove whitespace on empty lines.
                     continue;
@@ -137,14 +138,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var newIndentations = new Dictionary<int, int>();
             for (var i = range.Start.Line; i <= range.End.Line; i++)
             {
-                if (context.Indentations[i].EmptyOrWhitespaceLine)
+                if (indentations[i].EmptyOrWhitespaceLine)
                 {
                     // We should remove whitespace on empty lines.
                     newIndentations[i] = 0;
                     continue;
                 }
 
-                var minCSharpIndentation = context.GetIndentationOffsetForLevel(context.Indentations[i].MinCSharpIndentLevel);
+                var minCSharpIndentation = context.GetIndentationOffsetForLevel(indentations[i].MinCSharpIndentLevel);
                 var line = context.SourceText.Lines[i];
                 var lineStart = line.GetFirstNonWhitespacePosition() ?? line.Start;
                 var lineStartSpan = new TextSpan(lineStart, 0);
@@ -211,8 +212,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 }
 
                 var effectiveCSharpDesiredIndentation = csharpDesiredIndentation - minCSharpIndentation;
-                var razorDesiredIndentation = context.GetIndentationOffsetForLevel(context.Indentations[i].IndentationLevel);
-                if (context.Indentations[i].StartsInHtmlContext)
+                var razorDesiredIndentation = context.GetIndentationOffsetForLevel(indentations[i].IndentationLevel);
+                if (indentations[i].StartsInHtmlContext)
                 {
                     // This is a non-C# line.
                     if (context.IsFormatOnType)
@@ -226,7 +227,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                         // HTML is already correctly formatted. So we can use the existing indentation as is.
                         // We need to make sure to use the indentation size, as this will get passed to
                         // GetIndentationString eventually.
-                        razorDesiredIndentation = context.Indentations[i].ExistingIndentationSize;
+                        razorDesiredIndentation = indentations[i].ExistingIndentationSize;
                     }
                 }
 
@@ -244,7 +245,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 var indentation = item.Value;
                 Debug.Assert(indentation >= 0, "Negative indentation. This is unexpected.");
 
-                var existingIndentationLength = context.Indentations[line].ExistingIndentation;
+                var existingIndentationLength = indentations[line].ExistingIndentation;
                 var spanToReplace = new TextSpan(context.SourceText.Lines[line].Start, existingIndentationLength);
                 var effectiveDesiredIndentation = context.GetIndentationString(indentation);
                 changes.Add(new TextChange(spanToReplace, effectiveDesiredIndentation));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -408,7 +408,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var sourceMappingSpan = sourceMappingRange.AsTextSpan(text);
             var mappingEndLineIndex = sourceMappingRange.End.Line;
 
-            var startsInCSharpContext = context.Indentations[mappingEndLineIndex].StartsInCSharpContext;
+            var indentations = context.GetIndentations();
+
+            var startsInCSharpContext = indentations[mappingEndLineIndex].StartsInCSharpContext;
 
             // If the span is on a single line, and we added a line, then end point is now on a line that does start in a C# context.
             if (!startsInCSharpContext && newLineWasAddedAtStart && sourceMappingRange.Start.Line == mappingEndLineIndex)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
-            using var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, _workspaceFactory);
+            using var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, _workspaceFactory, isFormatOnType: false, automaticallyAddUsings: false);
 
             var result = new FormattingResult(Array.Empty<TextEdit>());
             foreach (var pass in _formattingPasses)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             ValidateComponents(CodeDocument, codeDocument);
 
-            var newContext = Create(Uri, OriginalSnapshot, codeDocument, Options, _workspaceFactory, IsFormatOnType);
+            var newContext = Create(Uri, OriginalSnapshot, codeDocument, Options, _workspaceFactory, IsFormatOnType, AutomaticallyAddUsings);
             return newContext;
         }
 
@@ -255,8 +255,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             RazorCodeDocument codeDocument,
             FormattingOptions options,
             AdhocWorkspaceFactory workspaceFactory,
-            bool isFormatOnType = false,
-            bool automaticallyAddUsings = false)
+            bool isFormatOnType,
+            bool automaticallyAddUsings)
         {
             if (uri is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -96,18 +96,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         /// </remarks>
         public IReadOnlyDictionary<int, IndentationContext> Indentations { get; private set; } = null!;
 
-        public IReadOnlyList<FormattingSpan> FormattingSpans
+        private IReadOnlyList<FormattingSpan> GetFormattingSpans()
         {
-            get
+            if (_formattingSpans is null)
             {
-                if (_formattingSpans is null)
-                {
-                    var syntaxTree = CodeDocument.GetSyntaxTree();
-                    _formattingSpans = syntaxTree.GetFormattingSpans();
-                }
-
-                return _formattingSpans;
+                var syntaxTree = CodeDocument.GetSyntaxTree();
+                _formattingSpans = syntaxTree.GetFormattingSpans();
             }
+
+            return _formattingSpans;
         }
 
         /// <summary>
@@ -186,9 +183,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public bool TryGetFormattingSpan(int absoluteIndex, [NotNullWhen(true)] out FormattingSpan? result)
         {
             result = null;
-            for (var i = 0; i < FormattingSpans.Count; i++)
+            var formattingspans = GetFormattingSpans();
+            for (var i = 0; i < formattingspans.Count; i++)
             {
-                var formattingspan = FormattingSpans[i];
+                var formattingspan = formattingspans[i];
                 var span = formattingspan.Span;
 
                 if (span.Start <= absoluteIndex && span.End >= absoluteIndex)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
@@ -87,8 +86,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public bool IsFormatOnType { get; private set; }
 
         public bool AutomaticallyAddUsings { get; private set; }
-
-        public Range Range { get; private set; } = null!;
 
         /// <summary>A Dictionary of int (line number) to IndentationContext.</summary>
         /// <remarks>
@@ -206,29 +203,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             else
             {
                 var tabs = indentation / Options.TabSize;
-                var tabPrefix = new string('\t', (int)tabs);
+                var tabPrefix = new string('\t', tabs);
 
                 var spaces = indentation % Options.TabSize;
-                var spaceSuffix = new string(' ', (int)spaces);
+                var spaceSuffix = new string(' ', spaces);
 
                 var combined = string.Concat(tabPrefix, spaceSuffix);
                 return combined;
             }
-        }
-
-        /// <summary>
-        /// Given an offset return the corresponding indent level.
-        /// </summary>
-        /// <param name="offset">A value represents the number of spaces/tabs at the start of a line.</param>
-        /// <returns>The corresponding indent level.</returns>
-        public int GetIndentationLevelForOffset(int offset)
-        {
-            if (Options.InsertSpaces)
-            {
-                offset /= (int)Options.TabSize;
-            }
-
-            return offset;
         }
 
         /// <summary>
@@ -238,7 +220,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         /// <returns></returns>
         public int GetIndentationOffsetForLevel(int level)
         {
-            return level * (int)Options.TabSize;
+            return level * Options.TabSize;
         }
 
         public bool TryGetIndentationLevel(int position, out int indentationLevel)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -296,7 +296,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             var codeDocument = _engine!.ProcessDesignTime(changedSourceDocument, OriginalSnapshot.FileKind, _importSources, OriginalSnapshot.Project.TagHelpers);
 
-            ValidateComponents(CodeDocument, codeDocument);
+            DEBUG_ValidateComponents(CodeDocument, codeDocument);
 
             var newContext = new FormattingContext(
                 _engine,
@@ -335,7 +335,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         /// Without this guarantee its hard to reason about test behaviour/failures.
         /// </summary>
         [Conditional("DEBUG")]
-        private static void ValidateComponents(RazorCodeDocument oldCodeDocument, RazorCodeDocument newCodeDocument)
+        private static void DEBUG_ValidateComponents(RazorCodeDocument oldCodeDocument, RazorCodeDocument newCodeDocument)
         {
             if (SkipValidateComponents)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -27,22 +27,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private IReadOnlyList<FormattingSpan>? _formattingSpans;
         private IReadOnlyDictionary<int, IndentationContext>? _indentations;
 
-        private FormattingContext(AdhocWorkspaceFactory workspaceFactory)
+        private FormattingContext(AdhocWorkspaceFactory workspaceFactory, DocumentUri uri, DocumentSnapshot originalSnapshot, RazorCodeDocument codeDocument, FormattingOptions options, bool isFormatOnType, bool automaticallyAddUsings)
         {
             _workspaceFactory = workspaceFactory;
+            Uri = uri;
+            OriginalSnapshot = originalSnapshot;
+            CodeDocument = codeDocument;
+            Options = options;
+            IsFormatOnType = isFormatOnType;
+            AutomaticallyAddUsings = automaticallyAddUsings;
         }
 
         public static bool SkipValidateComponents { get; set; }
 
-        public DocumentUri Uri { get; private set; } = null!;
-
-        public DocumentSnapshot OriginalSnapshot { get; private set; } = null!;
-
-        public RazorCodeDocument CodeDocument { get; private set; } = null!;
+        public DocumentUri Uri { get; }
+        public DocumentSnapshot OriginalSnapshot { get; }
+        public RazorCodeDocument CodeDocument { get; }
+        public FormattingOptions Options { get; }
+        public bool IsFormatOnType { get; }
+        public bool AutomaticallyAddUsings { get; }
 
         public SourceText SourceText => CodeDocument.GetSourceText();
 
         public SourceText CSharpSourceText => CodeDocument.GetCSharpSourceText();
+
+        public string NewLineString => Environment.NewLine;
 
         public Document CSharpWorkspaceDocument
         {
@@ -78,14 +87,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 return _csharpWorkspace;
             }
         }
-
-        public FormattingOptions Options { get; private set; } = null!;
-
-        public string NewLineString => Environment.NewLine;
-
-        public bool IsFormatOnType { get; private set; }
-
-        public bool AutomaticallyAddUsings { get; private set; }
 
         /// <summary>A Dictionary of int (line number) to IndentationContext.</summary>
         /// <remarks>
@@ -350,15 +351,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(workspaceFactory));
             }
 
-            var result = new FormattingContext(workspaceFactory)
-            {
-                Uri = uri,
-                OriginalSnapshot = originalSnapshot,
-                CodeDocument = codeDocument,
-                Options = options,
-                IsFormatOnType = isFormatOnType,
-                AutomaticallyAddUsings = automaticallyAddUsings
-            };
+            var result = new FormattingContext(
+                workspaceFactory,
+                uri,
+                originalSnapshot,
+                codeDocument,
+                options,
+                isFormatOnType,
+                automaticallyAddUsings
+            );
 
             return result;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -95,81 +95,78 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         /// Don't use this to discover the indentation level you should have, use
         /// <see cref="TryGetIndentationLevel(int, out int)"/> which operates on the position rather than just the line.
         /// </remarks>
-        public IReadOnlyDictionary<int, IndentationContext> Indentations
+        public IReadOnlyDictionary<int, IndentationContext> GetIndentations()
         {
-            get
+            if (_indentations is null)
             {
-                if (_indentations is null)
+                var sourceText = this.SourceText;
+                var indentations = new Dictionary<int, IndentationContext>();
+
+                var previousIndentationLevel = 0;
+                for (var i = 0; i < sourceText.Lines.Count; i++)
                 {
-                    var sourceText = this.SourceText;
-                    var indentations = new Dictionary<int, IndentationContext>();
+                    // Get first non-whitespace character position
+                    var nonWsPos = sourceText.Lines[i].GetFirstNonWhitespacePosition();
+                    var existingIndentation = (nonWsPos ?? sourceText.Lines[i].End) - sourceText.Lines[i].Start;
 
-                    var previousIndentationLevel = 0;
-                    for (var i = 0; i < sourceText.Lines.Count; i++)
+                    // The existingIndentation above is measured in characters, and is used to create text edits
+                    // The below is measured in columns, so takes into account tab size. This is useful for creating
+                    // new indentation strings
+                    var existingIndentationSize = sourceText.Lines[i].GetIndentationSize(this.Options.TabSize);
+
+                    var emptyOrWhitespaceLine = false;
+                    if (nonWsPos is null)
                     {
-                        // Get first non-whitespace character position
-                        var nonWsPos = sourceText.Lines[i].GetFirstNonWhitespacePosition();
-                        var existingIndentation = (nonWsPos ?? sourceText.Lines[i].End) - sourceText.Lines[i].Start;
-
-                        // The existingIndentation above is measured in characters, and is used to create text edits
-                        // The below is measured in columns, so takes into account tab size. This is useful for creating
-                        // new indentation strings
-                        var existingIndentationSize = sourceText.Lines[i].GetIndentationSize(this.Options.TabSize);
-
-                        var emptyOrWhitespaceLine = false;
-                        if (nonWsPos is null)
-                        {
-                            emptyOrWhitespaceLine = true;
-                            nonWsPos = sourceText.Lines[i].Start;
-                        }
-
-                        // position now contains the first non-whitespace character or 0. Get the corresponding FormattingSpan.
-                        if (TryGetFormattingSpan(nonWsPos.Value, out var span))
-                        {
-                            indentations[i] = new IndentationContext(firstSpan: span)
-                            {
-                                Line = i,
-                                RazorIndentationLevel = span.RazorIndentationLevel,
-                                HtmlIndentationLevel = span.HtmlIndentationLevel,
-                                RelativeIndentationLevel = span.IndentationLevel - previousIndentationLevel,
-                                ExistingIndentation = existingIndentation,
-                                ExistingIndentationSize = existingIndentationSize,
-                                EmptyOrWhitespaceLine = emptyOrWhitespaceLine,
-                            };
-                            previousIndentationLevel = span.IndentationLevel;
-                        }
-                        else
-                        {
-                            // Couldn't find a corresponding FormattingSpan. Happens if it is a 0 length line.
-                            // Let's create a 0 length span to represent this and default it to HTML.
-                            var placeholderSpan = new FormattingSpan(
-                                new Language.Syntax.TextSpan(nonWsPos.Value, 0),
-                                new Language.Syntax.TextSpan(nonWsPos.Value, 0),
-                                FormattingSpanKind.Markup,
-                                FormattingBlockKind.Markup,
-                                razorIndentationLevel: 0,
-                                htmlIndentationLevel: 0,
-                                isInClassBody: false,
-                                componentLambdaNestingLevel: 0);
-
-                            indentations[i] = new IndentationContext(firstSpan: placeholderSpan)
-                            {
-                                Line = i,
-                                RazorIndentationLevel = 0,
-                                HtmlIndentationLevel = 0,
-                                RelativeIndentationLevel = previousIndentationLevel,
-                                ExistingIndentation = existingIndentation,
-                                ExistingIndentationSize = existingIndentation,
-                                EmptyOrWhitespaceLine = emptyOrWhitespaceLine,
-                            };
-                        }
+                        emptyOrWhitespaceLine = true;
+                        nonWsPos = sourceText.Lines[i].Start;
                     }
 
-                    _indentations = Indentations;
+                    // position now contains the first non-whitespace character or 0. Get the corresponding FormattingSpan.
+                    if (TryGetFormattingSpan(nonWsPos.Value, out var span))
+                    {
+                        indentations[i] = new IndentationContext(firstSpan: span)
+                        {
+                            Line = i,
+                            RazorIndentationLevel = span.RazorIndentationLevel,
+                            HtmlIndentationLevel = span.HtmlIndentationLevel,
+                            RelativeIndentationLevel = span.IndentationLevel - previousIndentationLevel,
+                            ExistingIndentation = existingIndentation,
+                            ExistingIndentationSize = existingIndentationSize,
+                            EmptyOrWhitespaceLine = emptyOrWhitespaceLine,
+                        };
+                        previousIndentationLevel = span.IndentationLevel;
+                    }
+                    else
+                    {
+                        // Couldn't find a corresponding FormattingSpan. Happens if it is a 0 length line.
+                        // Let's create a 0 length span to represent this and default it to HTML.
+                        var placeholderSpan = new FormattingSpan(
+                            new Language.Syntax.TextSpan(nonWsPos.Value, 0),
+                            new Language.Syntax.TextSpan(nonWsPos.Value, 0),
+                            FormattingSpanKind.Markup,
+                            FormattingBlockKind.Markup,
+                            razorIndentationLevel: 0,
+                            htmlIndentationLevel: 0,
+                            isInClassBody: false,
+                            componentLambdaNestingLevel: 0);
+
+                        indentations[i] = new IndentationContext(firstSpan: placeholderSpan)
+                        {
+                            Line = i,
+                            RazorIndentationLevel = 0,
+                            HtmlIndentationLevel = 0,
+                            RelativeIndentationLevel = previousIndentationLevel,
+                            ExistingIndentation = existingIndentation,
+                            ExistingIndentationSize = existingIndentation,
+                            EmptyOrWhitespaceLine = emptyOrWhitespaceLine,
+                        };
+                    }
                 }
 
-                return _indentations;
+                _indentations = indentations;
             }
+
+            return _indentations;
         }
 
         private IReadOnlyList<FormattingSpan> GetFormattingSpans()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -70,13 +70,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 normalizedEdits = NormalizeTextEdits(originalText, htmlEdits);
             }
 
-            var mappedEdits = RemapTextEdits(context.CodeDocument, normalizedEdits, RazorLanguageKind.Html);
-            var changes = mappedEdits.Select(e => e.AsTextChange(originalText));
-
             var changedText = originalText;
             var changedContext = context;
-            if (changes.Any())
+
+            if (normalizedEdits.Length > 0)
             {
+                var changes = normalizedEdits.Select(e => e.AsTextChange(originalText));
                 changedText = originalText.WithChanges(changes);
                 // Create a new formatting context for the changed razor document.
                 changedContext = await context.WithTextAsync(changedText);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             }
 
             using var formattingContext = FormattingContext.Create(
-                request.TextDocument.Uri, documentSnapshot, codeDocument, request.Options, _adhocWorkspaceFactory, isFormatOnType: true);
+                request.TextDocument.Uri, documentSnapshot, codeDocument, request.Options, _adhocWorkspaceFactory, isFormatOnType: true, automaticallyAddUsings: false);
             var documentOptions = await GetDocumentOptionsAsync(request, formattingContext.CSharpWorkspaceDocument).ConfigureAwait(false);
 
             // Ask C# for formatting changes.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -398,7 +398,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 if (!context.TryGetIndentationLevel(codeNode.Position, out var desiredIndentationLevel))
                 {
                     // If for some reason we don't match a particular span use the indentation for the whole line
-                    var indentation = context.Indentations[range.Start.Line];
+                    var indentations = context.GetIndentations();
+                    var indentation = indentations[range.Start.Line];
                     desiredIndentationLevel = indentation.HtmlIndentationLevel + indentation.RazorIndentationLevel;
                 }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             };
 
             var provider = CreateProvider();
-            var context = FormattingContext.Create(uri, Mock.Of<DocumentSnapshot>(MockBehavior.Strict), codeDocument, options, TestAdhocWorkspaceFactory.Instance);
+            var context = FormattingContext.Create(uri, Mock.Of<DocumentSnapshot>(MockBehavior.Strict), codeDocument, options, TestAdhocWorkspaceFactory.Instance, isFormatOnType: false, automaticallyAddUsings: false);
 
             // Act
             if (!provider.TryResolveInsertion(position, context, out var edit, out _))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
@@ -140,7 +140,7 @@ public class Foo { }
                 InsertSpaces = insertSpaces,
             };
 
-            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, TestAdhocWorkspaceFactory.Instance);
+            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, TestAdhocWorkspaceFactory.Instance, isFormatOnType: false, automaticallyAddUsings: false);
             return context;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
@@ -147,7 +147,7 @@ public class Foo { }
                 InsertSpaces = insertSpaces,
             };
 
-            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, TestAdhocWorkspaceFactory.Instance);
+            var context = FormattingContext.Create(uri, documentSnapshot, codeDocument, options, TestAdhocWorkspaceFactory.Instance, isFormatOnType: false, automaticallyAddUsings: false);
             return context;
         }
 


### PR DESCRIPTION
This doesn't quite go as far as I'd like, but I thought I'd stop here in the interests of making the review not too hard, and this is definitely the "big hitters" in terms of wasted effort. This only saves about ~10% of time in formatting, which is not huge, but the indentation and formatting spans were previously being thrown out 33% of the time for each formatting operation, so its objectively wasteful. Caching the workspace would be a little bit of an additional gain, but not as much as you'd think, so I've left it off. I'd rather clean things up so that we properly dispose it properly at the same time, which would make this PR annoying

Review commit by commit and it should be pretty simple and straightforward.