### PR TITLE
Add support for document color requests for HTML.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -48,6 +48,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public const string RazorProvideSemanticTokensRangeEndpoint = "razor/provideSemanticTokensRange";
 
+        public const string RazorProvideHtmlDocumentColorEndpoint = "razor/provideHtmlDocumentColor";
+
         public const string RazorServerReadyEndpoint = "razor/serverReady";
 
         public const string RazorInlineCompletionEndpoint = "razor/inlineCompletion";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
+{
+    internal class DocumentColorEndpoint : IDocumentColorHandler
+    {
+        private static readonly Container<ColorInformation> EmptyDocumentColors = new Container<ColorInformation>();
+        private readonly ClientNotifierServiceBase _languageServer;
+
+        public DocumentColorEndpoint(ClientNotifierServiceBase languageServer)
+        {
+            if (languageServer is null)
+            {
+                throw new ArgumentNullException(nameof(languageServer));
+            }
+
+            _languageServer = languageServer;
+        }
+        public DocumentColorRegistrationOptions GetRegistrationOptions(ColorProviderCapability capability, ClientCapabilities clientCapabilities)
+        {
+            return new DocumentColorRegistrationOptions()
+            {
+                DocumentSelector = RazorDefaults.Selector,
+            };
+        }
+
+        public async Task<Container<ColorInformation>> Handle(DocumentColorParams request, CancellationToken cancellationToken)
+        {
+            var delegatedRequest = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorProvideHtmlDocumentColorEndpoint, request).ConfigureAwait(false);
+            var documentColors = await delegatedRequest.Returning<Container<ColorInformation>?>(cancellationToken).ConfigureAwait(false);
+
+            if (documentColors is null)
+            {
+                return EmptyDocumentColors;
+            }
+
+            // HTML and Razor documents have identical mapping locations. Because of this we can return the result as-is.
+
+            return documentColors;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -40,6 +40,7 @@ using OmniSharp.Extensions.LanguageServer.Server;
 using Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange;
 using Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag;
 using Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
+using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -137,6 +138,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     .WithHandler<WrapWithTagEndpoint>()
                     .WithHandler<InlineCompletionEndpoint>()
                     .WithHandler<RazorBreakpointSpanEndpoint>()
+                    .WithHandler<DocumentColorEndpoint>()
                     .WithServices(services =>
                     {
                         services.AddLogging(builder => builder

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -416,6 +416,40 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return response;
         }
 
+        public override async Task<IReadOnlyList<ColorInformation>> ProvideHtmlDocumentColorAsync(DocumentColorParams documentColorParams, CancellationToken cancellationToken)
+        {
+            if (documentColorParams is null)
+            {
+                throw new ArgumentNullException(nameof(documentColorParams));
+            }
+
+            var htmlDoc = GetHtmlDocumentSnapshsot(documentColorParams.TextDocument.Uri);
+            if (htmlDoc is null)
+            {
+                return Array.Empty<ColorInformation>();
+            }
+
+            documentColorParams.TextDocument.Uri = htmlDoc.Uri;
+            var htmlTextBuffer = htmlDoc.Snapshot.TextBuffer;
+            var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<DocumentColorParams, ColorInformation[]>(
+                htmlTextBuffer,
+                Methods.DocumentColorRequest.Name,
+                SupportsDocumentColor,
+                documentColorParams,
+                cancellationToken).ConfigureAwait(false);
+
+            var colorInformation = new List<ColorInformation>();
+            await foreach (var response in requests)
+            {
+                if (response.Response is not null)
+                {
+                    colorInformation.AddRange(response.Response);
+                }
+            }
+
+            return colorInformation;
+        }
+
         private CSharpVirtualDocumentSnapshot? GetCSharpDocumentSnapshsot(Uri uri)
         {
             var normalizedString = uri.GetAbsoluteOrUNCPath();
@@ -434,6 +468,24 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return csharpDoc;
         }
 
+        private HtmlVirtualDocumentSnapshot? GetHtmlDocumentSnapshsot(Uri uri)
+        {
+            var normalizedString = uri.GetAbsoluteOrUNCPath();
+            var normalizedUri = new Uri(WebUtility.UrlDecode(normalizedString));
+
+            if (!_documentManager.TryGetDocument(normalizedUri, out var documentSnapshot))
+            {
+                return null;
+            }
+
+            if (!documentSnapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var htmlDoc))
+            {
+                return null;
+            }
+
+            return htmlDoc;
+        }
+
         public override async Task RazorServerReadyAsync(CancellationToken cancellationToken)
         {
             // Doing both UIContext and BrokeredService while integrating
@@ -450,6 +502,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 options => (true, options.ResolveProvider)) ?? (false, false);
 
             return providesCodeActions && resolvesCodeActions;
+        }
+
+        private static bool SupportsDocumentColor(JToken token)
+        {
+            var serverCapabilities = token.ToObject<ServerCapabilities>();
+
+            var supportsDocumentColor = serverCapabilities?.DocumentColorProvider?.Match(
+                boolValue => boolValue,
+                options => options != null) ?? false;
+
+            return supportsDocumentColor;
         }
 
         // NOTE: This method is a polyfill for VS. We only intend to do it this way until VS formally

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -62,5 +62,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         // Called by the Razor Language Server to provide inline completions from the platform.
         [JsonRpcMethod(LanguageServerConstants.RazorInlineCompletionEndpoint, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<InlineCompletionList?> ProvideInlineCompletionAsync(RazorInlineCompletionRequest inlineCompletionParams, CancellationToken cancellationToken);
+
+        // Called by the Razor Language Server to provide document colors from the platform.
+        [JsonRpcMethod(LanguageServerConstants.RazorProvideHtmlDocumentColorEndpoint, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<IReadOnlyList<ColorInformation>> ProvideHtmlDocumentColorAsync(DocumentColorParams documentColorParams, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
- The [document color request](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor) is what provides color adornments
- Because the majority of the work here is through delegation there wasn't a great place to test this.

![image](https://i.imgur.com/dQqLsie.png)

Fixes #6073