### PR TITLE
Make TagHelper resolution delta based

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/IRemoteTagHelperProviderService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/IRemoteTagHelperProviderService.cs
@@ -12,5 +12,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
     internal interface IRemoteTagHelperProviderService
     {
         ValueTask<TagHelperResolutionResult> GetTagHelpersAsync(RazorPinnedSolutionInfoWrapper solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, CancellationToken cancellationToken);
+
+        ValueTask<TagHelperDeltaResult> GetTagHelpersDeltaAsync(RazorPinnedSolutionInfoWrapper solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, int lastResultId, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
@@ -126,18 +126,18 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
                 return null;
             }
 
-            var tagHelpers = ConsumeTagHelpersFromDelta(projectSnapshot.FilePath, lastResultId, result.Value);
+            var tagHelpers = ProduceTagHelpersFromDelta(projectSnapshot.FilePath, lastResultId, result.Value);
 
             var resolutionResult = new TagHelperResolutionResult(tagHelpers, diagnostics: Array.Empty<RazorDiagnostic>());
             return resolutionResult;
         }
 
         // Protected virtual for testing
-        protected virtual IReadOnlyList<TagHelperDescriptor> ConsumeTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
+        protected virtual IReadOnlyList<TagHelperDescriptor> ProduceTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
         {
             if (!_resultCache.TryGet(projectFilePath, lastResultId, out var tagHelpers))
             {
-                // We most likely haven't made a request to the server yet so there's no "delta" to apply
+                // We most likely haven't made a request to the server yet so there's no delta to apply
                 tagHelpers = Array.Empty<TagHelperDescriptor>();
 
                 if (deltaResult.Delta)
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             }
             else if (!deltaResult.Delta)
             {
-                // Not a delta based response, we should treat it as a "refresH"
+                // Not a delta based response, we should treat it as a "refresh"
                 tagHelpers = Array.Empty<TagHelperDescriptor>();
             }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperDeltaProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperDeltaProvider.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor
+{
+    internal class RemoteTagHelperDeltaProvider
+    {
+        private readonly TagHelperResultCache _resultCache;
+        private readonly object _resultIdLock = new();
+        private int _currentResultId;
+
+        public RemoteTagHelperDeltaProvider()
+        {
+            _resultCache = new TagHelperResultCache();
+        }
+
+        public TagHelperDeltaResult GetTagHelpersDelta(
+            string projectFilePath,
+            int lastResultId,
+            IReadOnlyList<TagHelperDescriptor> currentTagHelpers)
+        {
+            var deltaApplied = true;
+            if (!_resultCache.TryGet(projectFilePath, lastResultId, out var cachedTagHelpers))
+            {
+                deltaApplied = false;
+                cachedTagHelpers = Array.Empty<TagHelperDescriptor>();
+            }
+
+            var added = GetAddedTagHelpers(currentTagHelpers, cachedTagHelpers!);
+            var removed = GetRemovedTagHelpers(currentTagHelpers, cachedTagHelpers!);
+
+            lock (_resultIdLock)
+            {
+                var resultId = _currentResultId;
+                if (added.Count > 0 || removed.Count > 0)
+                {
+                    // The result actually changed, lets generate & cache a new result
+                    resultId = ++_currentResultId;
+                    _resultCache.Set(projectFilePath, resultId, currentTagHelpers);
+                }
+
+                var result = new TagHelperDeltaResult(deltaApplied, resultId, added, removed);
+                return result;
+            }
+        }
+
+        private static IReadOnlyList<TagHelperDescriptor> GetAddedTagHelpers(IReadOnlyList<TagHelperDescriptor> current, IReadOnlyList<TagHelperDescriptor> old)
+        {
+            if (old.Count == 0)
+            {
+                // Everythign is considered added when there is no collection to compare to.
+                return current;
+            }
+
+            if (current.Count == 0)
+            {
+                // No new descriptors so can't possibly add any
+                return Array.Empty<TagHelperDescriptor>();
+            }
+
+            var added = new List<TagHelperDescriptor>();
+
+            foreach (var tagHelper in current)
+            {
+                if (!old.Contains(tagHelper))
+                {
+                    added.Add(tagHelper);
+                }
+            }
+
+            return added;
+        }
+
+        private static IReadOnlyList<TagHelperDescriptor> GetRemovedTagHelpers(IReadOnlyList<TagHelperDescriptor> current, IReadOnlyList<TagHelperDescriptor> old)
+        {
+            if (old.Count == 0)
+            {
+                // Can't have anything removed if there's nothign to compare to
+                return Array.Empty<TagHelperDescriptor>();
+            }
+
+            if (current.Count == 0)
+            {
+                // Current collection has nothing so anything in "old" must have been removed
+                return old;
+            }
+
+            var removed = new List<TagHelperDescriptor>();
+
+            foreach (var tagHelper in old)
+            {
+                if (!current.Contains(tagHelper))
+                {
+                    removed.Add(tagHelper);
+                }
+            }
+
+            return removed;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderService.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             var resolutionResult = await RazorServices.TagHelperResolver.GetTagHelpersAsync(workspaceProject, projectHandle.Configuration, factoryTypeName, cancellationToken).ConfigureAwait(false);
             return resolutionResult;
         }
+
         public async ValueTask<TagHelperDeltaResult> GetTagHelpersDeltaCoreAsync(RazorPinnedSolutionInfoWrapper solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, int lastResultId, CancellationToken cancellationToken)
         {
             var tagHelperResolutionResult = await GetTagHelpersCoreAsync(solutionInfo, projectHandle, factoryTypeName, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderService.cs
@@ -15,13 +15,19 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
 {
     internal sealed class RemoteTagHelperProviderService : RazorServiceBase, IRemoteTagHelperProviderService
     {
+        private readonly RemoteTagHelperDeltaProvider _tagHelperDeltaProvider;
+
         internal RemoteTagHelperProviderService(IServiceBroker serviceBroker)
             : base(serviceBroker)
         {
+            _tagHelperDeltaProvider = new RemoteTagHelperDeltaProvider();
         }
 
         public ValueTask<TagHelperResolutionResult> GetTagHelpersAsync(RazorPinnedSolutionInfoWrapper solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, CancellationToken cancellationToken = default)
             => RazorBrokeredServiceImplementation.RunServiceAsync(cancellationToken => GetTagHelpersCoreAsync(solutionInfo, projectHandle, factoryTypeName, cancellationToken), cancellationToken);
+
+        public ValueTask<TagHelperDeltaResult> GetTagHelpersDeltaAsync(RazorPinnedSolutionInfoWrapper solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, int lastResultId, CancellationToken cancellationToken)
+            => RazorBrokeredServiceImplementation.RunServiceAsync(cancellationToken => GetTagHelpersDeltaCoreAsync(solutionInfo, projectHandle, factoryTypeName, lastResultId, cancellationToken), cancellationToken);
 
         private async ValueTask<TagHelperResolutionResult> GetTagHelpersCoreAsync(RazorPinnedSolutionInfoWrapper solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, CancellationToken cancellationToken)
         {
@@ -48,6 +54,13 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
 
             var resolutionResult = await RazorServices.TagHelperResolver.GetTagHelpersAsync(workspaceProject, projectHandle.Configuration, factoryTypeName, cancellationToken).ConfigureAwait(false);
             return resolutionResult;
+        }
+        public async ValueTask<TagHelperDeltaResult> GetTagHelpersDeltaCoreAsync(RazorPinnedSolutionInfoWrapper solutionInfo, ProjectSnapshotHandle projectHandle, string factoryTypeName, int lastResultId, CancellationToken cancellationToken)
+        {
+            var tagHelperResolutionResult = await GetTagHelpersCoreAsync(solutionInfo, projectHandle, factoryTypeName, cancellationToken).ConfigureAwait(false);
+            var currentTagHelpers = tagHelperResolutionResult.Descriptors;
+            var deltaResult = _tagHelperDeltaProvider.GetTagHelpersDelta(projectHandle.FilePath, lastResultId, currentTagHelpers);
+            return deltaResult;
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelperDeltaResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelperDeltaResult.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor
+{
+    internal record TagHelperDeltaResult(
+        bool Delta,
+        int ResultId,
+        IReadOnlyList<TagHelperDescriptor> Added,
+        IReadOnlyList<TagHelperDescriptor> Removed)
+    {
+        public IReadOnlyList<TagHelperDescriptor> Apply(IReadOnlyList<TagHelperDescriptor> baseTagHelpers)
+        {
+            if (Added.Count == 0 && Removed.Count == 0)
+            {
+                return baseTagHelpers;
+            }
+
+            var newTagHelpers = new List<TagHelperDescriptor>(baseTagHelpers.Count + Added.Count - Removed.Count);
+            newTagHelpers.AddRange(Added);
+
+            foreach (var existingTagHelper in baseTagHelpers)
+            {
+                if (!Removed.Contains(existingTagHelper))
+                {
+                    newTagHelpers.Add(existingTagHelper);
+                }
+            }
+
+            return newTagHelpers;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelperResultCache.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelperResultCache.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor
+{
+    internal class TagHelperResultCache
+    {
+        private readonly MemoryCache<string, ProjectResultCacheEntry> _projectResultCache;
+
+        public TagHelperResultCache()
+        {
+            _projectResultCache = new MemoryCache<string, ProjectResultCacheEntry>(sizeLimit: 50);
+        }
+
+        public bool TryGet(string projectFilePath, int resultId, out IReadOnlyList<TagHelperDescriptor>? cachedTagHelpers)
+        {
+            if (!_projectResultCache.TryGetValue(projectFilePath, out var cachedResult))
+            {
+                // Don't know about this project, miss!
+                cachedTagHelpers = null;
+                return false;
+            }
+            else if (cachedResult.ResultId != resultId)
+            {
+                // We don't know about the result that's being requested. Fallback to uncached behavior.
+                cachedTagHelpers = null;
+                return false;
+            }
+
+            cachedTagHelpers = cachedResult.Descriptors;
+            return true;
+        }
+
+        public bool TryGetId(string projectFilePath, out int resultId)
+        {
+            if (!_projectResultCache.TryGetValue(projectFilePath, out var cachedResult))
+            {
+                // Don't know about this project, miss!
+                resultId = -1;
+                return false;
+            }
+
+            resultId = cachedResult.ResultId;
+            return true;
+        }
+
+        public void Set(string projectFilePath, int resultId, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            var cacheEntry = new ProjectResultCacheEntry(resultId, tagHelpers);
+            _projectResultCache.Set(projectFilePath, cacheEntry);
+        }
+
+        private record ProjectResultCacheEntry(int ResultId, IReadOnlyList<TagHelperDescriptor> Descriptors);
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelperResultCache.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelperResultCache.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
         {
             if (!_projectResultCache.TryGetValue(projectFilePath, out var cachedResult))
             {
-                // Don't know about this project, miss!
                 cachedTagHelpers = null;
                 return false;
             }
@@ -39,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
         {
             if (!_projectResultCache.TryGetValue(projectFilePath, out var cachedResult))
             {
-                // Don't know about this project, miss!
                 resultId = -1;
                 return false;
             }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
 
             // Act
-            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+            var tagHelpers = resolver.PublicProduceTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
 
             // Assert
             Assert.Equal(Project1TagHelpers, tagHelpers);
@@ -165,12 +165,12 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             // Arrange
             var resolver = new TestTagHelperResolver(EngineFactory, ErrorReporter, Workspace);
             var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
-            resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+            resolver.PublicProduceTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
             var newTagHelperSet = new[] { TagHelper1_Project1 };
             var failedDeltaApplication = new TagHelperDeltaResult(Delta: false, initialDelta.ResultId + 1, newTagHelperSet, Array.Empty<TagHelperDescriptor>());
 
             // Act
-            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, failedDeltaApplication);
+            var tagHelpers = resolver.PublicProduceTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, failedDeltaApplication);
 
             // Assert
             Assert.Equal(newTagHelperSet, tagHelpers);
@@ -182,11 +182,11 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             // Arrange
             var resolver = new TestTagHelperResolver(EngineFactory, ErrorReporter, Workspace);
             var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
-            resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+            resolver.PublicProduceTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
             var noopDelta = new TagHelperDeltaResult(Delta: true, initialDelta.ResultId, Array.Empty<TagHelperDescriptor>(), Array.Empty<TagHelperDescriptor>());
 
             // Act
-            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, noopDelta);
+            var tagHelpers = resolver.PublicProduceTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, noopDelta);
 
             // Assert
             Assert.Equal(Project1TagHelpers, tagHelpers);
@@ -198,11 +198,11 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             // Arrange
             var resolver = new TestTagHelperResolver(EngineFactory, ErrorReporter, Workspace);
             var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
-            resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+            resolver.PublicProduceTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
             var changedDelta = new TagHelperDeltaResult(Delta: true, initialDelta.ResultId + 1, new[] { TagHelper2_Project2 }, new[] { TagHelper2_Project1 });
 
             // Act
-            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, changedDelta);
+            var tagHelpers = resolver.PublicProduceTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, changedDelta);
 
             // Assert
             Assert.Equal(new[] { TagHelper1_Project1, TagHelper2_Project2 }, tagHelpers.OrderBy(th => th.Name));
@@ -231,11 +231,11 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
                 return OnResolveInProcess(projectSnapshot);
             }
 
-            public IReadOnlyList<TagHelperDescriptor> PublicConsumeTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
-                => ConsumeTagHelpersFromDelta(projectFilePath, lastResultId, deltaResult);
+            public IReadOnlyList<TagHelperDescriptor> PublicProduceTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
+                => ProduceTagHelpersFromDelta(projectFilePath, lastResultId, deltaResult);
 
-            protected override IReadOnlyList<TagHelperDescriptor> ConsumeTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
-                => base.ConsumeTagHelpersFromDelta(projectFilePath, lastResultId, deltaResult);
+            protected override IReadOnlyList<TagHelperDescriptor> ProduceTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
+                => base.ProduceTagHelpersFromDelta(projectFilePath, lastResultId, deltaResult);
         }
 
         private class TestProjectSnapshotManager : DefaultProjectSnapshotManager

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
@@ -4,18 +4,20 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Remote.Razor.Test;
 using Moq;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor
 {
-    public class OOPTagHelperResolverTest
+    public class OOPTagHelperResolverTest : TagHelperDescriptorTestBase
     {
         public OOPTagHelperResolverTest()
         {
@@ -143,6 +145,69 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await resolver.GetTagHelpersAsync(WorkspaceProject, projectSnapshot, cancellationToken));
         }
 
+        [Fact]
+        public void CalculateTagHelpersFromDelta_NewProject()
+        {
+            // Arrange
+            var resolver = new TestTagHelperResolver(EngineFactory, ErrorReporter, Workspace);
+            var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
+
+            // Act
+            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+
+            // Assert
+            Assert.Equal(Project1TagHelpers, tagHelpers);
+        }
+
+        [Fact]
+        public void CalculateTagHelpersFromDelta_DeltaFailedToApplyToKnownProject()
+        {
+            // Arrange
+            var resolver = new TestTagHelperResolver(EngineFactory, ErrorReporter, Workspace);
+            var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
+            resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+            var newTagHelperSet = new[] { TagHelper1_Project1 };
+            var failedDeltaApplication = new TagHelperDeltaResult(Delta: false, initialDelta.ResultId + 1, newTagHelperSet, Array.Empty<TagHelperDescriptor>());
+
+            // Act
+            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, failedDeltaApplication);
+
+            // Assert
+            Assert.Equal(newTagHelperSet, tagHelpers);
+        }
+
+        [Fact]
+        public void CalculateTagHelpersFromDelta_NoopResult()
+        {
+            // Arrange
+            var resolver = new TestTagHelperResolver(EngineFactory, ErrorReporter, Workspace);
+            var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
+            resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+            var noopDelta = new TagHelperDeltaResult(Delta: true, initialDelta.ResultId, Array.Empty<TagHelperDescriptor>(), Array.Empty<TagHelperDescriptor>());
+
+            // Act
+            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, noopDelta);
+
+            // Assert
+            Assert.Equal(Project1TagHelpers, tagHelpers);
+        }
+
+        [Fact]
+        public void CalculateTagHelpersFromDelta_ReplacedTagHelpers()
+        {
+            // Arrange
+            var resolver = new TestTagHelperResolver(EngineFactory, ErrorReporter, Workspace);
+            var initialDelta = new TagHelperDeltaResult(Delta: false, ResultId: 1, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
+            resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, lastResultId: -1, initialDelta);
+            var changedDelta = new TagHelperDeltaResult(Delta: true, initialDelta.ResultId + 1, new[] { TagHelper2_Project2 }, new[] { TagHelper2_Project1 });
+
+            // Act
+            var tagHelpers = resolver.PublicConsumeTagHelpersFromDelta(Project1FilePath, initialDelta.ResultId, changedDelta);
+
+            // Assert
+            Assert.Equal(new[] { TagHelper1_Project1, TagHelper2_Project2 }, tagHelpers.OrderBy(th => th.Name));
+        }
+
         private class TestTagHelperResolver : OOPTagHelperResolver
         {
             public TestTagHelperResolver(ProjectSnapshotProjectEngineFactory factory, ErrorReporter errorReporter, Workspace workspace)
@@ -165,6 +230,12 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
                 Assert.NotNull(OnResolveInProcess);
                 return OnResolveInProcess(projectSnapshot);
             }
+
+            public IReadOnlyList<TagHelperDescriptor> PublicConsumeTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
+                => ConsumeTagHelpersFromDelta(projectFilePath, lastResultId, deltaResult);
+
+            protected override IReadOnlyList<TagHelperDescriptor> ConsumeTagHelpersFromDelta(string projectFilePath, int lastResultId, TagHelperDeltaResult deltaResult)
+                => base.ConsumeTagHelpersFromDelta(projectFilePath, lastResultId, deltaResult);
         }
 
         private class TestProjectSnapshotManager : DefaultProjectSnapshotManager

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/RemoteTagHelperDeltaProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/RemoteTagHelperDeltaProviderTest.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Test
+{
+    public class TagHelperDescriptorTestBase
+    {
+        public TagHelperDescriptorTestBase()
+        {
+            Project1FilePath = "C:/path/to/Project1/Project1.csproj";
+            TagHelper1_Project1 = TagHelperDescriptorBuilder.Create("TagHelper1", "Project1").Build();
+            TagHelper2_Project1 = TagHelperDescriptorBuilder.Create("TagHelper2", "Project1").Build();
+
+            Project2FilePath = "C:/path/to/Project2/Project2.csproj";
+            TagHelper1_Project2 = TagHelperDescriptorBuilder.Create("TagHelper1", "Project2").Build();
+            TagHelper2_Project2 = TagHelperDescriptorBuilder.Create("TagHelper2", "Project2").Build();
+        }
+
+        protected string Project1FilePath { get; }
+
+        protected TagHelperDescriptor TagHelper1_Project1 { get; }
+
+        protected TagHelperDescriptor TagHelper2_Project1 { get; }
+
+        protected IReadOnlyList<TagHelperDescriptor> Project1TagHelpers => new[] { TagHelper1_Project1, TagHelper2_Project1 };
+
+        protected string Project2FilePath { get; }
+
+        protected TagHelperDescriptor TagHelper1_Project2 { get; }
+
+        protected TagHelperDescriptor TagHelper2_Project2 { get; }
+
+        protected IReadOnlyList<TagHelperDescriptor> Project2TagHelpers => new[] { TagHelper1_Project2, TagHelper2_Project2 };
+
+        protected IReadOnlyList<TagHelperDescriptor> Project1AndProject2TagHelpers => new[] { TagHelper1_Project1, TagHelper2_Project1, TagHelper1_Project2, TagHelper2_Project2 };
+    }
+
+    public class RemoteTagHelperDeltaProviderTest : TagHelperDescriptorTestBase
+    {
+        public RemoteTagHelperDeltaProviderTest()
+        {
+            Provider = new RemoteTagHelperDeltaProvider();
+        }
+
+        private RemoteTagHelperDeltaProvider Provider { get; }
+
+        [Fact]
+        public void GetTagHelpersDelta_Clean_SingleProject()
+        {
+            // Act
+            var delta = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+
+            // Assert
+            Assert.False(delta.Delta);
+            Assert.Equal(Project1TagHelpers, delta.Added);
+            Assert.Empty(delta.Removed);
+        }
+
+        [Fact]
+        public void GetTagHelpersDelta_Clean_MultiProject()
+        {
+            // Act
+            var delta1 = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+            var delta2 = Provider.GetTagHelpersDelta(Project2FilePath, lastResultId: -1, Project2TagHelpers);
+
+            // Assert
+            Assert.False(delta1.Delta);
+            Assert.Equal(Project1TagHelpers, delta1.Added);
+            Assert.Empty(delta1.Removed);
+            Assert.False(delta2.Delta);
+            Assert.Equal(Project2TagHelpers, delta2.Added);
+            Assert.Empty(delta2.Removed);
+        }
+
+        [Fact]
+        public void GetTagHelpersDelta_TagHelperRemovedFromProjectOne_InvalidResultId()
+        {
+            // Arrange
+            var tagHelpersWithOneRemoved = new[]
+            {
+                TagHelper1_Project1
+            };
+            Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+            Provider.GetTagHelpersDelta(Project2FilePath, lastResultId: -1, Project2TagHelpers);
+
+            // Act
+            var delta = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1337, tagHelpersWithOneRemoved);
+
+            // Assert
+            Assert.False(delta.Delta);
+            Assert.Equal(tagHelpersWithOneRemoved, delta.Added);
+            Assert.Empty(delta.Removed);
+        }
+
+        [Fact]
+        public void GetTagHelpersDelta_TagHelperRemovedFromProjectOne()
+        {
+            // Arrange
+            var tagHelpersWithOneRemoved = new[]
+            {
+                TagHelper1_Project1
+            };
+            var initialDelta = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+            Provider.GetTagHelpersDelta(Project2FilePath, lastResultId: -1, Project2TagHelpers);
+
+            // Act
+            var delta = Provider.GetTagHelpersDelta(Project1FilePath, initialDelta.ResultId, tagHelpersWithOneRemoved);
+
+            // Assert
+            Assert.True(delta.Delta);
+            Assert.Empty(delta.Added);
+            var tagHelper = Assert.Single(delta.Removed);
+            Assert.Equal(TagHelper2_Project1, tagHelper);
+        }
+
+        [Fact]
+        public void GetTagHelpersDelta_TagHelpersCopiedToProjectOne()
+        {
+            // Arrange
+            var tagHelpers = new List<TagHelperDescriptor>();
+            tagHelpers.AddRange(Project1TagHelpers);
+            tagHelpers.AddRange(Project2TagHelpers);
+            var initialDelta = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+            Provider.GetTagHelpersDelta(Project2FilePath, lastResultId: -1, Project2TagHelpers);
+
+            // Act
+            var delta = Provider.GetTagHelpersDelta(Project1FilePath, initialDelta.ResultId, tagHelpers);
+
+            // Assert
+            Assert.True(delta.Delta);
+            Assert.Equal(Project2TagHelpers, delta.Added);
+            Assert.Empty(delta.Removed);
+        }
+
+        [Fact]
+        public void GetTagHelpersDelta_NoChange()
+        {
+            // Arrange
+            var initialDelta = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+
+            // Act
+            var delta = Provider.GetTagHelpersDelta(Project1FilePath, initialDelta.ResultId, Project1TagHelpers);
+
+            // Assert
+            Assert.True(delta.Delta);
+            Assert.Empty(delta.Added);
+            Assert.Empty(delta.Removed);
+        }
+
+        [Fact]
+        public void GetTagHelpersDelta_EndToEnd()
+        {
+            // Arrange
+            var mixedTagHelpers1 = new[]
+            {
+                TagHelper1_Project1,
+                TagHelper1_Project2,
+            };
+            var mixedTagHelpers2 = new[]
+            {
+                TagHelper2_Project1,
+                TagHelper2_Project2,
+            };
+            var initialDelta1 = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+            var initialDelta2 = Provider.GetTagHelpersDelta(Project2FilePath, lastResultId: -1, Project2TagHelpers);
+
+            // Act - 1
+            var delta1 = Provider.GetTagHelpersDelta(Project1FilePath, initialDelta1.ResultId, mixedTagHelpers1);
+            var delta2 = Provider.GetTagHelpersDelta(Project2FilePath, initialDelta2.ResultId, mixedTagHelpers2);
+
+            // Assert - 1
+            Assert.True(delta1.Delta);
+            Assert.Equal(new[] { TagHelper1_Project2 }, delta1.Added);
+            Assert.Equal(new[] { TagHelper2_Project1 }, delta1.Removed);
+            Assert.True(delta2.Delta);
+            Assert.Equal(new[] { TagHelper2_Project1 }, delta2.Added);
+            Assert.Equal(new[] { TagHelper1_Project2 }, delta2.Removed);
+
+            // Act - 2 (restore to original state)
+            delta1 = Provider.GetTagHelpersDelta(Project1FilePath, delta1.ResultId, Project1TagHelpers);
+            delta2 = Provider.GetTagHelpersDelta(Project2FilePath, delta2.ResultId, Project2TagHelpers);
+
+            // Assert - 2
+            Assert.True(delta1.Delta);
+            Assert.Equal(new[] { TagHelper2_Project1 }, delta1.Added);
+            Assert.Equal(new[] { TagHelper1_Project2 }, delta1.Removed);
+            Assert.True(delta2.Delta);
+            Assert.Equal(new[] { TagHelper1_Project2 }, delta2.Added);
+            Assert.Equal(new[] { TagHelper2_Project1 }, delta2.Removed);
+
+            // Act - 3 (No-op)
+            delta1 = Provider.GetTagHelpersDelta(Project1FilePath, delta1.ResultId, Project1TagHelpers);
+            delta2 = Provider.GetTagHelpersDelta(Project2FilePath, delta2.ResultId, Project2TagHelpers);
+
+            // Assert - 3
+            Assert.True(delta1.Delta);
+            Assert.Empty(delta1.Added);
+            Assert.Empty(delta1.Removed);
+            Assert.True(delta2.Delta);
+            Assert.Empty(delta2.Added);
+            Assert.Empty(delta2.Removed);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/RemoteTagHelperDeltaProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/RemoteTagHelperDeltaProviderTest.cs
@@ -5,42 +5,11 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Remote.Razor.Test;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Remote.Razor.Test
+namespace Microsoft.CodeAnalysis.Remote.Razor
 {
-    public class TagHelperDescriptorTestBase
-    {
-        public TagHelperDescriptorTestBase()
-        {
-            Project1FilePath = "C:/path/to/Project1/Project1.csproj";
-            TagHelper1_Project1 = TagHelperDescriptorBuilder.Create("TagHelper1", "Project1").Build();
-            TagHelper2_Project1 = TagHelperDescriptorBuilder.Create("TagHelper2", "Project1").Build();
-
-            Project2FilePath = "C:/path/to/Project2/Project2.csproj";
-            TagHelper1_Project2 = TagHelperDescriptorBuilder.Create("TagHelper1", "Project2").Build();
-            TagHelper2_Project2 = TagHelperDescriptorBuilder.Create("TagHelper2", "Project2").Build();
-        }
-
-        protected string Project1FilePath { get; }
-
-        protected TagHelperDescriptor TagHelper1_Project1 { get; }
-
-        protected TagHelperDescriptor TagHelper2_Project1 { get; }
-
-        protected IReadOnlyList<TagHelperDescriptor> Project1TagHelpers => new[] { TagHelper1_Project1, TagHelper2_Project1 };
-
-        protected string Project2FilePath { get; }
-
-        protected TagHelperDescriptor TagHelper1_Project2 { get; }
-
-        protected TagHelperDescriptor TagHelper2_Project2 { get; }
-
-        protected IReadOnlyList<TagHelperDescriptor> Project2TagHelpers => new[] { TagHelper1_Project2, TagHelper2_Project2 };
-
-        protected IReadOnlyList<TagHelperDescriptor> Project1AndProject2TagHelpers => new[] { TagHelper1_Project1, TagHelper2_Project1, TagHelper1_Project2, TagHelper2_Project2 };
-    }
-
     public class RemoteTagHelperDeltaProviderTest : TagHelperDescriptorTestBase
     {
         public RemoteTagHelperDeltaProviderTest()

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/TagHelperDeltaResultTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/TagHelperDeltaResultTest.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Remote.Razor.Test;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor
+{
+    public class TagHelperDeltaResultTest : TagHelperDescriptorTestBase
+    {
+        [Fact]
+        public void Apply_Noop()
+        {
+            // Arrange
+            var delta = new TagHelperDeltaResult(Delta: true, ResultId: 1337, Array.Empty<TagHelperDescriptor>(), Array.Empty<TagHelperDescriptor>());
+
+            // Act
+            var tagHelpers = delta.Apply(Project1TagHelpers);
+
+            // Assert
+            Assert.Equal(Project1TagHelpers, tagHelpers);
+        }
+
+        [Fact]
+        public void Apply_Added()
+        {
+            // Arrange
+            var delta = new TagHelperDeltaResult(Delta: true, ResultId: 1337, Project1TagHelpers, Array.Empty<TagHelperDescriptor>());
+
+            // Act
+            var tagHelpers = delta.Apply(Project2TagHelpers);
+
+            // Assert
+            Assert.Equal(Project1AndProject2TagHelpers, tagHelpers);
+        }
+
+        [Fact]
+        public void Apply_Removed()
+        {
+            // Arrange
+            var delta = new TagHelperDeltaResult(Delta: true, ResultId: 1337, Array.Empty<TagHelperDescriptor>(), Project1TagHelpers);
+
+            // Act
+            var tagHelpers = delta.Apply(Project1AndProject2TagHelpers);
+
+            // Assert
+            Assert.Equal(Project2TagHelpers, tagHelpers);
+        }
+
+        [Fact]
+        public void Apply_AddAndRemoved()
+        {
+            // Arrange
+            var delta = new TagHelperDeltaResult(Delta: true, ResultId: 1337, Project1TagHelpers, Project2TagHelpers);
+
+            // Act
+            var tagHelpers = delta.Apply(Project2TagHelpers);
+
+            // Assert
+            Assert.Equal(Project1TagHelpers, tagHelpers);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/TagHelperDescriptorTestBase.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/TagHelperDescriptorTestBase.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Test
+{
+    public class TagHelperDescriptorTestBase
+    {
+        public TagHelperDescriptorTestBase()
+        {
+            Project1FilePath = "C:/path/to/Project1/Project1.csproj";
+            TagHelper1_Project1 = TagHelperDescriptorBuilder.Create("TagHelper1", "Project1").Build();
+            TagHelper2_Project1 = TagHelperDescriptorBuilder.Create("TagHelper2", "Project1").Build();
+
+            Project2FilePath = "C:/path/to/Project2/Project2.csproj";
+            TagHelper1_Project2 = TagHelperDescriptorBuilder.Create("TagHelper1", "Project2").Build();
+            TagHelper2_Project2 = TagHelperDescriptorBuilder.Create("TagHelper2", "Project2").Build();
+        }
+
+        protected string Project1FilePath { get; }
+
+        protected TagHelperDescriptor TagHelper1_Project1 { get; }
+
+        protected TagHelperDescriptor TagHelper2_Project1 { get; }
+
+        protected IReadOnlyList<TagHelperDescriptor> Project1TagHelpers => new[] { TagHelper1_Project1, TagHelper2_Project1 };
+
+        protected string Project2FilePath { get; }
+
+        protected TagHelperDescriptor TagHelper1_Project2 { get; }
+
+        protected TagHelperDescriptor TagHelper2_Project2 { get; }
+
+        protected IReadOnlyList<TagHelperDescriptor> Project2TagHelpers => new[] { TagHelper1_Project2, TagHelper2_Project2 };
+
+        protected IReadOnlyList<TagHelperDescriptor> Project1AndProject2TagHelpers => new[] { TagHelper1_Project1, TagHelper2_Project1, TagHelper1_Project2, TagHelper2_Project2 };
+    }
+}


### PR DESCRIPTION
- We were getting hit pretty hard in serialization & deserialization paths in our TagHelper resolution endpoints. After investigation it looks like every keystroke will kick off resolution requests every 1 second. While this may seem "too frequent" it actually enables us to provide better TagHelper detection/colorization/error states so keeping a frequent polling approach is still a goal. Therefore I designed a path to reduce the amount of data that's passed back & forth between VS & the Roslyn service hub processes. The gist is that we now have a delta result which the client & server both understand. That result has an `Added`, `Removed`, `ResultId` and `Delta` parameter. First two are self explanatory, `ResultId` represents an "id" that a client needs to keep track of (inspired by LSP) and `Delta` just indicates if the response is delta based or the client should not try and apply the response as a delta.
- Added exhaustive unit tests for each of the delta pieces given they have an extremely high impact to end-user functionality.

# Results

Scenario: Opening users application and hitting "enter" 5x in their `@code` section. Wait for bottom left hand corner (background processing) to complete. Measure.

### Allocations

Before = Left, After = Right
![before & after memory profile picture](https://i.imgur.com/Bq8kfLX.png)

**Gist:** We allocate 61% less when only looking at Newtonsoft specific objects; however, Newtonsoft also allocates other transient objects like lists, dictionaries, extra strings etc so understanding the true reduction of memory is a bit harder. Therefore I also took CPU profiles

### CPU

Before = Left, After = Right
![before & after cpu profile picture](https://i.imgur.com/fOnbQaU.png)

**Gist:** devenv's CPU utilization is 58% less and ServiceHub's is 42% less. Taking both processes into account we utilize 52% less CPU on users machine for basic editing.

Fixes #5673