### PR TITLE
Pass formatting options in snippets

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,7 +93,7 @@
     <MicrosoftVisualStudioShellPackagesVersion>17.0.31723.112</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.0.487</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.1.0-1.21471.13</RoslynPackageVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.1.8</VisualStudioLanguageServerProtocolVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.1.11</VisualStudioLanguageServerProtocolVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
@@ -24,17 +24,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal class InlineCompletionEndpoint : IInlineCompletionHandler
 {
-    // Usually when we need to format code, we utilize the formatting options provided
-    // by the platform. Similar to DefaultCSharpCodeActionResolver we do not have any, so use defaults.
-    private static readonly FormattingOptions s_defaultFormattingOptions = new FormattingOptions()
-    {
-        TabSize = 4,
-        InsertSpaces = true,
-        TrimTrailingWhitespace = true,
-        InsertFinalNewline = true,
-        TrimFinalNewlines = true
-    };
-
     private static readonly ImmutableHashSet<string> s_cSharpKeywords = ImmutableHashSet.Create(
         "~", "Attribute", "checked", "class", "ctor", "cw", "do", "else", "enum", "equals", "Exception", "for", "foreach", "forr",
         "if", "indexer", "interface", "invoke", "iterator", "iterindex", "lock", "mbox", "namespace", "#if", "#region", "prop",
@@ -154,6 +143,7 @@ internal class InlineCompletionEndpoint : IInlineCompletionHandler
             Context = request.Context,
             Position = projectedPosition,
             Kind = languageKind,
+            Options = request.Options,
         };
 
         request.Position = projectedPosition;
@@ -178,7 +168,7 @@ internal class InlineCompletionEndpoint : IInlineCompletionHandler
                 continue;
             }
 
-            using var formattingContext = FormattingContext.Create(request.TextDocument.Uri, document, codeDocument, s_defaultFormattingOptions, _adhocWorkspaceFactory, isFormatOnType: true, automaticallyAddUsings: false);
+            using var formattingContext = FormattingContext.Create(request.TextDocument.Uri, document, codeDocument, request.Options, _adhocWorkspaceFactory, isFormatOnType: true, automaticallyAddUsings: false);
             if (!TryGetSnippetWithAdjustedIndentation(formattingContext, item.Text, hostDocumentIndex, out var newSnippetText))
             {
                 continue;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionRequest.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionRequest.cs
@@ -26,4 +26,7 @@ internal class InlineCompletionRequest : ITextDocumentIdentifierParams, IRequest
     [DataMember(Name = "_vs_context")]
     [JsonProperty(Required = Required.Always)]
     public InlineCompletionContext Context { get; set; }
+
+    [DataMember(Name = "_vs_options")]
+    public FormattingOptions Options { get; set; }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -549,6 +549,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 Context = inlineCompletionParams.Context,
                 Position = inlineCompletionParams.Position,
                 TextDocument = DocumentUri.From(csharpDoc.Uri),
+                Options = inlineCompletionParams.Options,
             };
 
             var textBuffer = csharpDoc.Snapshot.TextBuffer;


### PR DESCRIPTION
### Summary of the changes
 - Uses document options from client and passes them to C# to retrieve the razor formatted snippet text.



Tested