### PR TITLE
Fix naming

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -15,7 +15,7 @@ steps:
       -msbuildEngine dotnet
       -prepareMachine
       -integrationTest
-    name: Build and Test
+    name: BuildAndTest
     displayName: Build and Test
     condition: succeeded()
 


### PR DESCRIPTION
### Summary of the changes
 - AzDo will not allow you to have a space in the name, so we must remove them.
