### PR TITLE
Add '_' as TriggerCharacter

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             {
                 DocumentSelector = RazorDefaults.Selector,
                 ResolveProvider = true,
-                TriggerCharacters = new Container<string>("@", "<", ":"),
+                TriggerCharacters = new Container<string>("@", "<", ":", "_"),
 
                 // NOTE: This property is *NOT* processed in O# versions < 0.16
                 // https://github.com/OmniSharp/csharp-language-server-protocol/blame/bdec4c73240be52fbb25a81f6ad7d409f77b5215/src/Protocol/Server/Capabilities/CompletionOptions.cs#L35-L44


### PR DESCRIPTION
### Summary of the changes
 - I'm not totally sure how the interactions here work, but this seemed to fix it when I ran things locally. Best I could tell VSLanguageServerClient never called our endpoints because `_` wasn't a valid trigger for completion to fire. Someone with a deeper understanding of Completion should let me know if this is the "right" fix though.

Fixes: https://github.com/dotnet/razor-tooling/issues/5629