### PR TITLE
Re-generate VS Code grammar tests

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/Directory.Build.props
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/Directory.Build.props
@@ -1,11 +1,13 @@
 <Project>
-<PropertyGroup>
-  <!--
-    The Oniguruma package for regex testing has its own Arcade & SDK independent build mechanisms that automatically look for hierarchical Directory.Build.props files.
-    Therefore, we have this file here in order to suppress the usage of the global SDK and arcade build system to enable yarn install to pass.
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
-    For context the Oniguruma contains C++ code that's dynamically compiled on install.
-  -->
-  <_SuppressSdkImports>true</_SuppressSdkImports>
-</PropertyGroup>
+  <PropertyGroup>
+    <!--
+      The Oniguruma package for regex testing has its own Arcade & SDK independent build mechanisms that automatically look for hierarchical Directory.Build.props files.
+      Therefore, we have this file here in order to suppress the usage of the global SDK and arcade build system to enable yarn install to pass.
+
+      For context the Oniguruma contains C++ code that's dynamically compiled on install.
+    -->
+    <_SuppressSdkImports>true</_SuppressSdkImports>
+  </PropertyGroup>
 </Project>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/README.md
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/README.md
@@ -4,8 +4,6 @@
 ## Setup
 ```bash
 yarn install
-
-npm i -g jest
 ```
 
 **Note:** There are [known issues](https://github.com/nodejs/node-gyp/blob/master/macOS_Catalina.md) with MacOS Catalina for certain dependencies. Windows works well.
@@ -15,12 +13,6 @@ npm i -g jest
 [Jest Snapshot Tests](https://jestjs.io/docs/en/snapshot-testing) are utilized to test out the TextMate grammar in VS Code. As the name suggests, snapshot tests store a serialized _snapshot_ of the tokenized and parsed result of the grammar on a particular test string.
 
 ### Running Snapshot Tests
-```bash
-jest
-```
-
-or
-
 ```bash
 yarn test
 ```
@@ -36,7 +28,7 @@ yarn test
 ### Adding a Test Suite
 1. Add new test suite file in `./tests` (you can copy an existing test suite as a template).
 2. Update `./tests/GrammarTests.test.ts` with the new test suite.
-3. Run `jest --updateSnapshot`
+3. Run `yarn test --updateSnapshot`
 
 ### Adding / Updating a Test in an Existing Test Suite
 1. Ensure the grammar is functioning as expected visually using a test string within a `.cshtml` / `.razor` file.
@@ -46,5 +38,5 @@ it('[Test Name]', async () => {
     await assertMatchesSnapshot('[Test String]');
 });
 ```
-3.  Run `jest --updateSnapshot` to serialize the tokensized and parsed representation of the test string. This frozen state will be treated as the "source of truth" for future executions of the test suite, in order to identify regressions.
+3.  Run `yarn test --updateSnapshot` to serialize the tokensized and parsed representation of the test string. This frozen state will be treated as the "source of truth" for future executions of the test suite, in order to identify regressions.
 4. Ensure the `./tests/__snapshots__/GrammarTests.test.ts.snap` file is commited with your changes.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Grammar tests @addTagHelper directive No parameter 1`] = `
 `;
 
 exports[`Grammar tests @addTagHelper directive No parameter, spaced 1`] = `
-"Line: @addTagHelper
+"Line: @addTagHelper                 
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 13 (addTagHelper) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.addTagHelper
  - token from 13 to 31 (                 ) with scopes text.aspnetcorerazor, meta.directive
@@ -36,7 +36,7 @@ exports[`Grammar tests @addTagHelper directive Quoted parameter 1`] = `
 `;
 
 exports[`Grammar tests @addTagHelper directive Quoted parameter spaced 1`] = `
-"Line: @addTagHelper       \\"*     ,      Microsoft.AspNetCore.Mvc.TagHelpers   \\"
+"Line: @addTagHelper       \\"*     ,      Microsoft.AspNetCore.Mvc.TagHelpers   \\"            
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 13 (addTagHelper) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.addTagHelper
  - token from 13 to 20 (       ) with scopes text.aspnetcorerazor, meta.directive
@@ -59,11 +59,11 @@ exports[`Grammar tests @addTagHelper directive Unquoted parameter 1`] = `
 exports[`Grammar tests @attribute directive As C# local 1`] = `
 "Line: @attribute.method()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 11 to 17 (method) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 11 to 17 (method) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 "
 `;
 
@@ -149,7 +149,7 @@ exports[`Grammar tests @attribute directive No attribute 1`] = `
 `;
 
 exports[`Grammar tests @attribute directive No attribute spaced 1`] = `
-"Line: @attribute
+"Line: @attribute              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 10 (attribute) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.attribute
  - token from 10 to 25 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -184,57 +184,57 @@ exports[`Grammar tests @code directive Multi line 1`] = `
  - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     private int currentCount = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 15 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 31 to 32 (0) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, constant.numeric.decimal.cs
- - token from 32 to 33 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 15 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 31 to 32 (0) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, constant.numeric.decimal.cs
+ - token from 32 to 33 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:     private void IncrementCount()
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 31 to 32 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 32 to 33 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 31 to 32 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:         var someString = \\"{ var ThisShouldNotBeCSharp = true; }\\";
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 11 (var) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.other.var.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 22 (someString) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 24 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 25 to 26 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 26 to 63 ({ var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 63 to 64 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 64 to 65 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 11 (var) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.other.var.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 22 (someString) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 24 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 25 to 26 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 26 to 63 ({ var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 63 to 64 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 64 to 65 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:         currentCount++;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.increment.cs
- - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.increment.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
@@ -247,11 +247,11 @@ exports[`Grammar tests @code directive Multi-line comment with curly braces 1`] 
  - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
  - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
  - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 10 (/*) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
- - token from 10 to 49 ( { var ThisShouldNotBeCSharp = true; } ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs
- - token from 49 to 51 (*/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
- - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 10 (/*) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.block.cs, punctuation.definition.comment.cs
+ - token from 10 to 49 ( { var ThisShouldNotBeCSharp = true; } ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.block.cs
+ - token from 49 to 51 (*/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.block.cs, punctuation.definition.comment.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
  - token from 52 to 53 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -269,24 +269,24 @@ exports[`Grammar tests @code directive Single line 1`] = `
  - token from 1 to 5 (code) with scopes text.aspnetcorerazor, keyword.control.razor.directive.code
  - token from 5 to 6 ( ) with scopes text.aspnetcorerazor
  - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 14 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 15 to 19 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 20 to 23 (Foo) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 23 to 24 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 24 to 25 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
- - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
- - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 14 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 15 to 19 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 20 to 23 (Foo) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 23 to 24 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 24 to 25 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.close.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
  - token from 29 to 30 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests @code directive Single-line comment with curly braces 1`] = `
-"Line:
+"Line: 
  - token from 0 to 1 () with scopes text.aspnetcorerazor
 
 Line: @code {
@@ -296,9 +296,9 @@ Line: @code {
  - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     // { var ThisShouldNotBeCSharp = true; }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.whitespace.comment.leading.cs
- - token from 4 to 6 (//) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs, punctuation.definition.comment.cs
- - token from 6 to 44 ( { var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.whitespace.comment.leading.cs
+ - token from 4 to 6 (//) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.line.double-slash.cs, punctuation.definition.comment.cs
+ - token from 6 to 44 ( { var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.line.double-slash.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
@@ -313,130 +313,130 @@ exports[`Grammar tests @code directive With Razor and markup 1`] = `
  - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     private void SomeMethod()
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 17 to 27 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 17 to 27 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:         <p>This method <strong>is really</strong> nice!
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 11 to 15 (This) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 16 to 22 (method) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 24 to 30 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 31 to 33 (is) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.other.is.cs
- - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 34 to 40 (really) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 42 to 48 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 48 to 49 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 50 to 54 (nice) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 54 to 55 (!) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.logical.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 11 to 15 (This) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 16 to 22 (method) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 24 to 30 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 31 to 33 (is) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.other.is.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 34 to 40 (really) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 42 to 48 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 48 to 49 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 50 to 54 (nice) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 54 to 55 (!) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.logical.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:             @if(true) {
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 15 (@if) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 16 to 20 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, constant.language.boolean.true.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 15 (@if) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 16 to 20 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, constant.language.boolean.true.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:                 <input type=\\"checkbox\\" value=\\"true\\" name=\\"Something\\" />
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 17 to 22 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 27 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 27 to 28 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 28 to 29 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 29 to 37 (checkbox) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 37 to 38 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 39 to 44 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 44 to 45 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 46 to 50 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 52 to 56 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 56 to 57 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 57 to 58 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 58 to 67 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 67 to 68 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 68 to 69 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 69 to 70 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.arithmetic.cs
- - token from 70 to 71 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 17 to 22 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 27 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 27 to 28 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 28 to 29 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 29 to 37 (checkbox) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 37 to 38 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 39 to 44 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 44 to 45 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 46 to 50 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 52 to 56 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 56 to 57 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 57 to 58 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 58 to 67 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 67 to 68 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 68 to 69 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 69 to 70 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 70 to 71 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 14 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 14 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:         </p>
- - token from 0 to 10 (        </) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 11 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 10 (        </) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 11 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:         @DateTime.Now
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 17 (@DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 17 (@DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:         <input type=\\"hidden\\" value=\\" { true }\\" name=\\"Something\\">
- - token from 0 to 9 (        <) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 9 to 14 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 15 to 19 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 20 to 21 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 21 to 27 (hidden) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 29 to 34 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 35 to 36 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 36 to 45 ( { true }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 47 to 51 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 51 to 52 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 52 to 53 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 53 to 62 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 62 to 63 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 63 to 64 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
+ - token from 0 to 9 (        <) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 9 to 14 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 15 to 19 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 20 to 21 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 21 to 27 (hidden) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 29 to 34 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 34 to 35 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 35 to 36 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 36 to 45 ( { true }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 47 to 51 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 51 to 52 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 52 to 53 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 53 to 62 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 62 to 63 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 63 to 64 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 6 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 6 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line: }
- - token from 0 to 2 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 2 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 "
 `;
 
@@ -647,7 +647,7 @@ exports[`Grammar tests @do { ... } while ( ... ); Single line 1`] = `
 exports[`Grammar tests @for ( ... ) { ... } Incomplete for statement, no condition 1`] = `
 "Line: @for {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 4 (for) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 4 (for) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 4 to 8 ( {}) with scopes text.aspnetcorerazor
 "
 `;
@@ -655,7 +655,7 @@ exports[`Grammar tests @for ( ... ) { ... } Incomplete for statement, no conditi
 exports[`Grammar tests @for ( ... ) { ... } Incomplete for statement, no condition or body 1`] = `
 "Line: @for
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 4 (for) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 4 (for) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
@@ -743,7 +743,7 @@ Line:             <p>@i</p>
  - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
  - token from 15 to 16 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 16 to 17 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 16 to 17 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 17 to 19 (</) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
  - token from 19 to 20 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
@@ -894,7 +894,7 @@ exports[`Grammar tests @for ( ... ) { ... } Single line 1`] = `
  - token from 55 to 56 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
  - token from 56 to 68 (Hello World ) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
  - token from 68 to 69 (@) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 69 to 70 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 69 to 70 (i) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 70 to 72 (</) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
  - token from 72 to 73 (p) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 73 to 74 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
@@ -934,7 +934,7 @@ exports[`Grammar tests @foreach ( ... ) { ... } Awaited foreach 1`] = `
  - token from 54 to 55 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
  - token from 55 to 67 (Hello World ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
  - token from 67 to 68 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 68 to 73 (value) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 68 to 73 (value) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 73 to 75 (</) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
  - token from 75 to 76 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 76 to 77 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
@@ -946,8 +946,8 @@ exports[`Grammar tests @foreach ( ... ) { ... } Awaited foreach 1`] = `
 exports[`Grammar tests @foreach ( ... ) { ... } Incomplete await foreach statement, no condition 1`] = `
 "Line: @await foreach {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.other.await.cs
- - token from 7 to 14 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 7 to 14 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 14 to 18 ( {}) with scopes text.aspnetcorerazor
 "
 `;
@@ -955,15 +955,15 @@ exports[`Grammar tests @foreach ( ... ) { ... } Incomplete await foreach stateme
 exports[`Grammar tests @foreach ( ... ) { ... } Incomplete await foreach statement, no condition or body 1`] = `
 "Line: @await foreach
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.other.await.cs
- - token from 7 to 14 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 7 to 14 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
 exports[`Grammar tests @foreach ( ... ) { ... } Incomplete foreach statement, no condition 1`] = `
 "Line: @foreach {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 8 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 8 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 8 to 12 ( {}) with scopes text.aspnetcorerazor
 "
 `;
@@ -971,7 +971,7 @@ exports[`Grammar tests @foreach ( ... ) { ... } Incomplete foreach statement, no
 exports[`Grammar tests @foreach ( ... ) { ... } Incomplete foreach statement, no condition or body 1`] = `
 "Line: @foreach
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 8 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 8 (foreach) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
@@ -1036,7 +1036,7 @@ Line:             <p>@i</p>
  - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
  - token from 15 to 16 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 16 to 17 (i) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 16 to 17 (i) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 17 to 19 (</) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
  - token from 19 to 20 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
@@ -1120,7 +1120,7 @@ Line: ){@value}
  - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
  - token from 2 to 3 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 3 to 8 (value) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 3 to 8 (value) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 "
 `;
@@ -1155,7 +1155,7 @@ exports[`Grammar tests @foreach ( ... ) { ... } Single line 1`] = `
  - token from 48 to 49 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
  - token from 49 to 61 (Hello World ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
  - token from 61 to 62 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 62 to 67 (value) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 62 to 67 (value) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 67 to 69 (</) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
  - token from 69 to 70 (p) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 70 to 71 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
@@ -1181,57 +1181,57 @@ exports[`Grammar tests @functions directive Multi line 1`] = `
  - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     private int currentCount = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 15 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 31 to 32 (0) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, constant.numeric.decimal.cs
- - token from 32 to 33 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 15 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 16 to 28 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 31 to 32 (0) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, constant.numeric.decimal.cs
+ - token from 32 to 33 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:     private void IncrementCount()
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 31 to 32 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 32 to 33 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 17 to 31 (IncrementCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 31 to 32 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:         var someString = \\"{ var ThisShouldNotBeCSharp = true; }\\";
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 11 (var) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.other.var.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 22 (someString) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 24 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 25 to 26 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 26 to 63 ({ var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 63 to 64 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 64 to 65 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 11 (var) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.other.var.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 22 (someString) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 24 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 25 to 26 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 26 to 63 ({ var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 63 to 64 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 64 to 65 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:         currentCount++;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.increment.cs
- - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 20 (currentCount) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.increment.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
@@ -1244,11 +1244,11 @@ exports[`Grammar tests @functions directive Multi-line comment with curly braces
  - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
  - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
  - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 13 to 15 (/*) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
- - token from 15 to 54 ( { var ThisShouldNotBeCSharp = true; } ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs
- - token from 54 to 56 (*/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.block.cs, punctuation.definition.comment.cs
- - token from 56 to 57 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 13 to 15 (/*) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.block.cs, punctuation.definition.comment.cs
+ - token from 15 to 54 ( { var ThisShouldNotBeCSharp = true; } ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.block.cs
+ - token from 54 to 56 (*/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.block.cs, punctuation.definition.comment.cs
+ - token from 56 to 57 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
  - token from 57 to 58 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -1266,24 +1266,24 @@ exports[`Grammar tests @functions directive Single line 1`] = `
  - token from 1 to 10 (functions) with scopes text.aspnetcorerazor, keyword.control.razor.directive.functions
  - token from 10 to 11 ( ) with scopes text.aspnetcorerazor
  - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 13 to 19 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 20 to 24 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 25 to 28 (Foo) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 28 to 29 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
- - token from 32 to 33 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
- - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 13 to 19 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 20 to 24 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 25 to 28 (Foo) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 28 to 29 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
+ - token from 32 to 33 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.close.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
  - token from 34 to 35 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
 
 exports[`Grammar tests @functions directive Single-line comment with curly braces 1`] = `
-"Line:
+"Line: 
  - token from 0 to 1 () with scopes text.aspnetcorerazor
 
 Line: @functions {
@@ -1293,9 +1293,9 @@ Line: @functions {
  - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     // { var ThisShouldNotBeCSharp = true; }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.whitespace.comment.leading.cs
- - token from 4 to 6 (//) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs, punctuation.definition.comment.cs
- - token from 6 to 44 ( { var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, comment.line.double-slash.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.whitespace.comment.leading.cs
+ - token from 4 to 6 (//) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.line.double-slash.cs, punctuation.definition.comment.cs
+ - token from 6 to 44 ( { var ThisShouldNotBeCSharp = true; }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, comment.line.double-slash.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
@@ -1310,137 +1310,137 @@ exports[`Grammar tests @functions directive With Razor and markup 1`] = `
  - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     private void SomeMethod()
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 17 to 27 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 11 (private) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 16 (void) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 17 to 27 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:         <p>This method <strong>is really</strong> nice!
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 11 to 15 (This) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 16 to 22 (method) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 24 to 30 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 31 to 33 (is) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.other.is.cs
- - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 34 to 40 (really) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 42 to 48 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 48 to 49 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 50 to 54 (nice) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 54 to 55 (!) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.logical.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 11 to 15 (This) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 16 to 22 (method) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 24 to 30 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 31 to 33 (is) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.other.is.cs
+ - token from 33 to 34 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 34 to 40 (really) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 42 to 48 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 48 to 49 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 50 to 54 (nice) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 54 to 55 (!) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.logical.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:             @if(true) {
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 15 (@if) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 16 to 20 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, constant.language.boolean.true.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 15 (@if) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 16 to 20 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, constant.language.boolean.true.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:                 <input type=\\"checkbox\\" value=\\"true\\" name=\\"Something\\" />
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 17 to 22 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 27 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 27 to 28 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 28 to 29 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 29 to 37 (checkbox) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 37 to 38 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 39 to 44 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 44 to 45 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 46 to 50 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 52 to 56 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 56 to 57 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 57 to 58 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 58 to 67 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 67 to 68 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 68 to 69 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 69 to 70 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.arithmetic.cs
- - token from 70 to 71 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 17 to 22 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 27 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 27 to 28 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 28 to 29 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 29 to 37 (checkbox) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 37 to 38 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 39 to 44 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 44 to 45 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 46 to 50 (true) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 52 to 56 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 56 to 57 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 57 to 58 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 58 to 67 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 67 to 68 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 68 to 69 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 69 to 70 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 70 to 71 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 12 to 14 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 12 to 14 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:         </p>
- - token from 0 to 10 (        </) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 11 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 10 (        </) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 11 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:         @DateTime.Now
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 17 (@DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 17 (@DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line:         <input type=\\"hidden\\" value=\\" { true }\\" name=\\"Something\\">
- - token from 0 to 9 (        <) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 9 to 14 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 15 to 19 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 20 to 21 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 21 to 27 (hidden) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 29 to 34 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 35 to 36 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 36 to 45 ( { true }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 47 to 51 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 51 to 52 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 52 to 53 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 53 to 62 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs
- - token from 62 to 63 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 63 to 64 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
+ - token from 0 to 9 (        <) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 9 to 14 (input) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 15 to 19 (type) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 20 to 21 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 21 to 27 (hidden) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 29 to 34 (value) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 34 to 35 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 35 to 36 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 36 to 45 ( { true }) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 45 to 46 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 47 to 51 (name) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 51 to 52 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 52 to 53 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 53 to 62 (Something) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs
+ - token from 62 to 63 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 63 to 64 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 6 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 6 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 
 Line: }
- - token from 0 to 2 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
+ - token from 0 to 2 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
 "
 `;
 
 exports[`Grammar tests @if ( ... ) { ... } Incomplete if statement, no condition 1`] = `
 "Line: @if {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 3 to 7 ( {}) with scopes text.aspnetcorerazor
 "
 `;
@@ -1448,7 +1448,7 @@ exports[`Grammar tests @if ( ... ) { ... } Incomplete if statement, no condition
 exports[`Grammar tests @if ( ... ) { ... } Incomplete if statement, no condition or body 1`] = `
 "Line: @if
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
@@ -1648,7 +1648,7 @@ exports[`Grammar tests @implements directive No type 1`] = `
 `;
 
 exports[`Grammar tests @implements directive No type spaced 1`] = `
-"Line: @implements
+"Line: @implements              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 11 (implements) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.implements
  - token from 11 to 26 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -1665,7 +1665,7 @@ exports[`Grammar tests @implements directive Type provided 1`] = `
 `;
 
 exports[`Grammar tests @implements directive Type provided spaced 1`] = `
-"Line: @implements              Person
+"Line: @implements              Person         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 11 (implements) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.implements
  - token from 11 to 25 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -1693,7 +1693,7 @@ exports[`Grammar tests @inherits directive No type 1`] = `
 `;
 
 exports[`Grammar tests @inherits directive No type spaced 1`] = `
-"Line: @inherits
+"Line: @inherits              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 9 (inherits) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.inherits
  - token from 9 to 24 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -1710,7 +1710,7 @@ exports[`Grammar tests @inherits directive Type provided 1`] = `
 `;
 
 exports[`Grammar tests @inherits directive Type provided spaced 1`] = `
-"Line: @inherits              Person
+"Line: @inherits              Person         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 9 (inherits) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.inherits
  - token from 9 to 23 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -1731,7 +1731,7 @@ exports[`Grammar tests @inject directive Fulfilled inject 1`] = `
 `;
 
 exports[`Grammar tests @inject directive Fulfilled inject spaced 1`] = `
-"Line: @inject      DateTime        TheTime
+"Line: @inject      DateTime        TheTime         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.inject
  - token from 7 to 13 (      ) with scopes text.aspnetcorerazor, meta.directive
@@ -1789,7 +1789,7 @@ exports[`Grammar tests @inject directive No parameters 1`] = `
 `;
 
 exports[`Grammar tests @inject directive No parameters spaced 1`] = `
-"Line: @inject
+"Line: @inject              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 7 (inject) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.inject
  - token from 7 to 22 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -1815,7 +1815,7 @@ exports[`Grammar tests @layout directive No type 1`] = `
 `;
 
 exports[`Grammar tests @layout directive No type spaced 1`] = `
-"Line: @layout
+"Line: @layout              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 7 (layout) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.layout
  - token from 7 to 22 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -1832,7 +1832,7 @@ exports[`Grammar tests @layout directive Type provided 1`] = `
 `;
 
 exports[`Grammar tests @layout directive Type provided spaced 1`] = `
-"Line: @layout              MainLayout
+"Line: @layout              MainLayout         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 7 (layout) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.layout
  - token from 7 to 21 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -1844,7 +1844,7 @@ exports[`Grammar tests @layout directive Type provided spaced 1`] = `
 exports[`Grammar tests @lock ( ... ) { ... } Incomplete lock statement, no reference 1`] = `
 "Line: @lock {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 5 (lock) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 5 (lock) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 5 to 9 ( {}) with scopes text.aspnetcorerazor
 "
 `;
@@ -1852,7 +1852,7 @@ exports[`Grammar tests @lock ( ... ) { ... } Incomplete lock statement, no refer
 exports[`Grammar tests @lock ( ... ) { ... } Incomplete lock statement, no reference or body 1`] = `
 "Line: @lock
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 5 (lock) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 5 (lock) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
@@ -2052,7 +2052,7 @@ exports[`Grammar tests @model directive Model provided 1`] = `
 `;
 
 exports[`Grammar tests @model directive Model provided spaced 1`] = `
-"Line: @model              Person
+"Line: @model              Person         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.model
  - token from 6 to 20 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -2069,7 +2069,7 @@ exports[`Grammar tests @model directive No model 1`] = `
 `;
 
 exports[`Grammar tests @model directive No model spaced 1`] = `
-"Line: @model
+"Line: @model              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (model) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.model
  - token from 6 to 21 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -2077,7 +2077,7 @@ exports[`Grammar tests @model directive No model spaced 1`] = `
 `;
 
 exports[`Grammar tests @namespace directive Broken up namespace 1`] = `
-"Line: @namespace     MyApp  .  Models  .   Data
+"Line: @namespace     MyApp  .  Models  .   Data    
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.namespace
  - token from 10 to 15 (     ) with scopes text.aspnetcorerazor, meta.directive
@@ -2106,7 +2106,7 @@ exports[`Grammar tests @namespace directive Namespace provided 1`] = `
 `;
 
 exports[`Grammar tests @namespace directive Namespace provided spaced 1`] = `
-"Line: @namespace     MyApp.Models.Data
+"Line: @namespace     MyApp.Models.Data    
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.namespace
  - token from 10 to 15 (     ) with scopes text.aspnetcorerazor, meta.directive
@@ -2127,7 +2127,7 @@ exports[`Grammar tests @namespace directive No namespace 1`] = `
 `;
 
 exports[`Grammar tests @namespace directive No namespace spaced 1`] = `
-"Line: @namespace
+"Line: @namespace              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 10 (namespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.namespace
  - token from 10 to 25 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -2151,7 +2151,7 @@ exports[`Grammar tests @page directive No route 1`] = `
 `;
 
 exports[`Grammar tests @page directive No route spaced 1`] = `
-"Line: @page
+"Line: @page              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 5 (page) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.page
  - token from 5 to 20 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -2170,7 +2170,7 @@ exports[`Grammar tests @page directive Routed 1`] = `
 `;
 
 exports[`Grammar tests @page directive Routed spaced 1`] = `
-"Line: @page              \\"/counter\\"
+"Line: @page              \\"/counter\\"         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 5 (page) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.page
  - token from 5 to 19 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -2198,7 +2198,7 @@ exports[`Grammar tests @removeTagHelper directive No parameter 1`] = `
 `;
 
 exports[`Grammar tests @removeTagHelper directive No parameter, spaced 1`] = `
-"Line: @removeTagHelper
+"Line: @removeTagHelper                 
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 16 (removeTagHelper) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.removeTagHelper
  - token from 16 to 34 (                 ) with scopes text.aspnetcorerazor, meta.directive
@@ -2217,7 +2217,7 @@ exports[`Grammar tests @removeTagHelper directive Quoted parameter 1`] = `
 `;
 
 exports[`Grammar tests @removeTagHelper directive Quoted parameter spaced 1`] = `
-"Line: @removeTagHelper       \\"*     ,      Microsoft.AspNetCore.Mvc.TagHelpers   \\"
+"Line: @removeTagHelper       \\"*     ,      Microsoft.AspNetCore.Mvc.TagHelpers   \\"            
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 16 (removeTagHelper) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.removeTagHelper
  - token from 16 to 23 (       ) with scopes text.aspnetcorerazor, meta.directive
@@ -2240,11 +2240,11 @@ exports[`Grammar tests @removeTagHelper directive Unquoted parameter 1`] = `
 exports[`Grammar tests @section directive As C# local 1`] = `
 "Line: @section.method()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 8 to 9 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 9 to 15 (method) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 16 to 17 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 8 to 9 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 9 to 15 (method) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 16 to 17 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 "
 `;
 
@@ -2275,9 +2275,9 @@ Line:     <section>
 Line:         @DateTime.Now
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock
  - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (DateTime) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml
- - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 9 to 17 (DateTime) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 17 to 18 (.) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, source.cs
+ - token from 18 to 21 (Now) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
 
 Line:         @section INVALID {}
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock
@@ -2321,7 +2321,7 @@ exports[`Grammar tests @section directive No name 1`] = `
 `;
 
 exports[`Grammar tests @section directive No name, spaced 1`] = `
-"Line: @section
+"Line: @section                 
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive.block, keyword.control.cshtml.transition
  - token from 1 to 8 (section) with scopes text.aspnetcorerazor, meta.directive.block, keyword.control.razor.directive.section
  - token from 8 to 26 (                 ) with scopes text.aspnetcorerazor, meta.directive.block
@@ -2337,9 +2337,9 @@ exports[`Grammar tests @section directive Single line 1`] = `
  - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.directive.block
  - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.open
  - token from 15 to 16 (@) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 16 to 24 (DateTime) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 24 to 25 (.) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml
- - token from 25 to 28 (Now) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 16 to 24 (DateTime) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 24 to 25 (.) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, source.cs
+ - token from 25 to 28 (Now) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 28 to 29 (}) with scopes text.aspnetcorerazor, meta.directive.block, meta.structure.razor.directive.markblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -2380,7 +2380,7 @@ exports[`Grammar tests @switch ( ... ) { ... } Incomplete switch statement, no c
 exports[`Grammar tests @switch ( ... ) { ... } Incomplete switch statement, no condition 1`] = `
 "Line: @switch {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 7 (switch) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 7 (switch) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 7 to 11 ( {}) with scopes text.aspnetcorerazor
 "
 `;
@@ -2388,7 +2388,7 @@ exports[`Grammar tests @switch ( ... ) { ... } Incomplete switch statement, no c
 exports[`Grammar tests @switch ( ... ) { ... } Incomplete switch statement, no condition or body 1`] = `
 "Line: @switch
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 7 (switch) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 7 (switch) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
@@ -2600,7 +2600,7 @@ exports[`Grammar tests @tagHelperPrefix directive No parameter 1`] = `
 `;
 
 exports[`Grammar tests @tagHelperPrefix directive No parameter, spaced 1`] = `
-"Line: @tagHelperPrefix
+"Line: @tagHelperPrefix                 
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 16 (tagHelperPrefix) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.tagHelperPrefix
  - token from 16 to 34 (                 ) with scopes text.aspnetcorerazor, meta.directive
@@ -2619,7 +2619,7 @@ exports[`Grammar tests @tagHelperPrefix directive Quoted parameter 1`] = `
 `;
 
 exports[`Grammar tests @tagHelperPrefix directive Quoted parameter spaced 1`] = `
-"Line: @tagHelperPrefix       \\"th:   \\"
+"Line: @tagHelperPrefix       \\"th:   \\"            
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 16 (tagHelperPrefix) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.tagHelperPrefix
  - token from 16 to 23 (       ) with scopes text.aspnetcorerazor, meta.directive
@@ -2712,9 +2712,9 @@ Line:     <div>Invoked: @SomeMethod()</div>
  - token from 8 to 9 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
  - token from 9 to 18 (Invoked: ) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
  - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 19 to 29 (SomeMethod) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 29 to 30 (() with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 19 to 29 (SomeMethod) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 29 to 30 (() with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 31 to 33 (</) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
  - token from 33 to 36 (div) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
  - token from 36 to 37 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
@@ -2795,7 +2795,7 @@ Line:         } catch(Exception ex) {
  - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor
  - token from 30 to 31 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
-Line:
+Line: 
  - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
 
 Line:         } finally { <strong>In the finally</strong> }
@@ -2865,9 +2865,9 @@ exports[`Grammar tests @try { ... } catch/finally { ... } Single line 1`] = `
  - token from 60 to 61 ( ) with scopes text.aspnetcorerazor, meta.statement.catch.razor
  - token from 61 to 62 ({) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
  - token from 62 to 63 (@) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 63 to 71 (DateTime) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 71 to 72 (.) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml
- - token from 72 to 75 (Now) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 63 to 71 (DateTime) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 71 to 72 (.) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs
+ - token from 72 to 75 (Now) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 75 to 76 (}) with scopes text.aspnetcorerazor, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
  - token from 76 to 83 (finally) with scopes text.aspnetcorerazor, meta.statement.finally.razor, keyword.control.try.finally.cs
  - token from 83 to 84 ({) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
@@ -3066,11 +3066,11 @@ exports[`Grammar tests @using ( ... ) { ... } Single line 1`] = `
 exports[`Grammar tests @using directive As C# local 1`] = `
 "Line: @using.method()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 6 to 7 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 7 to 13 (method) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 13 to 14 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 14 to 15 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 6 to 7 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 7 to 13 (method) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 13 to 14 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 14 to 15 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 "
 `;
 
@@ -3086,7 +3086,7 @@ exports[`Grammar tests @using directive Standard using 1`] = `
 `;
 
 exports[`Grammar tests @using directive Standard using spaced 1`] = `
-"Line: @using              System.IO
+"Line: @using              System.IO         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive, keyword.other.using.cs
  - token from 6 to 20 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -3105,7 +3105,7 @@ exports[`Grammar tests @using directive Standard using, no namespace 1`] = `
 `;
 
 exports[`Grammar tests @using directive Standard using, no namespace spaced 1`] = `
-"Line: @using
+"Line: @using              
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive, keyword.other.using.cs
  - token from 6 to 21 (              ) with scopes text.aspnetcorerazor, meta.directive
@@ -3138,7 +3138,7 @@ exports[`Grammar tests @using directive Static using 1`] = `
 `;
 
 exports[`Grammar tests @using directive Static using spaced 1`] = `
-"Line: @using    static          System.Math
+"Line: @using    static          System.Math         
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive, keyword.other.using.cs
  - token from 6 to 10 (    ) with scopes text.aspnetcorerazor, meta.directive
@@ -3161,7 +3161,7 @@ exports[`Grammar tests @using directive Static using, no namespace 1`] = `
 `;
 
 exports[`Grammar tests @using directive Static using, no namespace spaced 1`] = `
-"Line: @using        static
+"Line: @using        static      
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive, keyword.other.using.cs
  - token from 6 to 14 (        ) with scopes text.aspnetcorerazor, meta.directive
@@ -3201,7 +3201,7 @@ exports[`Grammar tests @using directive Using alias 1`] = `
 `;
 
 exports[`Grammar tests @using directive Using alias spaced 1`] = `
-"Line: @using     TheConsole     =    System.Console
+"Line: @using     TheConsole     =    System.Console   
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive, keyword.other.using.cs
  - token from 6 to 11 (     ) with scopes text.aspnetcorerazor, meta.directive
@@ -3249,7 +3249,7 @@ exports[`Grammar tests @using directive Using alias, no type 1`] = `
 `;
 
 exports[`Grammar tests @using directive Using alias, no type spaced 1`] = `
-"Line: @using        Something   =
+"Line: @using        Something   =    
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 6 (using) with scopes text.aspnetcorerazor, meta.directive, keyword.other.using.cs
  - token from 6 to 14 (        ) with scopes text.aspnetcorerazor, meta.directive
@@ -3280,7 +3280,7 @@ exports[`Grammar tests @using directive Using alias, optional semicolon 1`] = `
 exports[`Grammar tests @while ( ... ) { ... } Incomplete while statement, no condition 1`] = `
 "Line: @while {}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 6 (while) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 6 (while) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 6 to 10 ( {}) with scopes text.aspnetcorerazor
 "
 `;
@@ -3288,7 +3288,7 @@ exports[`Grammar tests @while ( ... ) { ... } Incomplete while statement, no con
 exports[`Grammar tests @while ( ... ) { ... } Incomplete while statement, no condition or body 1`] = `
 "Line: @while
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 6 (while) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 6 (while) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
@@ -3938,18 +3938,18 @@ exports[`Grammar tests Explicit expressions Single line simple 1`] = `
 exports[`Grammar tests Implicit Expressions Awaited method invocation 1`] = `
 "Line: @await AsyncMethod()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.other.await.cs
- - token from 7 to 18 (AsyncMethod) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 7 to 18 (AsyncMethod) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 "
 `;
 
 exports[`Grammar tests Implicit Expressions Awaited property 1`] = `
 "Line: @await AsyncProperty
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.other.await.cs
- - token from 7 to 20 (AsyncProperty) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
+ - token from 1 to 7 (await ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 7 to 20 (AsyncProperty) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
 "
 `;
 
@@ -3957,18 +3957,18 @@ exports[`Grammar tests Implicit Expressions Close curly prefix 1`] = `
 "Line: }@DateTime.Now
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor
  - token from 1 to 2 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 2 to 10 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 2 to 10 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
 "
 `;
 
 exports[`Grammar tests Implicit Expressions Close curly suffix 1`] = `
 "Line: @DateTime.Now}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 13 to 15 (}) with scopes text.aspnetcorerazor
 "
 `;
@@ -3976,9 +3976,9 @@ exports[`Grammar tests Implicit Expressions Close curly suffix 1`] = `
 exports[`Grammar tests Implicit Expressions Close parenthesis suffix 1`] = `
 "Line: @DateTime.Now)
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 13 to 15 ()) with scopes text.aspnetcorerazor
 "
 `;
@@ -3986,9 +3986,9 @@ exports[`Grammar tests Implicit Expressions Close parenthesis suffix 1`] = `
 exports[`Grammar tests Implicit Expressions Close parenthesis suffix 2`] = `
 "Line: @DateTime.Now]
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 13 to 15 (]) with scopes text.aspnetcorerazor
 "
 `;
@@ -3999,9 +3999,9 @@ exports[`Grammar tests Implicit Expressions Combined with HTML 1`] = `
  - token from 1 to 2 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, entity.name.tag.html
  - token from 2 to 3 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
  - token from 3 to 4 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 4 to 12 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 12 to 13 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 13 to 16 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 4 to 12 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 12 to 13 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 13 to 16 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 16 to 18 (</) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.begin.html
  - token from 18 to 19 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, entity.name.tag.html
  - token from 19 to 20 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.end.html
@@ -4221,7 +4221,7 @@ Line:     var x = 123;
 Line:     var y = true;
  - token from 0 to 18 (    var y = true;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
 
-Line:
+Line: 
  - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
 
 Line:     return y ? x : 457;
@@ -4557,7 +4557,7 @@ Line:     var x = 123;
 Line:     var y = true;
  - token from 0 to 18 (    var y = true;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
 
-Line:
+Line: 
  - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
 
 Line:     return y ? x : 457;
@@ -4695,111 +4695,111 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Single l
 exports[`Grammar tests Implicit Expressions Multi line 1`] = `
 "Line: @DateTime!.Now()[1234 +
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 9 to 11 (!.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 14 to 15 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 15 to 16 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 16 to 17 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
- - token from 17 to 21 (1234) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets
- - token from 22 to 23 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 9 to 11 (!.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 14 to 15 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 15 to 16 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 16 to 17 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 17 to 21 (1234) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 22 to 23 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
 
 Line: 5678](
- - token from 0 to 4 (5678) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
- - token from 4 to 5 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
- - token from 5 to 6 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 0 to 4 (5678) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 4 to 5 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 5 to 6 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
 
 Line: abc()!.Current,
- - token from 0 to 3 (abc) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
- - token from 3 to 4 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 5 to 6 (!) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.logical.cs
- - token from 6 to 7 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
- - token from 7 to 14 (Current) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.property.cs
- - token from 14 to 16 (,) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+ - token from 0 to 3 (abc) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 3 to 4 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 5 to 6 (!) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 6 to 7 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 7 to 14 (Current) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 14 to 16 (,) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
 
 Line: 1 + 2 + getValue())?.ToString[123](
- - token from 0 to 1 (1) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
- - token from 1 to 2 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 2 to 3 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
- - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 4 to 5 (2) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 6 to 7 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 8 to 16 (getValue) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
- - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 17 to 18 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 19 to 21 (?.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 21 to 29 (ToString) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
- - token from 29 to 30 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
- - token from 30 to 33 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
- - token from 33 to 34 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
- - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 0 to 1 (1) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 1 to 2 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 2 to 3 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 5 (2) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 6 to 7 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 16 (getValue) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 17 to 18 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 19 to 21 (?.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 21 to 29 (ToString) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 29 to 30 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 30 to 33 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 33 to 34 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
 
 Line: () =>
- - token from 0 to 1 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 3 to 5 (=>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
+ - token from 0 to 1 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 3 to 5 (=>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
 
 Line: {
- - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.curlybrace.open.cs
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.curlybrace.open.cs
 
 Line:     var x = 123;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
- - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line:     var y = true;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 8 to 9 (y) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.language.boolean.true.cs
- - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 9 (y) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.language.boolean.true.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
 
 Line:     return y ? x : 457;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 4 to 10 (return) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.control.flow.return.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 11 to 12 (y) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 13 to 14 (?) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.conditional.question-mark.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 15 to 16 (x) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.conditional.colon.cs
- - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 19 to 22 (457) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
- - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 10 (return) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.control.flow.return.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 11 to 12 (y) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 13 to 14 (?) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.conditional.question-mark.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 15 to 16 (x) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.conditional.colon.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 19 to 22 (457) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line: })
- - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.curlybrace.close.cs
- - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.curlybrace.close.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 "
 `;
 
 exports[`Grammar tests Implicit Expressions Open curly suffix 1`] = `
 "Line: @DateTime.Now{
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 13 to 15 ({) with scopes text.aspnetcorerazor
 "
 `;
@@ -4808,9 +4808,9 @@ exports[`Grammar tests Implicit Expressions Parenthesis prefix 1`] = `
 "Line: )@DateTime.Now
  - token from 0 to 1 ()) with scopes text.aspnetcorerazor
  - token from 1 to 2 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 2 to 10 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 2 to 10 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
 "
 `;
 
@@ -4818,69 +4818,69 @@ exports[`Grammar tests Implicit Expressions Punctuation prefix 1`] = `
 "Line: .@DateTime.Now
  - token from 0 to 1 (.) with scopes text.aspnetcorerazor
  - token from 1 to 2 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 2 to 10 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 2 to 10 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 10 to 11 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
 "
 `;
 
 exports[`Grammar tests Implicit Expressions Single line complex 1`] = `
 "Line: @DateTime!.Now()[1234 + 5678](abc()!.Current, 1 + 2 + getValue())?.ToString[123](() => 456)
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 9 to 11 (!.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 14 to 15 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 15 to 16 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 16 to 17 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
- - token from 17 to 21 (1234) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets
- - token from 22 to 23 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets
- - token from 24 to 28 (5678) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
- - token from 28 to 29 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
- - token from 29 to 30 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 30 to 33 (abc) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
- - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 34 to 35 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 35 to 36 (!) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.logical.cs
- - token from 36 to 37 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
- - token from 37 to 44 (Current) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.property.cs
- - token from 44 to 46 (, ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 46 to 47 (1) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
- - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 48 to 49 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
- - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 50 to 51 (2) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
- - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 52 to 53 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
- - token from 53 to 54 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 54 to 62 (getValue) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
- - token from 62 to 63 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 63 to 64 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 64 to 65 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 65 to 67 (?.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 67 to 75 (ToString) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
- - token from 75 to 76 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
- - token from 76 to 79 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, constant.numeric.decimal.cs
- - token from 79 to 80 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
- - token from 80 to 81 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 81 to 82 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 82 to 83 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 83 to 84 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 84 to 86 (=>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
- - token from 86 to 87 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 87 to 90 (456) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
- - token from 90 to 91 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 9 to 11 (!.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 11 to 14 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 14 to 15 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 15 to 16 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 16 to 17 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 17 to 21 (1234) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 22 to 23 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 24 to 28 (5678) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 28 to 29 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 29 to 30 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 30 to 33 (abc) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 34 to 35 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 35 to 36 (!) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 36 to 37 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 37 to 44 (Current) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 44 to 46 (, ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 46 to 47 (1) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 48 to 49 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 50 to 51 (2) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 52 to 53 (+) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 53 to 54 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 54 to 62 (getValue) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 62 to 63 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 63 to 64 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 64 to 65 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 65 to 67 (?.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 67 to 75 (ToString) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 75 to 76 ([) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 76 to 79 (123) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 79 to 80 (]) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 80 to 81 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 81 to 82 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 82 to 83 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 83 to 84 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 84 to 86 (=>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
+ - token from 86 to 87 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 87 to 90 (456) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 90 to 91 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 "
 `;
 
 exports[`Grammar tests Implicit Expressions Single line simple 1`] = `
 "Line: @DateTime.Now
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml
- - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 1 to 9 (DateTime) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 9 to 10 (.) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs
+ - token from 10 to 13 (Now) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
 "
 `;
 
@@ -4888,31 +4888,31 @@ exports[`Grammar tests Razor code blocks @{ ... } Complex HTML tag structures 1`
 "Line: @{<p><input      /><strong>Hello <hr/> <br> World</strong></p>}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 3 to 4 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 5 to 6 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 6 to 11 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 11 to 17 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 17 to 19 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 19 to 20 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 20 to 26 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 27 to 33 (Hello ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 33 to 34 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
- - token from 34 to 36 (hr) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, entity.name.tag.html
- - token from 36 to 38 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
- - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
- - token from 40 to 42 (br) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, entity.name.tag.html
- - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
- - token from 43 to 49 ( World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 49 to 51 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 57 to 58 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 58 to 60 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 60 to 61 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 61 to 62 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 2 to 3 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 3 to 4 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 5 to 6 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 6 to 11 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 11 to 17 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 17 to 19 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 19 to 20 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 20 to 26 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 27 to 33 (Hello ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 33 to 34 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
+ - token from 34 to 36 (hr) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.hr.void.html, entity.name.tag.html
+ - token from 36 to 38 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+ - token from 38 to 39 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
+ - token from 40 to 42 (br) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.br.void.html, entity.name.tag.html
+ - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
+ - token from 43 to 49 ( World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 49 to 51 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 57 to 58 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 58 to 60 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 60 to 61 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 61 to 62 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
  - token from 62 to 63 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -4923,101 +4923,101 @@ exports[`Grammar tests Razor code blocks @{ ... } Complex with various nested st
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     if (true) {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:         @using (someDisposable) {
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
- - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:             <p>Foo!</p>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:             var x = 123;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:             while (i++ % 2 == 0)
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:             {
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:                 <strong>Bar</strong>
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 17 to 23 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 24 to 27 (Bar) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 27 to 29 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 29 to 35 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 17 to 23 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 24 to 27 (Bar) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 27 to 29 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 29 to 35 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         }
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         </div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5052,300 +5052,300 @@ exports[`Grammar tests Razor code blocks @{ ... } Multi line complex 1`] = `
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var x = true;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.language.boolean.true.cs
- - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, constant.language.boolean.true.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     <text>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 10 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 10 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.open
 
 Line:         @{
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
- - token from 9 to 10 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 9 to 10 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:             @DateTime.Now
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 13 to 21 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 21 to 22 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
- - token from 22 to 25 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 13 to 21 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 21 to 22 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs
+ - token from 22 to 25 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
 
 Line:             @{
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
- - token from 13 to 14 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 13 to 14 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:                 @{
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 16 to 17 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
- - token from 17 to 18 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 16 to 17 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 17 to 18 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
 
 Line:                 }
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 16 to 17 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 16 to 17 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 
 Line:         }
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 
 Line:     </text>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 11 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 11 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.close
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:     <p></p>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 5 to 6 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 6 to 7 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 7 to 9 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 5 to 6 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 6 to 7 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 7 to 9 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line: <p class=\\"hello <world></p>\\" @DateTime.Now> Foo<strong @{ <text> can't believe this works </text>}>Bar</strong> Baz
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 1 to 2 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 3 to 8 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 8 to 9 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 9 to 10 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 10 to 27 (hello <world></p>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html
- - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 29 to 30 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 30 to 38 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 38 to 39 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
- - token from 39 to 42 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
- - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 43 to 47 ( Foo) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 47 to 48 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 48 to 54 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 54 to 55 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 55 to 56 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition
- - token from 56 to 57 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 58 to 64 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
- - token from 64 to 90 ( can't believe this works ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock
- - token from 90 to 97 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
- - token from 97 to 98 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
- - token from 98 to 99 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 99 to 102 (Bar) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 102 to 104 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 104 to 110 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 110 to 111 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 111 to 116 ( Baz) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 1 to 2 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 8 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 8 to 9 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 9 to 10 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 10 to 27 (hello <world></p>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, string.quoted.double.html
+ - token from 27 to 28 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 29 to 30 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 30 to 38 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 38 to 39 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs
+ - token from 39 to 42 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 43 to 47 ( Foo) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 47 to 48 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 48 to 54 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 54 to 55 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 55 to 56 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 56 to 57 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 58 to 64 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.open
+ - token from 64 to 90 ( can't believe this works ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs
+ - token from 90 to 97 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.close
+ - token from 97 to 98 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+ - token from 98 to 99 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 99 to 102 (Bar) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 102 to 104 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 104 to 110 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 110 to 111 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 111 to 116 ( Baz) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:         <p class=\\"hello world\\">
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html
- - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, string.quoted.double.html
+ - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line:             Below is an incomplete tag
- - token from 0 to 39 (            Below is an incomplete tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 0 to 39 (            Below is an incomplete tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:             </strong>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 12 to 14 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 14 to 20 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 14 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 14 to 20 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line:         </p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 10 to 11 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:         <text>This is not a special transition tag</text>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 13 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 14 to 50 (This is not a special transition tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 52 to 56 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 56 to 57 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 9 to 13 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 14 to 50 (This is not a special transition tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 52 to 56 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 56 to 57 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line:         Hello World
- - token from 0 to 20 (        Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 0 to 20 (        Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:     </p>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line:     @: <strong> <-- This is incomplete @DateTime.Now
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.singleLineMarkup
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.inline.strong.start.html, punctuation.definition.tag.begin.html
- - token from 8 to 14 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.inline.strong.start.html, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.inline.strong.start.html, punctuation.definition.tag.end.html
- - token from 15 to 39 ( <-- This is incomplete ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 40 to 48 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 48 to 49 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
- - token from 49 to 52 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.razor.singleLineMarkup
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.inline.strong.start.html, punctuation.definition.tag.begin.html
+ - token from 8 to 14 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.inline.strong.start.html, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.inline.strong.start.html, punctuation.definition.tag.end.html
+ - token from 15 to 39 ( <-- This is incomplete ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 39 to 40 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 40 to 48 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 48 to 49 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs
+ - token from 49 to 52 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:     <input class=\\"hello world\\">
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
- - token from 5 to 10 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, entity.name.tag.html
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html
- - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, entity.other.attribute-name.html
- - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, punctuation.separator.key-value.html
- - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html
- - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 5 to 10 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html
+ - token from 11 to 16 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, meta.attribute.class.html, entity.other.attribute-name.html
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, meta.attribute.class.html, punctuation.separator.key-value.html
+ - token from 17 to 18 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 18 to 29 (hello world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html
+ - token from 29 to 30 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:     void SomeMethod(int value)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 8 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
- - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 9 to 19 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
- - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
- - token from 20 to 23 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 24 to 29 (value) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.parameter.cs
- - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 8 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.type.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 9 to 19 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.function.cs
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 20 to 23 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.type.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 24 to 29 (value) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.parameter.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<strong>Value: @item</strong>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 33 to 39 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 40 to 45 (Value) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 45 to 47 (: ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 47 to 52 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 52 to 53 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 53 to 54 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.arithmetic.cs
- - token from 54 to 60 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 33 to 39 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 40 to 45 (Value) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 45 to 47 (: ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 47 to 52 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 52 to 53 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 53 to 54 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 54 to 60 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:         <section>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 9 to 16 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 9 to 16 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
 
 Line:             This section is rendered when called: @template(1337)
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 12 to 16 (This) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 17 to 24 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 25 to 27 (is) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.is.cs
- - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 28 to 36 (rendered) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
- - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 37 to 41 (when) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 41 to 42 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 42 to 48 (called) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.label.cs
- - token from 48 to 49 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.separator.colon.cs
- - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 50 to 59 (@template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
- - token from 59 to 60 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
- - token from 60 to 64 (1337) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
- - token from 64 to 65 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 16 (This) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 17 to 24 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 25 to 27 (is) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.other.is.cs
+ - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 28 to 36 (rendered) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, storage.type.cs
+ - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 37 to 41 (when) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 41 to 42 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 42 to 48 (called) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.label.cs
+ - token from 48 to 49 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.separator.colon.cs
+ - token from 49 to 50 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 50 to 59 (@template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.function.cs
+ - token from 59 to 60 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 60 to 64 (1337) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, constant.numeric.decimal.cs
+ - token from 64 to 65 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:         </section>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 9 to 10 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.arithmetic.cs
- - token from 10 to 17 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 17 to 18 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 9 to 10 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 10 to 17 (section) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 17 to 18 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.curlybrace.close.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:     <p>aHello</p>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 5 to 6 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 6 to 7 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 7 to 13 (aHello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 5 to 6 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 6 to 7 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 7 to 13 (aHello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:     if (true) {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>alksdjfl</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 19 (alksdjfl) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 19 (alksdjfl) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5358,50 +5358,50 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested do while statement with
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     do
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
- - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, keyword.control.loop.do.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@i</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     } while (i++ != 10);
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.terminator.statement.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5414,52 +5414,52 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested for statement with mark
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     for (var i = 0; i % 2 == 0; i++)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.control.loop.for.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.open.cs
- - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.other.var.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, entity.name.variable.local.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.assignment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.arithmetic.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.comparison.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.increment.cs
- - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.other.var.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.comparison.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.increment.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@i</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5472,37 +5472,37 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested foreach statement with 
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     foreach (var person in people)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
- - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.other.var.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, entity.name.variable.local.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.in.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, variable.other.readwrite.cs
- - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, keyword.other.var.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, entity.name.variable.local.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, keyword.control.loop.in.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@person</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 18 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 18 to 20 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 20 to 21 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 18 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 18 to 20 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 20 to 21 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5515,30 +5515,30 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested if statement with marku
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     if (true)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World!</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 23 (Hello World!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 23 to 25 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 23 (Hello World!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 23 to 25 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5551,43 +5551,43 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested local function with mar
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     void SomeMethod() { <p class=\\"priority\\"><strong>Hello World</strong></p> }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 8 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
- - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 9 to 19 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
- - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.open.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 24 to 25 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 27 to 32 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 33 to 34 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 34 to 42 (priority) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs
- - token from 42 to 43 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 45 to 51 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 52 to 57 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 58 to 63 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 63 to 64 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 64 to 65 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.arithmetic.cs
- - token from 65 to 71 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 71 to 72 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 72 to 73 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 73 to 74 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.arithmetic.cs
- - token from 74 to 75 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 75 to 76 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 76 to 77 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 77 to 79 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 8 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.type.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 9 to 19 (SomeMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.function.cs
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.curlybrace.open.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 24 to 25 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 25 to 26 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, storage.type.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 27 to 32 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 33 to 34 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 34 to 42 (priority) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs
+ - token from 42 to 43 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 44 to 45 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 45 to 51 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 52 to 57 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 58 to 63 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 63 to 64 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 64 to 65 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 65 to 71 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 71 to 72 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 72 to 73 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 73 to 74 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 74 to 75 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 75 to 76 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 76 to 77 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 77 to 79 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line: }
- - token from 0 to 2 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 0 to 2 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 "
 `;
 
@@ -5597,30 +5597,30 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested lock statement with mar
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     lock (someObject)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
- - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, keyword.other.lock.cs
- - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
- - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.open.cs
- - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, variable.other.readwrite.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5633,42 +5633,42 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested switch statement with m
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     switch (something)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
- - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, keyword.control.switch.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
- - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.open.cs
- - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, variable.other.readwrite.cs
- - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
 
 Line:         case true:
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
- - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
 
 Line:             <p>Hello World</p>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
- - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
- - token from 15 to 26 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 26 to 28 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
- - token from 28 to 29 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
- - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+ - token from 15 to 26 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 26 to 28 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 28 to 29 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
 
 Line:             break;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
- - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5679,21 +5679,21 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested text tag 1`] = `
 "Line: @{ <p><text>Hello</text></p> }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 4 to 5 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 7 to 11 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 12 to 17 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 17 to 19 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 19 to 23 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 24 to 26 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 26 to 27 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 4 to 5 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 7 to 11 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 12 to 17 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 17 to 19 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 19 to 23 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 24 to 26 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 26 to 27 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
  - token from 29 to 30 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -5702,17 +5702,17 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested text text tag 1`] = `
 "Line: @{ <text><text>Hello</text></text> }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
- - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 10 to 14 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 15 to 20 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 20 to 22 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 22 to 26 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 27 to 34 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
- - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.open
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 10 to 14 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 15 to 20 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 20 to 22 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 22 to 26 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 27 to 34 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.close
+ - token from 34 to 35 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
  - token from 35 to 36 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -5723,36 +5723,36 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested try statement with mark
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     try
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
- - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, keyword.control.try.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, keyword.control.try.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     } catch (Exception ex){}
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
- - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, keyword.control.try.catch.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.open.cs
- - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, storage.type.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
- - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, entity.name.variable.local.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.close.cs
- - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
- - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor
+ - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor
+ - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5765,30 +5765,30 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested using statement with ma
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     using (someDisposable)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
- - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, keyword.other.using.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>Hello World</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 22 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 22 to 24 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 24 to 25 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5801,47 +5801,47 @@ exports[`Grammar tests Razor code blocks @{ ... } Nested while statement with ma
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     while (i++ != 10)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <p>@i</p>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 12 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 12 to 13 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 13 to 15 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 15 to 16 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5852,24 +5852,24 @@ exports[`Grammar tests Razor code blocks @{ ... } Pure C# 1`] = `
 "Line: @{var x = true; Console.WriteLine(\\"Hello World\\");}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 5 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 6 to 7 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 10 to 14 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.language.boolean.true.cs
- - token from 14 to 15 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 16 to 23 (Console) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.object.cs
- - token from 23 to 24 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.accessor.cs
- - token from 24 to 33 (WriteLine) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
- - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
- - token from 34 to 35 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 35 to 46 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs
- - token from 46 to 47 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 47 to 48 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
- - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 2 to 5 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.other.var.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 6 to 7 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 10 to 14 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, constant.language.boolean.true.cs
+ - token from 14 to 15 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 16 to 23 (Console) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.object.cs
+ - token from 23 to 24 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.accessor.cs
+ - token from 24 to 33 (WriteLine) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.function.cs
+ - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 34 to 35 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 35 to 46 (Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs
+ - token from 46 to 47 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 47 to 48 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.close.cs
+ - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
  - token from 49 to 50 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -5878,16 +5878,16 @@ exports[`Grammar tests Razor code blocks @{ ... } Single line local function 1`]
 "Line: @{ void Foo() {} }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 3 to 7 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 11 (Foo) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.function.cs
- - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.open.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.open.cs
- - token from 15 to 16 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.close.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 7 (void) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.type.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 11 (Foo) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.function.cs
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.curlybrace.open.cs
+ - token from 15 to 16 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.curlybrace.close.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
  - token from 17 to 18 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -5898,20 +5898,20 @@ exports[`Grammar tests Razor code blocks @{ ... } Single line markup complex 1`]
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     @:@DateTime.Now <text>Nope</text>
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.singleLineMarkup
- - token from 6 to 7 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 7 to 15 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.cs
- - token from 15 to 16 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml
- - token from 16 to 19 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, variable.other.object.property.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.begin.html
- - token from 21 to 25 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
- - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.end.html
- - token from 26 to 30 (Nope) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 30 to 32 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.begin.html
- - token from 32 to 36 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
- - token from 36 to 37 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.other.text.html, punctuation.definition.tag.end.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.razor.singleLineMarkup
+ - token from 6 to 7 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 7 to 15 (DateTime) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 15 to 16 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs
+ - token from 16 to 19 (Now) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.other.text.html, punctuation.definition.tag.begin.html
+ - token from 21 to 25 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
+ - token from 25 to 26 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.other.text.html, punctuation.definition.tag.end.html
+ - token from 26 to 30 (Nope) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 30 to 32 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.other.text.html, punctuation.definition.tag.begin.html
+ - token from 32 to 36 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.other.text.html, entity.name.tag.html, invalid.illegal.unrecognized-tag.html
+ - token from 36 to 37 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.other.text.html, punctuation.definition.tag.end.html
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5924,13 +5924,13 @@ exports[`Grammar tests Razor code blocks @{ ... } Single line markup simple 1`] 
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     @: <p> Incomplete
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.singleLineMarkup
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
- - token from 8 to 9 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.p.start.html, entity.name.tag.html
- - token from 9 to 10 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
- - token from 10 to 22 ( Incomplete) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 6 (@:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.razor.singleLineMarkup
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 7 to 8 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
+ - token from 8 to 9 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.p.start.html, entity.name.tag.html
+ - token from 9 to 10 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
+ - token from 10 to 22 ( Incomplete) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -5941,11 +5941,11 @@ exports[`Grammar tests Razor code blocks @{ ... } Top level text tag 1`] = `
 "Line: @{ <text>Hello</text> }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.open
- - token from 9 to 14 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 14 to 21 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition.textTag.close
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 9 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.open
+ - token from 9 to 14 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 14 to 21 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.close
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
  - token from 22 to 23 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -5998,32 +5998,32 @@ exports[`Grammar tests Razor templates @<p>....</p> Complex HTML tag structure n
 "Line: @{@<p><input      /><strong>Hello <hr/> <br> World</strong></p>}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 4 to 5 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 7 to 12 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 12 to 18 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 18 to 20 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 21 to 27 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 28 to 34 (Hello ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 34 to 35 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
- - token from 35 to 37 (hr) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, entity.name.tag.html
- - token from 37 to 39 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
- - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
- - token from 41 to 43 (br) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, entity.name.tag.html
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
- - token from 44 to 50 ( World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 52 to 58 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 58 to 59 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
- - token from 59 to 61 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.begin.html
- - token from 61 to 62 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.tag.html
- - token from 62 to 63 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.tag.end.html
+ - token from 2 to 3 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 4 to 5 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 7 to 12 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 12 to 18 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 18 to 20 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 21 to 27 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 28 to 34 (Hello ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 34 to 35 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.hr.void.html, punctuation.definition.tag.begin.html
+ - token from 35 to 37 (hr) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.hr.void.html, entity.name.tag.html
+ - token from 37 to 39 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.hr.void.html, punctuation.definition.tag.end.html
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.br.void.html, punctuation.definition.tag.begin.html
+ - token from 41 to 43 (br) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.br.void.html, entity.name.tag.html
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.br.void.html, punctuation.definition.tag.end.html
+ - token from 44 to 50 ( World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 52 to 58 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 58 to 59 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 59 to 61 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 61 to 62 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 62 to 63 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
  - token from 63 to 64 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -6034,153 +6034,153 @@ exports[`Grammar tests Razor templates @<p>....</p> Complex with various nested 
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     if (true) {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
- - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor
- - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         <div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 12 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 12 to 13 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:         @using (someDisposable) {
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
- - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
- - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.control.cshtml.transition
+ - token from 9 to 14 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 16 to 30 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 30 to 31 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 32 to 33 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:             <p>Foo!</p>
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
- - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 15 to 19 (Foo!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 19 to 21 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 21 to 22 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:             var x = 123;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 15 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.other.var.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 17 (x) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 18 to 19 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 23 (123) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:             while (i++ % 2 == 0)
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
- - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 17 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 19 to 20 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 20 to 22 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 23 to 24 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
+ - token from 24 to 25 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 25 to 26 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 27 to 29 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 30 to 31 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:             {
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
- - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 12 to 13 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:                 Action<int> template = @<p>
- - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 16 to 22 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 22 to 23 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 23 to 26 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 28 to 36 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 37 to 38 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 38 to 40 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 16 to 22 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 22 to 23 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 23 to 26 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 28 to 36 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 36 to 37 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 37 to 38 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 38 to 40 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 41 to 42 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 42 to 43 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
 
 Line:                     @item
- - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 25 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 25 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
 
-Line:
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+Line: 
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
 
 Line:                     @{
- - token from 0 to 21 (                    @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 21 to 22 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 21 (                    @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 21 to 22 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:                         Action anotherTemplate = @<strong class='really loud!'>LOUD</strong>;
- - token from 0 to 24 (                        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 24 to 30 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 31 to 46 (anotherTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 47 to 48 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 48 to 50 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 50 to 51 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 64 to 65 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, string.quoted.single.cs, punctuation.definition.char.begin.cs
- - token from 65 to 77 (really loud!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, string.quoted.single.cs
- - token from 77 to 78 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, string.quoted.single.cs, punctuation.definition.char.end.cs
- - token from 78 to 79 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 79 to 83 (LOUD) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 83 to 84 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 84 to 85 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 85 to 91 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 92 to 94 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 0 to 24 (                        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 24 to 30 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 31 to 46 (anotherTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 47 to 48 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 48 to 50 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 50 to 51 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 51 to 57 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 64 to 65 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, string.quoted.single.cs, punctuation.definition.char.begin.cs
+ - token from 65 to 77 (really loud!) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, string.quoted.single.cs
+ - token from 77 to 78 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, string.quoted.single.cs, punctuation.definition.char.end.cs
+ - token from 78 to 79 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 79 to 83 (LOUD) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 83 to 84 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 84 to 85 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 85 to 91 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 92 to 94 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
 
 Line:                     }
- - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 21 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 21 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:                     </p>;
- - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 21 to 22 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 22 to 23 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 24 to 25 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 20 (                    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 21 to 22 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 22 to 23 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 23 to 24 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 24 to 25 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:             }
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 12 to 13 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         }
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line:         </div>
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
- - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
- - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 10 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 10 to 13 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6240,68 +6240,68 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested do while statement wi
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     do
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
- - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, keyword.control.loop.do.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     } while (i++ != 10);
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 14 to 16 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 17 to 19 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 20 to 22 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 22 to 23 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.terminator.statement.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6314,70 +6314,70 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested for statement with te
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     for (var i = 0; i % 2 == 0; i++)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.control.loop.for.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.open.cs
- - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.other.var.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, entity.name.variable.local.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.assignment.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.arithmetic.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.comparison.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
- - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, keyword.operator.increment.cs
- - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.other.var.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 22 to 23 (%) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.arithmetic.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 24 to 25 (2) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 26 to 28 (==) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.comparison.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 29 to 30 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 32 to 33 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 33 to 35 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, keyword.operator.increment.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6390,55 +6390,55 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested foreach statement wit
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     foreach (var person in people)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
- - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.other.var.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, entity.name.variable.local.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, keyword.control.loop.in.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, variable.other.readwrite.cs
- - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, keyword.other.var.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 17 to 23 (person) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, entity.name.variable.local.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 24 to 26 (in) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, keyword.control.loop.in.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 27 to 33 (people) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6451,59 +6451,59 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested lock statement with t
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     lock (someObject)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
- - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, keyword.other.lock.cs
- - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
- - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.open.cs
- - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, variable.other.readwrite.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 20 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<string> template = @<p class=\\"world\\">@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 21 (string) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 23 to 31 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 33 to 35 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 36 to 37 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 38 to 43 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 44 to 45 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 45 to 50 (world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs
- - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 52 to 57 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 57 to 58 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 58 to 59 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 59 to 60 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 21 (string) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 23 to 31 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 33 to 35 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 36 to 37 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 38 to 43 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 43 to 44 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 44 to 45 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 45 to 50 (world) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs
+ - token from 50 to 51 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 51 to 52 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 52 to 57 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 57 to 58 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 58 to 59 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 59 to 60 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 60 to 61 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 61 to 62 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(someObject.ToString())
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 28 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.object.cs
- - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.accessor.cs
- - token from 29 to 37 (ToString) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.function.cs
- - token from 37 to 38 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 38 to 39 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
- - token from 39 to 40 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 28 (someObject) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 29 to 37 (ToString) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 37 to 38 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 38 to 39 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 39 to 40 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6516,53 +6516,53 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested switch statement with
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     switch (something)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
- - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, keyword.control.switch.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
- - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.open.cs
- - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, variable.other.readwrite.cs
- - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 21 (something) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
 
 Line:         case true:
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
- - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 13 to 17 (true) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.language.boolean.true.cs
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
 
 Line:             Action<int> template = @<p>@item</p>;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 18 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, storage.type.cs
- - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.begin.cs
- - token from 19 to 22 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.type.cs
- - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.end.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 24 to 32 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.variable.local.cs
- - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 33 to 34 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.assignment.cs
- - token from 34 to 36 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 36 to 37 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
- - token from 37 to 38 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, variable.other.readwrite.cs
- - token from 38 to 39 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
- - token from 39 to 44 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, variable.other.readwrite.cs
- - token from 44 to 45 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
- - token from 45 to 46 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.arithmetic.cs
- - token from 46 to 47 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, variable.other.readwrite.cs
- - token from 47 to 48 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
- - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 18 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, storage.type.cs
+ - token from 18 to 19 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.begin.cs
+ - token from 19 to 22 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.type.cs
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.typeparameters.end.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 24 to 32 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.variable.local.cs
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 33 to 34 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.assignment.cs
+ - token from 34 to 36 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 36 to 37 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
+ - token from 37 to 38 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, variable.other.readwrite.cs
+ - token from 38 to 39 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
+ - token from 39 to 44 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, variable.other.readwrite.cs
+ - token from 44 to 45 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
+ - token from 45 to 46 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.arithmetic.cs
+ - token from 46 to 47 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, variable.other.readwrite.cs
+ - token from 47 to 48 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.operator.relational.cs
+ - token from 48 to 49 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
 
 Line:             break;
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
- - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6573,61 +6573,61 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested template 1`] = `
 "Line: @{ Action<object> abc = @<div>@{ Action<object> def = @<p class=\\"john\\" onclick='someMethod'>Hello World</p>; }</div>; }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
- - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 10 to 16 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 22 to 23 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 23 to 25 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 30 to 31 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.open.cs
- - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 33 to 39 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 40 to 46 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 46 to 47 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 48 to 51 (def) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 52 to 53 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 53 to 55 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 55 to 56 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 56 to 57 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 64 to 65 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 65 to 69 (john) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs
- - token from 69 to 70 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 70 to 71 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 71 to 78 (onclick) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 78 to 79 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 79 to 80 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.single.cs, punctuation.definition.char.begin.cs
- - token from 80 to 90 (someMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.single.cs
- - token from 90 to 91 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, string.quoted.single.cs, punctuation.definition.char.end.cs
- - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 92 to 97 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 97 to 98 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 98 to 103 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 103 to 104 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 104 to 105 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.arithmetic.cs
- - token from 105 to 106 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 106 to 107 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 107 to 109 (; ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 109 to 110 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.curlybrace.close.cs
- - token from 110 to 111 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 111 to 112 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.arithmetic.cs
- - token from 112 to 115 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 115 to 116 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 116 to 117 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
- - token from 117 to 118 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, storage.type.cs
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 10 to 16 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.type.cs
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 22 to 23 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 23 to 25 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 30 to 31 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.curlybrace.open.cs
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 33 to 39 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 39 to 40 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 40 to 46 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 46 to 47 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 47 to 48 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 48 to 51 (def) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 51 to 52 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 52 to 53 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 53 to 55 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 55 to 56 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 56 to 57 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 57 to 58 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 58 to 63 (class) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 63 to 64 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 64 to 65 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 65 to 69 (john) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs
+ - token from 69 to 70 (\\") with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 70 to 71 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 71 to 78 (onclick) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 78 to 79 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 79 to 80 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.single.cs, punctuation.definition.char.begin.cs
+ - token from 80 to 90 (someMethod) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.single.cs
+ - token from 90 to 91 (') with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, string.quoted.single.cs, punctuation.definition.char.end.cs
+ - token from 91 to 92 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 92 to 97 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 97 to 98 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 98 to 103 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 103 to 104 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 104 to 105 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 105 to 106 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 106 to 107 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 107 to 109 (; ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 109 to 110 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.curlybrace.close.cs
+ - token from 110 to 111 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 111 to 112 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 112 to 115 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 115 to 116 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 116 to 117 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
+ - token from 117 to 118 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
  - token from 118 to 119 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;
@@ -6640,53 +6640,53 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested template in @code dir
  - token from 6 to 7 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     public Action<int> GetTemplate()
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 10 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 11 to 17 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 18 to 21 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 34 (GetTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 10 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 11 to 17 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 18 to 21 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 34 (GetTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:         return template;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 14 (return) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.flow.return.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 15 to 23 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 14 (return) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.control.flow.return.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 15 to 23 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6701,53 +6701,53 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested template in @function
  - token from 11 to 12 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     public Action<int> GetTemplate()
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 10 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.modifier.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 11 to 17 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 18 to 21 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 23 to 34 (GetTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.function.cs
- - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.open.cs
- - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 10 (public) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.modifier.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 11 to 17 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 18 to 21 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 21 to 22 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 23 to 34 (GetTemplate) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.function.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.open.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:         return template;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 8 to 14 (return) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.flow.return.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 15 to 23 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, variable.other.readwrite.cs
- - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 8 to 14 (return) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, keyword.control.flow.return.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 15 to 23 (template) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 23 to 24 (;) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, source.cs, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.directive.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6784,31 +6784,31 @@ Line: </p>))
 exports[`Grammar tests Razor templates @<p>....</p> Nested template in implicit expression 1`] = `
 "Line: @CallSomeMethod(@<p style=\\"margin:1px;\\">
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 1 to 15 (CallSomeMethod) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 16 to 17 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.relational.cs
- - token from 18 to 19 (p) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, storage.type.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 20 to 25 (style) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, entity.name.variable.local.cs
- - token from 25 to 26 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
- - token from 26 to 27 (\\") with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, string.quoted.double.cs, punctuation.definition.string.begin.cs
- - token from 27 to 38 (margin:1px;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, string.quoted.double.cs
- - token from 38 to 39 (\\") with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, string.quoted.double.cs, punctuation.definition.string.end.cs
- - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.relational.cs
+ - token from 1 to 15 (CallSomeMethod) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 15 to 16 (() with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 16 to 17 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 17 to 18 (<) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.relational.cs
+ - token from 18 to 19 (p) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, storage.type.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 20 to 25 (style) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 25 to 26 (=) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 26 to 27 (\\") with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 27 to 38 (margin:1px;) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, string.quoted.double.cs
+ - token from 38 to 39 (\\") with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.relational.cs
 
 Line:     The Template
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 4 to 7 (The) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis
- - token from 8 to 16 (Template) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 7 (The) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 16 (Template) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
 
 Line: </p>)
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
- - token from 2 to 3 (p) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 3 to 4 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, keyword.operator.relational.cs
- - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 2 to 3 (p) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 3 to 4 (>) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.relational.cs
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 "
 `;
 
@@ -6818,47 +6818,47 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested try statement with te
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     try
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
- - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, keyword.control.try.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, keyword.control.try.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:     } catch (Exception ex){}
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
- - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
- - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, keyword.control.try.catch.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.open.cs
- - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, storage.type.cs
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor
- - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, entity.name.variable.local.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, punctuation.parenthesis.close.cs
- - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
- - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor
+ - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 22 (Exception) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, storage.type.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor
+ - token from 23 to 25 (ex) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 27 to 28 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6871,41 +6871,41 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested using statement with 
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     using (someDisposable)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
- - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, keyword.other.using.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 25 (someDisposable) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -6918,65 +6918,65 @@ exports[`Grammar tests Razor templates @<p>....</p> Nested while statement with 
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
 
 Line:     var i = 0;
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.other.var.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, constant.numeric.decimal.cs
- - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 9 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 12 to 13 (0) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, constant.numeric.decimal.cs
+ - token from 13 to 14 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
 
 Line:     while (i++ != 10)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
- - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
- - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.increment.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, keyword.operator.comparison.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, constant.numeric.decimal.cs
- - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 12 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 12 to 14 (++) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.increment.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 15 to 17 (!=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, keyword.operator.comparison.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 18 to 20 (10) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, constant.numeric.decimal.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, punctuation.parenthesis.close.cs
 
 Line:     {
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor
- - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor
+ - token from 4 to 5 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
 
 Line:         Action<int> template = @<p>@item</p>;
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
- - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
- - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
- - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
- - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
- - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
- - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
- - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 14 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, storage.type.cs
+ - token from 14 to 15 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.begin.cs
+ - token from 15 to 18 (int) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.type.cs
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.typeparameters.end.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 20 to 28 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, entity.name.variable.local.cs
+ - token from 28 to 29 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 29 to 30 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.assignment.cs
+ - token from 30 to 32 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 32 to 33 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 33 to 34 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 35 to 40 (@item) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 40 to 41 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 41 to 42 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.arithmetic.cs
+ - token from 42 to 43 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, variable.other.readwrite.cs
+ - token from 43 to 44 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, keyword.operator.relational.cs
+ - token from 44 to 45 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
 
 Line:         @template(i)
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
- - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, entity.name.function.cs
- - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
- - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, variable.other.readwrite.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 9 to 17 (template) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 17 to 18 (() with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 18 to 19 (i) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
 
 Line:     }
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
- - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
 
 Line: }
  - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
@@ -7003,28 +7003,28 @@ exports[`Grammar tests Razor templates @<p>....</p> Single line local variable 1
 "Line: @{ Action<object> abc = @<div>Hello World</p>; }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
- - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, storage.type.cs
- - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.begin.cs
- - token from 10 to 16 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.type.cs
- - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.definition.typeparameters.end.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, entity.name.variable.local.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 22 to 23 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.assignment.cs
- - token from 23 to 25 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 30 to 35 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 35 to 36 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
- - token from 36 to 41 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 41 to 42 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 42 to 43 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.arithmetic.cs
- - token from 43 to 44 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, variable.other.readwrite.cs
- - token from 44 to 45 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.operator.relational.cs
- - token from 45 to 46 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, punctuation.terminator.statement.cs
- - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 9 (Action) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, storage.type.cs
+ - token from 9 to 10 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.typeparameters.begin.cs
+ - token from 10 to 16 (object) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.type.cs
+ - token from 16 to 17 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.typeparameters.end.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 18 to 21 (abc) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.variable.local.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 22 to 23 (=) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.assignment.cs
+ - token from 23 to 25 ( @) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 25 to 26 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 26 to 29 (div) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 30 to 35 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 35 to 36 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 36 to 41 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 41 to 42 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 42 to 43 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 43 to 44 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 44 to 45 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 45 to 46 (;) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.terminator.statement.cs
+ - token from 46 to 47 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
  - token from 47 to 48 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
 "
 `;


### PR DESCRIPTION
### Summary of the changes
 - Re-generate the snapshot used for VS Code grammar tests
 - [Added] Run grammar tests as a part of `cibuild` / `build --test`

Fixes:
This:
```
Snapshot Summary
 › 116 snapshots failed from 1 test suite. Inspect your code changes or run `yarn test -u` to update them.

Test Suites: 1 failed, 1 total
Tests:       116 failed, 166 passed, 282 total
Snapshots:   116 failed, 166 passed, 282 total
Time:        3.529s
Ran all test suites.
```

Most of the changes were either adding missing trailing whitespace (I suspect someone manually saved the file with "Trim Trailing Whitespace" enabled) or adding `source.cs` from #3602.

I have a feeling these tests aren't being run by CI...
Addendum - turns out this was because the grammar test project included its own Directory.Build.props that didn't include its parent Directory.Build.props, resulting in the common npm logic not getting imported.
Validation:
![Grammar tests in CI](https://user-images.githubusercontent.com/2766036/148722159-7acfd72e-39e0-4a04-b5d9-d0ddbd20fe39.png)
