### PR TITLE
Expanding CODEOWNERS to include BlazorWASMDebuggingExtension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,4 @@
 /eng/Versions.props                            @dotnet-maestro-bot
 /eng/Version.Details.xml                       @dotnet-maestro-bot
 /src/                                          @dotnet/razor-tooling @NTaylorMullen @ryanbrandenburg @allisonchou @sharwell @davidwengier
+/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/ @dotnet/razor-tooling @dotnet/aspnet-blazor-eng @captainsafia


### PR DESCRIPTION
Capture cases like https://github.com/dotnet/razor-tooling/pull/6000.
