### PR TITLE
Fix HTML scenarios

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
@@ -246,18 +246,17 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 
                     _cts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken);
 
-                    // If requestCancellationToken is already cancelled then registering
-                    // the callback will cause _cts to throw. So let's just set NotSynchronized now.
-                    if (_cts.IsCancellationRequested)
-                    {
-                        SetSynchronized(false);
-                    }
-                    else
+                    // This might throw because the token has already been marked as cancelled
+                    try
                     {
                         // This cancellation token is the one passed in from the call-site that needs to synchronize an LSP document with a virtual document.
                         // Meaning, if the outer token is cancelled we need to fail to synchronize.
                         _cts.Token.Register(() => SetSynchronized(false));
                         _cts.CancelAfter(timeout);
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        SetSynchronized(false);
                     }
                 }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
@@ -243,12 +243,19 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                     RequiredHostDocumentVersion = requiredHostDocumentVersion;
                     RejectOnNewerParallelRequest = rejectOnNewerParallelRequest;
                     _onSynchronizedSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    _cts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken);
 
-                    // This cancellation token is the one passed in from the call-site that needs to synchronize an LSP document with a virtual document.
-                    // Meaning, if the outer token is cancelled we need to fail to synchronize.
-                    _cts.Token.Register(() => SetSynchronized(false));
-                    _cts.CancelAfter(timeout);
+                    _cts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken);
+                    if (_cts.IsCancellationRequested)
+                    {
+                        SetSynchronized(false);
+                    }
+                    else
+                    {
+                        // This cancellation token is the one passed in from the call-site that needs to synchronize an LSP document with a virtual document.
+                        // Meaning, if the outer token is cancelled we need to fail to synchronize.
+                        _cts.Token.Register(() => SetSynchronized(false));
+                        _cts.CancelAfter(timeout);
+                    }
                 }
 
                 public bool RejectOnNewerParallelRequest { get; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentSynchronizer.cs
@@ -245,6 +245,9 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                     _onSynchronizedSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     _cts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken);
+
+                    // If requestCancellationToken is already cancelled then registering
+                    // the callback will cause _cts to throw. So let's just set NotSynchronized now.
                     if (_cts.IsCancellationRequested)
                     {
                         SetSynchronized(false);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDiagnosticsTranslator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPDiagnosticsTranslator.cs
@@ -70,8 +70,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 RazorLSPConstants.RazorLanguageServerName,
                 diagnosticsParams,
                 cancellationToken).ConfigureAwait(false);
-
-            if (!ReinvocationResponseHelper.TryExtractResultOrLog(response, await GetLoggerAsync(cancellationToken), RazorLSPConstants.RazorLanguageServerName, out var result))
+            var logger = await GetLoggerAsync(cancellationToken).ConfigureAwait(false);
+            if (!ReinvocationResponseHelper.TryExtractResultOrLog(response, logger, RazorLSPConstants.RazorLanguageServerName, out var result))
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/HTMLCSharpLanguageServerLogHubLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/HTMLCSharpLanguageServerLogHubLoggerProvider.cs
@@ -98,6 +98,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
             return LoggerProvider.CreateLogger(categoryName);
         }
 
+        public virtual async Task<ILogger> CreateLoggerAsync(string categoryName, CancellationToken cancellationToken)
+        {
+            await InitializeLoggerAsync(cancellationToken);
+            return CreateLogger(categoryName);
+        }
+
         public TraceSource GetTraceSource()
         {
             return LoggerProvider.GetTraceSource();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HandlerTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HandlerTestBase.cs
@@ -18,7 +18,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             var logger = new TestLogger();
             LoggerProvider = Mock.Of<HTMLCSharpLanguageServerLogHubLoggerProvider>(l =>
-                l.CreateLogger(It.IsAny<string>()) == logger && l.InitializeLoggerAsync(It.IsAny<CancellationToken>()) == Task.CompletedTask,
+                l.CreateLogger(It.IsAny<string>()) == logger &&
+                l.InitializeLoggerAsync(It.IsAny<CancellationToken>()) == Task.CompletedTask &&
+                l.CreateLoggerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()) == Task.FromResult<ILogger>(logger),
                 MockBehavior.Strict);
         }
 


### PR DESCRIPTION
### Summary of the changes
 - First problem: LoggerProvider might not have been initialized when opening a plain `.html` file.
 - Second problem: In some Scenarios WebTools calls our virtual document synchronizer with an already expired CancellationToken. This can cause us to throw an exception when we try to operate on it. I've modified the code to harden us against that scenario and alerted WebTools to the scenario.

Fixes: https://github.com/dotnet/razor-tooling/issues/5924
