### PR TITLE
Use vscode-languageserver-textdocument

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "ps-list": "^7.0.0",
     "vscode-html-languageservice": "^4.2.1",
-    "vscode-languageclient": "5.2.1"
+    "vscode-languageclient": "5.2.1",
+    "vscode-languageserver-textdocument": "^1.0.3"
   },
   "main": "./dist/extension.js",
   "types": "./dist/extension.d.ts",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Html/HtmlTagCompletionProvider.ts
@@ -8,7 +8,7 @@ import {
     getLanguageService as getHtmlLanguageService,
     LanguageService as HtmlLanguageService,
 } from 'vscode-html-languageservice';
-import { TextDocument as ServiceTextDocument } from 'vscode-languageserver-types';
+import { TextDocument as ServiceTextDocument } from 'vscode-languageserver-textdocument';
 import { IRazorDocumentManager } from '../IRazorDocumentManager';
 import { RazorLanguage } from '../RazorLanguage';
 import { RazorLanguageServiceClient } from '../RazorLanguageServiceClient';

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/yarn.lock
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/yarn.lock
@@ -330,10 +330,10 @@ vscode-languageserver-protocol@3.14.1:
     vscode-jsonrpc "^4.0.0"
     vscode-languageserver-types "3.14.0"
 
-vscode-languageserver-textdocument@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.2.tgz#2f9f6bd5b5eb3d8e21424c0c367009216f016236"
-  integrity sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==
+vscode-languageserver-textdocument@^1.0.1, vscode-languageserver-textdocument@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.3.tgz#879f2649bfa5a6e07bc8b392c23ede2dfbf43eff"
+  integrity sha512-ynEGytvgTb6HVSUwPJIAZgiHQmPCx8bZ8w5um5Lz+q5DjP0Zj8wTFhQpyg8xaMvefDytw2+HH5yzqS+FhsR28A==
 
 vscode-languageserver-types@3.14.0:
   version "3.14.0"


### PR DESCRIPTION
### Summary of the changes
 - Get TextDocument from vscode-languageserver-textdocument, rather than from the deprecated version in vscode-languageserver-types
 - Explicitly install vscode-languageserver-textdocument as a dependency to control its versioning

Fixes: 
A deprecation warning I noticed while working on #5767. The TextDocument from vscode-languageserver-textdocument is a drop-in replacement, and I've tested it against omnisharp-vscode and confirmed tag completion is still working.
I've also added it as a dependency in package.json so that its versioning isn't at the whim of vscode-html-languageservice's transitive dependency.