### PR TITLE
Fixed wrong completion icons

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             "BuildRenderTree"
         };
 
-        private static readonly IReadOnlyCollection<CompletionItem> s_keywordCompletionItems = GenerateCompletionItems(s_keywords);
+        private static readonly IReadOnlyCollection<CompletionItem> s_keywordCompletionItems = GenerateCompletionItems(s_keywords, CompletionItemKind.Keyword);
         private static readonly IReadOnlyCollection<CompletionItem> s_designTimeHelpersCompletionItems = GenerateCompletionItems(s_designTimeHelpers);
 
         private readonly JoinableTaskFactory _joinableTaskFactory;
@@ -479,8 +479,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             return completionList;
         }
 
-        private static IReadOnlyCollection<CompletionItem> GenerateCompletionItems(IReadOnlyCollection<string> completionItems)
-            => completionItems.Select(item => new CompletionItem { Label = item, Kind = CompletionItemKind.Keyword }).ToArray();
+        private static IReadOnlyCollection<CompletionItem> GenerateCompletionItems(IReadOnlyCollection<string> completionItems, CompletionItemKind completionKind = CompletionItemKind.None)
+            => completionItems.Select(item => new CompletionItem { Label = item, Kind = completionKind }).ToArray();
 
         private static bool IsSimpleImplicitExpression(CompletionParams request, LSPDocumentSnapshot documentSnapshot, TextExtent? wordExtent)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -480,7 +480,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         }
 
         private static IReadOnlyCollection<CompletionItem> GenerateCompletionItems(IReadOnlyCollection<string> completionItems)
-            => completionItems.Select(item => new CompletionItem { Label = item }).ToArray();
+            => completionItems.Select(item => new CompletionItem { Label = item, Kind = CompletionItemKind.Keyword }).ToArray();
 
         private static bool IsSimpleImplicitExpression(CompletionParams request, LSPDocumentSnapshot documentSnapshot, TextExtent? wordExtent)
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/razor-tooling/issues/5793

**Before:**
![devenv_8PTDbcJsDR](https://user-images.githubusercontent.com/70431552/150513770-405d4475-072f-4588-b33f-8d74e9f3e555.png)
_"for" and "foreach" completions has weird icons_

**After:**
![devenv_BV6Bf12wXg](https://user-images.githubusercontent.com/70431552/150513828-f7ba49ca-68df-47b6-a639-1be8fab8ad2f.png)
_All icons are ok_

Yet another bug, occured because of completions post processing. In general having such post processing is the opposit of an idea of a language server, because every client needs to implement this post processing on his own. I'm not a fan of this approach at all! 😠 All functionality should be processed on the server side!