### PR TITLE
Fail CI if packaging Blazor WASM Debugging Extension fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,6 +224,7 @@ stages:
             npx vsce@1.100.2 package -o $(Build.SourcesDirectory)/artifacts/packages/VSCode/$(_BuildConfig)/blazorwasm-companion-$version.vsix
           displayName: Produce Blazor WASM Debugging Extension VSIX
           workingDirectory: $(Build.SourcesDirectory)/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension
+          failOnStderr: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         - task: PublishBuildArtifacts@1
           displayName: Upload Test Results


### PR DESCRIPTION
### Summary of the changes
PowerShell is finicky in that it needs to support both native commands and cmdlets which have different methods of error reporting, but doesn't (yet, thankfully that's changing soon) have an equivalent of `$ErrorActionPreference = 'Stop'` for native commands. So fail on both stderr _and_ cmdlet errors.

Fixes: 
CI "passing" and producing a mostly-empty Blazor WASM debugging extension when it shouldn't. I can't actually verify this since I'm submitting from a fork and the pipeline skips that step on forked CI runs, so feel free to make your own change and run it if you want verification, I'm not particularly possessive of this commit, haha.
Refs #6000

(While I'm here, two questions. 1) Why is this skipped on forks in the first place? It doesn't seem to use any confidential credentials since I was able to run the script fine from a Codespace. 2) Would this be better off being in `package.json` as part of the build or vscode:prepublish step, rather than a special step in CI?)