### PR TITLE
Fixed hover display on tag helpers end tag

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -11,23 +11,29 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public override bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes)
         {
-            if (element is MarkupStartTagSyntax startTag)
+            switch (element)
             {
-                containingTagNameToken = startTag.Name;
-                attributeNodes = startTag.Attributes;
-                return true;
+                case MarkupStartTagSyntax startTag:
+                    containingTagNameToken = startTag.Name;
+                    attributeNodes = startTag.Attributes;
+                    return true;
+                case MarkupEndTagSyntax endTag:
+                    containingTagNameToken = endTag.Name;
+                    attributeNodes = ((MarkupElementSyntax)endTag.Parent).StartTag.Attributes;
+                    return true;
+                case MarkupTagHelperStartTagSyntax startTagHelper:
+                    containingTagNameToken = startTagHelper.Name;
+                    attributeNodes = startTagHelper.Attributes;
+                    return true;
+                case MarkupTagHelperEndTagSyntax endTagHelper:
+                    containingTagNameToken = endTagHelper.Name;
+                    attributeNodes = ((MarkupTagHelperElementSyntax)endTagHelper.Parent).StartTag.Attributes;
+                    return true;
+                default:
+                    containingTagNameToken = null;
+                    attributeNodes = default;
+                    return false;
             }
-
-            if (element is MarkupTagHelperStartTagSyntax startTagHelper)
-            {
-                containingTagNameToken = startTagHelper.Name;
-                attributeNodes = startTagHelper.Attributes;
-                return true;
-            }
-
-            containingTagNameToken = null;
-            attributeNodes = default;
-            return false;
         }
 
         public override bool TryGetAttributeInfo(
@@ -86,7 +92,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                         selectedAttributeNameLocation = fullNameSpan;
                         return true;
                     }
-                case MarkupMiscAttributeContentSyntax _:
+                case MarkupMiscAttributeContentSyntax:
                     prefixLocation = null;
                     selectedAttributeName = null;
                     selectedAttributeNameLocation = null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -17,17 +17,17 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     containingTagNameToken = startTag.Name;
                     attributeNodes = startTag.Attributes;
                     return true;
-                case MarkupEndTagSyntax endTag:
+                case MarkupEndTagSyntax { Parent: MarkupElementSyntax parent } endTag:
                     containingTagNameToken = endTag.Name;
-                    attributeNodes = ((MarkupElementSyntax)endTag.Parent).StartTag.Attributes;
+                    attributeNodes = parent.StartTag.Attributes;
                     return true;
                 case MarkupTagHelperStartTagSyntax startTagHelper:
                     containingTagNameToken = startTagHelper.Name;
                     attributeNodes = startTagHelper.Attributes;
                     return true;
-                case MarkupTagHelperEndTagSyntax endTagHelper:
+                case MarkupTagHelperEndTagSyntax { Parent: MarkupTagHelperElementSyntax parent } endTagHelper:
                     containingTagNameToken = endTagHelper.Name;
-                    attributeNodes = ((MarkupTagHelperElementSyntax)endTagHelper.Parent).StartTag.Attributes;
+                    attributeNodes = parent.StartTag.Attributes;
                     return true;
                 default:
                     containingTagNameToken = null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -70,6 +70,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
         }
 
         [Fact]
+        public void GetHoverInfo_TagHelper_Element_EndTag()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+            var service = GetDefaultRazorHoverInfoService();
+            var location = new SourceLocation(txt.LastIndexOf("test1", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = LanguageServer.ClientSettings.Capabilities;
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
+
+            // Assert
+            Assert.Contains("**Test1TagHelper**", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
+            var expectedRange = new RangeModel(new Position(1, 9), new Position(1, 14));
+            Assert.Equal(expectedRange, hover.Range);
+        }
+
+        [Fact]
         public void GetHoverInfo_TagHelper_Attribute()
         {
             // Arrange
@@ -283,6 +302,29 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             Assert.Contains("Test1TagHelper", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
             Assert.Equal(MarkupKind.PlainText, hover.Contents.MarkupContent.Kind);
             var expectedRange = new RangeModel(new Position(1, 1), new Position(1, 6));
+            Assert.Equal(expectedRange, hover.Range);
+        }
+
+        [Fact]
+        public void GetHoverInfo_TagHelper_PlainTextElement_EndTag()
+        {
+            // Arrange
+            var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+            var codeDocument = CreateCodeDocument(txt, DefaultTagHelpers);
+
+            var languageServer = LanguageServer;
+            languageServer.ClientSettings.Capabilities.TextDocument.Hover.Value.ContentFormat = new Container<MarkupKind>(MarkupKind.PlainText);
+            var service = GetDefaultRazorHoverInfoService(languageServer);
+            var location = new SourceLocation(txt.LastIndexOf("test1", StringComparison.Ordinal), -1, -1);
+            var clientCapabilities = languageServer.ClientSettings.Capabilities;
+
+            // Act
+            var hover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
+
+            // Assert
+            Assert.Contains("Test1TagHelper", hover.Contents.MarkupContent.Value, StringComparison.Ordinal);
+            Assert.Equal(MarkupKind.PlainText, hover.Contents.MarkupContent.Kind);
+            var expectedRange = new RangeModel(new Position(1, 9), new Position(1, 14));
             Assert.Equal(expectedRange, hover.Range);
         }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/razor-tooling/issues/4363

**Before:**
![devenv_RXL30CpCjU](https://user-images.githubusercontent.com/70431552/149834631-d4fa958f-d90d-4e77-b994-ad6d505f331c.gif)

**After:**
![devenv_d5RLTIEcWJ](https://user-images.githubusercontent.com/70431552/149834693-5d32deb7-6001-4b3a-8197-8bb28fda39b4.gif)

By the way, it's a bit confusing, that functionality of `DefaultHtmlFactsService`, which is located in `Microsoft.CodeAnalysis.Razor.Workspace`, is tested in `Microsoft.AspNetCore.Razor.LanguageServer.Test`🤨