### PR TITLE
Properly syntax highlight self-closing components

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -201,17 +201,17 @@
       }
     },
     "non-void-tag": {
-      "begin": "(?=<(!)?[^/\\s>]+(\\s|/?>))",
-      "end": "(/>)|(</)([^/\\s>]+)\\s*(>)",
+      "begin": "(?=<(!)?([^/\\s>]+)(\\s|/?>))",
+      "end": "(</)(\\2)\\s*(>)|(/>)",
       "endCaptures": {
         "1": {
-          "name": "punctuation.definition.tag.end.html"
-        },
-        "2": {
           "name": "punctuation.definition.tag.begin.html"
         },
-        "3": {
+        "2": {
           "name": "entity.name.tag.html"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.html"
         },
         "4": {
           "name": "punctuation.definition.tag.end.html"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -121,10 +121,10 @@
       },
       "patterns": [
         {
-          "include": "#balanced-open-close-tag-body"
+          "include": "#wellformed-html"
         },
         {
-          "include": "#wellformed-html"
+          "include": "$self"
         }
       ],
       "end": "(</text>)",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -167,106 +167,20 @@
     "wellformed-html": {
       "patterns": [
         {
-          "include": "#void-tag"
+          "include": "#start-tag"
         },
         {
-          "include": "#balanced-open-close-tag"
-        }
-      ]
-    },
-    "void-tag": {
-      "name": "meta.tag.structure.$3.void.html",
-      "begin": "(?i)(<)(!?)(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)(?=\\s|/?>)",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.definition.tag.begin.html"
-        },
-        "2": {
-          "name": "constant.character.escape.razor.tagHelperOptOut"
-        },
-        "3": {
-          "name": "entity.name.tag.html"
-        }
-      },
-      "patterns": [
-        {
-          "include": "text.html.basic#attribute"
-        }
-      ],
-      "end": "/?>",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.tag.end.html"
-        }
-      }
-    },
-    "balanced-open-close-tag": {
-      "begin": "(?=<([^/\\s>]+))",
-      "patterns": [
-        {
-          "include": "#balanced-open-close-tag-start"
-        },
-        {
-          "include": "#balanced-open-close-tag-end"
-        },
-        {
-          "include": "#balanced-open-close-tag-body"
-        }
-      ],
-      "end": "(?<=(</\\1>))|(/>)"
-    },
-    "balanced-open-close-tag-start": {
-      "begin": "(<)(?!(/))([^/\\s>]+)",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.definition.tag.begin.html"
-        },
-        "2": {
-          "name": "constant.character.escape.razor.tagHelperOptOut"
-        },
-        "3": {
-          "name": "entity.name.tag.html"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#balanced-open-close-tag-attributes"
-        }
-      ],
-      "end": "/?>",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.tag.end.html"
-        }
-      }
-    },
-    "balanced-open-close-tag-attributes": {
-      "begin": "(?=\\s)",
-      "patterns": [
-        {
-          "include": "#razor-control-structures"
-        },
-        {
-          "include": "text.html.basic#attribute"
-        }
-      ],
-      "end": "(?=/?>)"
-    },
-    "balanced-open-close-tag-body": {
-      "begin": "(?<=([^/])>)",
-      "patterns": [
-        {
-          "include": "#wellformed-html"
+          "include": "#end-tag"
         },
         {
           "include": "$self"
         }
-      ],
-      "end": "(?=\\</)"
+      ]
     },
-    "balanced-open-close-tag-end": {
-      "match": "(</)(!?)([^/\\s>]+)\\s*(>)",
-      "captures": {
+    "start-tag": {
+      "name": "meta.tag.start.html",
+      "begin": "(?i)(<)(!)?([^/\\\\s>]+)(?=\\\\s|/?>)",
+      "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
         },
@@ -275,8 +189,34 @@
         },
         "3": {
           "name": "entity.name.tag.html"
+        }
+      },
+      "patterns": [
+        {
+          "include": "text.html.basic#attribute"
+        }
+      ],
+      "end": "/?>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.html"
+        }
+      }
+    },
+    "end-tag": {
+      "name": "meta.tag.end.html",
+      "begin": "(?i)(</)([^/\\\\s>]+)(?=\\\\s|>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.html"
         },
