### PR TITLE
Remove TextEdit translation safety checks on completion.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -767,23 +767,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         End = translatedEndPosition,
                     };
 
-                    // Reduce the range down to the wordRange if needed. This means if we have a C# text edit that goes beyond
-                    // the original word, then we need to ensure that the edit is scoped to the word, otherwise it may remove
-                    // portions of the Razor document. This may not happen in practice, but we want to be fail-safe.
-                    //
-                    // For example, if we had the following code in the C# virtual doc:
-                    //     SomeMethod(|1|, 2);
-                    // Which corresponded to the following in a Razor file (notice '2' is not present here):
-                    //     <MyTagHelper SomeAttribute="|1|"/>
-                    // If there was a completion item that replaced '|1|, 2' with something like 'MyVariable', then without the
-                    // logic below, the TextEdit may be applied to the Razor file as:
-                    //     <MyTagHelper SomeAttribute="MyVariable>
-                    var scopedTranslatedRange = wordRange?.Overlap(translatedRange) ?? translatedRange;
-
                     var translatedText = item.TextEdit.NewText;
                     item.TextEdit = new TextEdit()
                     {
-                        Range = scopedTranslatedRange,
+                        Range = translatedRange,
                         NewText = translatedText,
                     };
                 }


### PR DESCRIPTION
- We had logic to shrink completion `TextEdit`'s  potential impact area to the current completion word; however, turns out this wasn't a great route. If a `TextEdit` does not expand past the boundaries of the current word then there's no reason to use a `TextEdit`, `InsertText` would suffice. Meaning, every time a completion item utilized `TextEdit`s we'd almost always do the wrong thing. In this case URL completion in HTML scenarios would almost always expand past the word boundary because you'd go from `~/css/parent` => `~/css` when selecting the `..` (up one folder) item. They also replaced entire spans for sub-folder logic as well.
- In testing I didn't see anything fall over from this change. If anything things work better now :), turns out there were no tests!

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1448933