### PR TITLE
Update Razor CodeActions to allow latest light bulb capabilities.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
             };
             razorCodeAction = razorCodeAction with { Data = JToken.FromObject(resolutionParams) };
 
-            if (razorCodeAction.Children?.Length != 0)
+            if (razorCodeAction.Children != null)
             {
                 for (var i = 0; i < razorCodeAction.Children.Length; i++)
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeAction.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeAction.cs
@@ -1,30 +1,51 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using MediatR;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
-{
-    [DebuggerDisplay("{Title,nq}")]
-    internal record RazorCodeAction : CodeAction, IRequest<RazorCodeAction>, IBaseRequest
-    {
-        /// <summary>
-        /// Typically null, only present in VS scenarios.
-        /// </summary>
-        [JsonProperty(PropertyName = "children", NullValueHandling = NullValueHandling.Ignore)]
-        public RazorCodeAction[] Children { get; set; } = Array.Empty<RazorCodeAction>();
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 
-        /// <summary>
-        /// Used internally by the Razor Language Server to store the Code Action name extracted
-        /// from the Data.CustomTags payload.
-        /// </summary>
-        [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
-        public string Name { get; set; }
-    }
+[DebuggerDisplay("{Title,nq}")]
+internal record RazorCodeAction : CodeAction, IRequest<RazorCodeAction>, IBaseRequest
+{
+    /// <summary>
+    /// Gets or sets the children of this action. Only present in VS scenarios.
+    /// </summary>
+    [JsonProperty(PropertyName = "_vs_group", NullValueHandling = NullValueHandling.Ignore)]
+    public string? Group { get; set; }
+
+    /// <summary>
+    /// Gets or sets the priority level of the code action. Only present in VS scenarios.
+    /// </summary>
+    [JsonProperty(PropertyName = "_vs_priority", NullValueHandling = NullValueHandling.Ignore)]
+    public RazorCodeActionPriorityLevel? Priority { get; set; }
+
+    /// <summary>
+    /// Gets or sets the range of the span this action is applicable to. Only present in VS scenarios.
+    /// </summary>
+    [JsonProperty(PropertyName = "_vs_applicableRange", NullValueHandling = NullValueHandling.Ignore)]
+    public Range? ApplicableRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the children of this action. Only present in VS scenarios.
+    /// </summary>
+    [JsonProperty(PropertyName = "_vs_children", NullValueHandling = NullValueHandling.Ignore)]
+    public RazorCodeAction[]? Children { get; set; }
+
+    /// <summary>
+    /// Gets or sets the telemetry id of this action. Only present in VS scenarios.
+    /// </summary>
+    [JsonProperty(PropertyName = "_vs_telemetryId", NullValueHandling = NullValueHandling.Ignore)]
+    public Guid? TelemetryId { get; set; }
+
+    /// <summary>
+    /// Used internally by the Razor Language Server to store the Code Action name extracted
+    /// from the Data.CustomTags payload.
+    /// </summary>
+    [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
+    public string? Name { get; set; }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionPriorityLevel.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorCodeActionPriorityLevel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+
+internal enum RazorCodeActionPriorityLevel
+{
+    Lowest = 0,
+    Low = 1,
+    Normal = 2,
+    High = 3,
+}


### PR DESCRIPTION
- Updating our Razor representation of code actions to allow latest VS concepts so when / if sub-languages utilize them we respect it.
- This is pre-requisite work to providing our own telemetry IDs on code actions.
-  Utilized file-scoped namespaces so viewing the diff here with whitespace changes off would be best.

Part of #4899