-        "4": {
+        "2": {
+          "name": "entity.name.tag.html"
+        }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": {
           "name": "punctuation.definition.tag.end.html"
         }
       }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -167,19 +167,16 @@
     "wellformed-html": {
       "patterns": [
         {
-          "include": "#start-tag"
+          "include": "#void-tag"
         },
         {
-          "include": "#end-tag"
-        },
-        {
-          "include": "$self"
+          "include": "#non-void-tag"
         }
       ]
     },
-    "start-tag": {
-      "name": "meta.tag.start.html",
-      "begin": "(?i)(<)(!)?([^/\\\\s>]+)(?=\\\\s|/?>)",
+    "void-tag": {
+      "name": "meta.tag.structure.$3.void.html",
+      "begin": "(?i)(<)(!)?(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)(?=\\s|/?>)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -203,23 +200,65 @@
         }
       }
     },
-    "end-tag": {
-      "name": "meta.tag.end.html",
-      "begin": "(?i)(</)([^/\\\\s>]+)(?=\\\\s|>)",
-      "beginCaptures": {
+    "non-void-tag": {
+      "begin": "(?=<(!)?[^/\\s>]+(\\s|/?>))",
+      "end": "(/>)|(</)([^/\\s>]+)\\s*(>)",
+      "endCaptures": {
         "1": {
-          "name": "punctuation.definition.tag.begin.html"
+          "name": "punctuation.definition.tag.end.html"
         },
         "2": {
+          "name": "punctuation.definition.tag.begin.html"
+        },
+        "3": {
           "name": "entity.name.tag.html"
-        }
-      },
-      "end": ">",
-      "endCaptures": {
-        "0": {
+        },
+        "4": {
           "name": "punctuation.definition.tag.end.html"
         }
-      }
+      },
+      "patterns": [
+        {
+          "begin": "(<)(!)?([^/\\s>]+)(?=\\s|/?>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.begin.html"
+            },
+            "2": {
+              "name": "constant.character.escape.razor.tagHelperOptOut"
+            },
+            "3": {
+              "name": "entity.name.tag.html"
+            }
+          },
+          "end": "(?=/?>)",
+          "patterns": [
+            {
+              "include": "#razor-control-structures"
+            },
+            {
+              "include": "text.html.basic#attribute"
+            }
+          ]
+        },
+        {
+          "begin": ">",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.tag.end.html"
+            }
+          },
+          "end": "(?=</)",
+          "patterns": [
+            {
+              "include": "#wellformed-html"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
     },
     "explicit-razor-expression": {
       "name": "meta.expression.explicit.cshtml",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -106,17 +106,17 @@ repository:
       0: { name: 'punctuation.definition.tag.end.html' }
 
   # This is some complicated trickery to be able to detect & match
-  # self-closing components as well as elements with begin/end tags,
+  # self-closing components as well as *matching* elements with begin/end tags,
   # more-or-less copied from microsoft/TypeScript-TmLanguage's TSX grammar.
   # Basically - we match both ways a tag can be closed (self-closing or an end tag),
   # and leave the inner patterns to figure out which one we matched.
   non-void-tag:
-    begin: '(?=<(!)?[^/\s>]+(\s|/?>))'
-    end: '(/>)|(</)([^/\s>]+)\s*(>)'
+    begin: '(?=<(!)?([^/\s>]+)(\s|/?>))'
+    end: '(</)(\2)\s*(>)|(/>)' # The \2 back-references the second capture in 'begin', for matching tags
     endCaptures:
-      1: { name: 'punctuation.definition.tag.end.html' }
-      2: { name: 'punctuation.definition.tag.begin.html' }
-      3: { name: 'entity.name.tag.html' }
+      1: { name: 'punctuation.definition.tag.begin.html' }
+      2: { name: 'entity.name.tag.html' }
+      3: { name: 'punctuation.definition.tag.end.html' }
       4: { name: 'punctuation.definition.tag.end.html' }
     patterns:
       - begin: '(<)(!)?([^/\s>]+)(?=\s|/?>)'

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -85,65 +85,43 @@ repository:
 
 # ----------  HTML ------------
 
+  # We can't capture the full context of a tag (e.g. <div>...</div>) because we can't tell
+  # solely using line-based regexes whether the starting tag is a self-closing tag.
+  # For example, consider:
+  # <SurveyPrompt
+  #   Title="Title"
+  # />
+  # So rather than trying to do the impossible, we'll just match tags individually
+  # and recursively include the grammar to capture everything in between.
+  # We also can't simply include text.html.basic#tags-valid because of the tag helper opt-out.
   wellformed-html:
     patterns:
-      - include: '#void-tag'
-      - include: '#balanced-open-close-tag'
-
-  void-tag:
-    name: 'meta.tag.structure.$3.void.html'
-    begin: '(?i)(<)(!?)(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)(?=\s|/?>)'
-    beginCaptures:
-      1: { name: 'punctuation.definition.tag.begin.html'}
-      2: { name: 'constant.character.escape.razor.tagHelperOptOut' }
-      3: { name: 'entity.name.tag.html' }
-    patterns:
-      - include: 'text.html.basic#attribute'
-    end: '/?>'
-    endCaptures:
-      0: { name: 'punctuation.definition.tag.end.html' }
-
-  balanced-open-close-tag:
-    begin: (?=<([^/\s>]+))
-    patterns:
-      - include: '#balanced-open-close-tag-start'
-      - include: '#balanced-open-close-tag-end'
-      - include: '#balanced-open-close-tag-body'
-    end: (?<=(</\1>))|(/>)
-
-  balanced-open-close-tag-start:
-    begin: '(<)(?!(/))([^/\s>]+)'
-    beginCaptures:
-      1: { name: 'punctuation.definition.tag.begin.html'}
-      2: { name: 'constant.character.escape.razor.tagHelperOptOut' }
-      3: { name: 'entity.name.tag.html' }
-    patterns:
-      - include: '#balanced-open-close-tag-attributes'
-    end: '/?>'
-    endCaptures:
-      0: { name: 'punctuation.definition.tag.end.html' }
-
-  balanced-open-close-tag-attributes:
-    begin: '(?=\s)'
-    patterns:
-      - include: '#razor-control-structures'
-      - include: 'text.html.basic#attribute'
-    end: '(?=/?>)'
-
-  balanced-open-close-tag-body:
-    begin: '(?<=([^/])>)'
-    patterns:
-      - include: '#wellformed-html'
+      - include: '#start-tag'
+      - include: '#end-tag'
       - include: '$self'
-    end: '(?=\</)'
 
-  balanced-open-close-tag-end:
-    match: '(</)(!?)([^/\s>]+)\s*(>)'
-    captures:
-      1: { name: 'punctuation.definition.tag.begin.html' }
+  start-tag:
+    name: 'meta.tag.start.html'
+    begin: '(?i)(<)(!)?([^/\\s>]+)(?=\\s|/?>)'
+    beginCaptures:
+      1: { name: 'punctuation.definition.tag.begin.html'}
       2: { name: 'constant.character.escape.razor.tagHelperOptOut' }
       3: { name: 'entity.name.tag.html' }
-      4: { name: 'punctuation.definition.tag.end.html' }
+    patterns:
+      - include: 'text.html.basic#attribute'
+    end: '/?>'
+    endCaptures:
+      0: { name: 'punctuation.definition.tag.end.html' }
+
+  end-tag:
+    name: 'meta.tag.end.html'
+    begin: '(?i)(</)([^/\\s>]+)(?=\\s|>)'
+    beginCaptures:
+      1: { name: 'punctuation.definition.tag.begin.html'}
+      2: { name: 'entity.name.tag.html' }
+    end: '>'
+    endCaptures:
+      0: { name: 'punctuation.definition.tag.end.html' }
 
 # ----------  Explicit Expression ------------
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -63,8 +63,8 @@ repository:
     beginCaptures:
       1: { name: 'keyword.control.cshtml.transition.textTag.open' }
     patterns:
-      - include: '#balanced-open-close-tag-body'
       - include: '#wellformed-html'
+      - include: '$self'
     end: '(</text>)'
     endCaptures:
       1: { name: 'keyword.control.cshtml.transition.textTag.close' }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -85,24 +85,16 @@ repository:
 
 # ----------  HTML ------------
 
-  # We can't capture the full context of a tag (e.g. <div>...</div>) because we can't tell
-  # solely using line-based regexes whether the starting tag is a self-closing tag.
-  # For example, consider:
-  # <SurveyPrompt
-  #   Title="Title"
-  # />
-  # So rather than trying to do the impossible, we'll just match tags individually
-  # and recursively include the grammar to capture everything in between.
-  # We also can't simply include text.html.basic#tags-valid because of the tag helper opt-out.
   wellformed-html:
     patterns:
-      - include: '#start-tag'
-      - include: '#end-tag'
-      - include: '$self'
+      - include: '#void-tag'
+      - include: '#non-void-tag'
 
-  start-tag:
-    name: 'meta.tag.start.html'
-    begin: '(?i)(<)(!)?([^/\\s>]+)(?=\\s|/?>)'
+  # Void tags are well-known tags that do not have an end tag *and* are not required to be self-closing.
+  # https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+  void-tag:
+    name: 'meta.tag.structure.$3.void.html'
+    begin: '(?i)(<)(!)?(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)(?=\s|/?>)'
     beginCaptures:
       1: { name: 'punctuation.definition.tag.begin.html'}
       2: { name: 'constant.character.escape.razor.tagHelperOptOut' }
@@ -113,15 +105,36 @@ repository:
     endCaptures:
       0: { name: 'punctuation.definition.tag.end.html' }
 
-  end-tag:
-    name: 'meta.tag.end.html'
-    begin: '(?i)(</)([^/\\s>]+)(?=\\s|>)'
-    beginCaptures:
-      1: { name: 'punctuation.definition.tag.begin.html'}
-      2: { name: 'entity.name.tag.html' }
-    end: '>'
+  # This is some complicated trickery to be able to detect & match
+  # self-closing components as well as elements with begin/end tags,
+  # more-or-less copied from microsoft/TypeScript-TmLanguage's TSX grammar.
+  # Basically - we match both ways a tag can be closed (self-closing or an end tag),
+  # and leave the inner patterns to figure out which one we matched.
+  non-void-tag:
+    begin: '(?=<(!)?[^/\s>]+(\s|/?>))'
+    end: '(/>)|(</)([^/\s>]+)\s*(>)'
     endCaptures:
-      0: { name: 'punctuation.definition.tag.end.html' }
+      1: { name: 'punctuation.definition.tag.end.html' }
+      2: { name: 'punctuation.definition.tag.begin.html' }
+      3: { name: 'entity.name.tag.html' }
+      4: { name: 'punctuation.definition.tag.end.html' }
+    patterns:
+      - begin: '(<)(!)?([^/\s>]+)(?=\s|/?>)'
+        beginCaptures:
+          1: { name: 'punctuation.definition.tag.begin.html' }
+          2: { name: 'constant.character.escape.razor.tagHelperOptOut' }
+          3: { name: 'entity.name.tag.html' }
+        end: '(?=/?>)'
+        patterns:
+          - include: '#razor-control-structures'
+          - include: 'text.html.basic#attribute'
+      - begin: '>'
+        beginCaptures:
+          0: { name: 'punctuation.definition.tag.end.html' }
+        end: '(?=</)'
+        patterns:
+          - include: '#wellformed-html'
+          - include: '$self'
 
 # ----------  Explicit Expression ------------
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeBlock.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/CodeBlock.ts
@@ -37,6 +37,10 @@ export function RunCodeBlockSuite() {
             await assertMatchesSnapshot('@{ <p><text>Hello</text></p> }');
         });
 
+        it('Self-closing component', async () => {
+            await assertMatchesSnapshot('@{ <SurveyPrompt /> }');
+        });
+
         it('Single line markup simple', async () => {
             await assertMatchesSnapshot(
                 `@{

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -5169,8 +5169,7 @@ Line:             Below is an incomplete tag
 
 Line:             </strong>
  - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 12 to 14 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
- - token from 14 to 20 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 12 to 20 (</strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
  - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line:         </p>
@@ -5184,22 +5183,22 @@ Line:
 
 Line:         <text>This is not a special transition tag</text>
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 8 to 14 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.open
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 9 to 13 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
  - token from 14 to 50 (This is not a special transition tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 50 to 57 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.close
+ - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 52 to 56 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 56 to 57 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line:         Hello World
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 8 to 13 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 14 to 19 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 0 to 20 (        Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
 
 Line:     </p>
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
- - token from 5 to 6 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
- - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
- - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
 
 Line:     @: <strong> <-- This is incomplete @DateTime.Now
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -4891,10 +4891,10 @@ exports[`Grammar tests Razor code blocks @{ ... } Complex HTML tag structures 1`
  - token from 2 to 3 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
  - token from 3 to 4 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
- - token from 5 to 6 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
- - token from 6 to 11 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
- - token from 11 to 17 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 17 to 19 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 5 to 6 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 6 to 11 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 11 to 17 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html
+ - token from 17 to 19 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
  - token from 19 to 20 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
  - token from 20 to 26 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
  - token from 26 to 27 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
@@ -5184,22 +5184,22 @@ Line:
 
 Line:         <text>This is not a special transition tag</text>
  - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
- - token from 9 to 13 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
- - token from 13 to 14 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 8 to 14 (<text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.open
  - token from 14 to 50 (This is not a special transition tag) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 50 to 52 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
- - token from 52 to 56 (text) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
- - token from 56 to 57 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 50 to 57 (</text>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.control.cshtml.transition.textTag.close
 
 Line:         Hello World
- - token from 0 to 20 (        Hello World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 8 to 13 (Hello) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 14 to 19 (World) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
 
 Line:     </p>
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
- - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
- - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 4 to 5 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
+ - token from 5 to 6 (/) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.arithmetic.cs
+ - token from 6 to 7 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, variable.other.readwrite.cs
+ - token from 7 to 8 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, keyword.operator.relational.cs
 
 Line:     @: <strong> <-- This is incomplete @DateTime.Now
  - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
@@ -6002,10 +6002,10 @@ exports[`Grammar tests Razor templates @<p>....</p> Complex HTML tag structure n
  - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
  - token from 4 to 5 (p) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
  - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
- - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
- - token from 7 to 12 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
- - token from 12 to 18 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
- - token from 18 to 20 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 6 to 7 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, punctuation.definition.tag.begin.html
+ - token from 7 to 12 (input) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, entity.name.tag.html
+ - token from 12 to 18 (      ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html
+ - token from 18 to 20 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, meta.tag.structure.input.void.html, punctuation.definition.tag.end.html
  - token from 20 to 21 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
  - token from 21 to 27 (strong) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
  - token from 27 to 28 (>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -5873,6 +5873,20 @@ exports[`Grammar tests Razor code blocks @{ ... } Pure C# 1`] = `
 "
 `;
 
+exports[`Grammar tests Razor code blocks @{ ... } Self-closing component 1`] = `
+"Line: @{ <SurveyPrompt /> }
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition
+ - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.open
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 3 to 4 (<) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.begin.html
+ - token from 4 to 16 (SurveyPrompt) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, entity.name.tag.html
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 17 to 19 (/>) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs, punctuation.definition.tag.end.html
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, source.cs
+ - token from 20 to 21 (}) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.razor.directive.codeblock.close
+"
+`;
+
 exports[`Grammar tests Razor code blocks @{ ... } Single line local function 1`] = `
 "Line: @{ void Foo() {} }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.structure.razor.codeblock, keyword.control.cshtml.transition


### PR DESCRIPTION
### Summary of the changes
 - Syntax-highlight self-closing components

So, the one-line fix that I didn't spot until looking over my final diff is technically just
```diff
diff --git a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
index 7a4e6dd9d..c6b03c274 100644
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -109,7 +109,7 @@ repository:
       - include: '#balanced-open-close-tag-start'
       - include: '#balanced-open-close-tag-end'
       - include: '#balanced-open-close-tag-body'
-    end: (?<=(</\1>))|(/>)
+    end: (?<=</\1>|/>)
```
_However_, after some consideration, I've decided to go with my current proposal (copied from [TypeScriptReact.YAML-tmLanguage](https://github.com/microsoft/TypeScript-TmLanguage/blob/master/TypeScriptReact.YAML-tmLanguage)), which has the added benefit of detecting void tags in more cases.
Though I could be convinced to just go with the one-line fix for now and investigate the void tag detection separately :).

TODO:
* [x] Get clarification on two tests
* [x] Write some tests to cover #5919

Fixes: 
#5919