### PR TITLE
Add telemetry identifiers for Razor light bulbs.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return codeAction;
             }
 
-            if (!AddUsingsCodeActionProviderFactory.TryExtractNamespace(addUsingTextEdit.NewText, out var @namespace))
+            if (!AddUsingsCodeActionProviderHelper.TryExtractNamespace(addUsingTextEdit.NewText, out var @namespace))
             {
                 // Invalid text edit, missing namespace
                 return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
@@ -235,7 +235,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         private static RazorCodeAction CreateFQNCodeAction(
             RazorCodeActionContext context,
             Diagnostic fqnDiagnostic,
-            RazorCodeAction codeAction,
+            RazorCodeAction nonFQNCodeAction,
             string fullyQualifiedName)
         {
             var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { Uri = context.Request.TextDocument.Uri };
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 DocumentChanges = new[] { fqnWorkspaceEditDocumentChange }
             };
 
-            var codeAction = RazorCodeActionFactory.CreateFullyQualifyComponent(codeAction.Title, fqnWorkspaceEdit);
+            var codeAction = RazorCodeActionFactory.CreateFullyQualifyComponent(nonFQNCodeAction.Title, fqnWorkspaceEdit);
             return codeAction;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
@@ -28,7 +28,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
                 razorCodeAction = new RazorCodeAction()
                 {
                     Title = razorCodeAction.Title,
-                    Data = JToken.FromObject(resolutionParams)
+                    Data = JToken.FromObject(resolutionParams),
+                    TelemetryId = razorCodeAction.TelemetryId,
                 };
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Newtonsoft.Json.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Razor;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -107,12 +108,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 Data = actionParams,
             };
 
-            var codeAction = new RazorCodeAction()
-            {
-                Title = RazorLS.Resources.ExtractTo_CodeBehind_Title,
-                Data = JToken.FromObject(resolutionParams)
-            };
-
+            var codeAction = RazorCodeActionFactory.CreateExtractToCodeBehind(resolutionParams);
             var codeActions = new List<RazorCodeAction> { codeAction };
 
             return Task.FromResult(codeActions as IReadOnlyList<RazorCodeAction>);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Razor;
+
+internal static class RazorCodeActionFactory
+{
+    private readonly static Guid s_addComponentUsingTelemetryId = new("6c5416b7-7be7-49ee-aa60-904385be676f");
+    private readonly static Guid s_fullyQualifyComponentTelemetryId = new("3d9abe36-7d10-4e08-8c18-ad88baa9a923");
+    private readonly static Guid s_createComponentFromTagTelemetryId = new("a28e0baa-a4d5-4953-a817-1db586035841");
+    private readonly static Guid s_createExtractToCodeBehindTelemetryId = new("f63167f7-fdc6-450f-8b7b-b240892f4a27");
+
+    public static RazorCodeAction CreateAddComponentUsing(string @namespace, RazorCodeActionResolutionParams resolutionParams)
+    {
+        var title = $"@using {@namespace}";
+        var data = JToken.FromObject(resolutionParams);
+        var codeAction = new RazorCodeAction
+        {
+            Title = title,
+            Data = data,
+            TelemetryId = s_addComponentUsingTelemetryId,
+        };
+        return codeAction;
+    }
+
+    public static RazorCodeAction CreateFullyQualifyComponent(string fullyQualifiedName, WorkspaceEdit workspaceEdit)
+    {
+        var codeAction = new RazorCodeAction()
+        {
+            Title = fullyQualifiedName,
+            Edit = workspaceEdit,
+            TelemetryId = s_fullyQualifyComponentTelemetryId,
+        };
+        return codeAction;
+    }
+
+    public static RazorCodeAction CreateComponentFromTag(RazorCodeActionResolutionParams resolutionParams)
+    {
+        var title = RazorLS.Resources.Create_Component_FromTag_Title;
+        var data = JToken.FromObject(resolutionParams);
+        var codeAction = new RazorCodeAction()
+        {
+            Title = title,
+            Data = data,
+            TelemetryId = s_createComponentFromTagTelemetryId,
+        };
+        return codeAction;
+    }
+
+    public static RazorCodeAction CreateExtractToCodeBehind(RazorCodeActionResolutionParams resolutionParams)
+    {
+        var title = RazorLS.Resources.ExtractTo_CodeBehind_Title;
+        var data = JToken.FromObject(resolutionParams);
+        var codeAction = new RazorCodeAction()
+        {
+            Title = title,
+            Data = data,
+            TelemetryId = s_createExtractToCodeBehindTelemetryId,
+        };
+        return codeAction;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionProviderFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionProviderFactoryTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var fqn = "Abc";
 
             // Act
-            var namespaceName = AddUsingsCodeActionProviderFactory.GetNamespaceFromFQN(fqn);
+            var namespaceName = AddUsingsCodeActionProviderHelper.GetNamespaceFromFQN(fqn);
 
             // Assert
             Assert.Empty(namespaceName);
@@ -30,24 +30,26 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var fqn = "Abc.Xyz";
 
             // Act
-            var namespaceName = AddUsingsCodeActionProviderFactory.GetNamespaceFromFQN(fqn);
+            var namespaceName = AddUsingsCodeActionProviderHelper.GetNamespaceFromFQN(fqn);
 
             // Assert
             Assert.Equal("Abc", namespaceName);
         }
 
         [Fact]
-        public void CreateAddUsingCodeAction_CreatesCodeAction()
+        public void TryCreateAddUsingResolutionParams_CreatesResolutionParams()
         {
             // Arrange
             var fqn = "Abc.Xyz";
             var docUri = DocumentUri.From("c:/path");
 
             // Act
-            var codeAction = AddUsingsCodeActionProviderFactory.CreateAddUsingCodeAction(fqn, docUri);
+            var result = AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fqn, docUri, out var @namespace, out var resolutionParams);
 
             // Assert
-            Assert.Equal("@using Abc", codeAction.Title);
+            Assert.True(result);
+            Assert.Equal("Abc", @namespace);
+            Assert.NotNull(resolutionParams);
         }
 
         [Fact]
@@ -57,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var csharpAddUsing = "Abc.Xyz;";
 
             // Act
-            var res = AddUsingsCodeActionProviderFactory.TryExtractNamespace(csharpAddUsing, out var @namespace);
+            var res = AddUsingsCodeActionProviderHelper.TryExtractNamespace(csharpAddUsing, out var @namespace);
 
             // Assert
             Assert.False(res);
@@ -71,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var csharpAddUsing = "using Abc.Xyz;";
 
             // Act
-            var res = AddUsingsCodeActionProviderFactory.TryExtractNamespace(csharpAddUsing, out var @namespace);
+            var res = AddUsingsCodeActionProviderHelper.TryExtractNamespace(csharpAddUsing, out var @namespace);
 
             // Assert
             Assert.True(res);
@@ -85,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var csharpAddUsing = "using static X.Y.Z;";
 
             // Act
-            var res = AddUsingsCodeActionProviderFactory.TryExtractNamespace(csharpAddUsing, out var @namespace);
+            var res = AddUsingsCodeActionProviderHelper.TryExtractNamespace(csharpAddUsing, out var @namespace);
 
             // Assert
             Assert.True(res);


### PR DESCRIPTION
- This changeset adds unique telemetry IDs for each of our light bulbs. It also includes changing the VSCode representation of our light bulbs for consistencies-sake.
- Made a singular "code action factory" which owns all `new RazorCodeAction(...)` creations so it can stamp telemetry IDs onto them.
- Updated the existing `AddUsingsCodeActionProviderFactory` to be a `Helper` to help distinguish a singular factory for code actions.

Final part of #4899