### PR TITLE
Retrieve BlazorDebugProxy on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,5 @@ yarn-*.log
 *.svclog
 
 # Bundled extension assets
-src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/BlazorDebugProxy/*.dll
-src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/BlazorDebugProxy/*.json
+src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/BlazorDebugProxy/
 *.vsix

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,8 +218,7 @@ stages:
           condition: always()
         - powershell: |
             $version = $(node -p "require('./package.json').version" | Out-String).Trim()
-            yarn
-            node ./scripts/retrieveDebugProxy.js
+            yarn install
             md $(Build.SourcesDirectory)/artifacts/packages/VSCode/$(_BuildConfig)/ -ea 0
             npx vsce@1.103.1 package -o $(Build.SourcesDirectory)/artifacts/packages/VSCode/$(_BuildConfig)/blazorwasm-companion-$version.vsix
           displayName: Produce Blazor WASM Debugging Extension VSIX

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/BlazorDebugProxy/README.md
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/BlazorDebugProxy/README.md
@@ -1,1 +1,0 @@
-This directory contains the assets for the BlazorDebugProxy that needs to be launched on a users machine. To obtain these assets run the `node` script located at `../scripts/retrieveDebugProxy.js`.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.4",
-    "@types/node": "^12.11.7",
+    "@types/node": "^14.18.12",
     "@types/vscode": "^1.52.0",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -40,7 +40,7 @@
   },
   "contributes": {},
   "scripts": {
-    "vscode:prepublish": "yarn run compile",
+    "vscode:prepublish": "yarn run build",
     "clean": "rimraf dist",
     "build": "yarn run clean && yarn run lint && yarn run compile && node scripts/retrieveDebugProxy.js",
     "compile": "tsc -p ./",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "vscode:prepublish": "yarn run compile",
     "clean": "rimraf dist",
-    "build": "yarn run clean && yarn run lint && yarn run compile",
+    "build": "yarn run clean && yarn run lint && yarn run compile && node scripts/retrieveDebugProxy.js",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile && yarn run lint",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -69,7 +69,12 @@ async function copyDebugProxyAssets(version) {
 
     log(`Using ${targetDirectory} as targetDirectory...`);
     log(`Cleaning ${targetDirectory}...`);
-    fs.rmdirSync(targetDirectory);
+
+    // TODO: This can be replaced by fs.rmSync(targetDirectory, { recursive: true, force: true })
+    // on Node 14+. No existsSync check needed.
+    if (fs.existsSync(targetDirectory)) {
+        fs.rmdirSync(targetDirectory);
+    }
 
     const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
     log(`Moving BlazorDebugProxy assets from ${srcDirectory} to ${targetDirectory}...`);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -9,7 +9,6 @@ const extract = require('extract-zip');
 const fs = require('fs');
 const util = require('util');
 const path = require('path');
-const { spawn } = require("child_process");
 const os = require('os');
 
 const finished = util.promisify(stream.finished);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -75,9 +75,10 @@ async function copyDebugProxyAssets(version) {
     if (fs.existsSync(targetDirectory)) {
         fs.rmdirSync(targetDirectory);
     }
+    fs.mkdirSync(targetDirectory);
 
     const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
-    log(`Copying BlazorDebugProxy assets from ${srcDirectory} to bundle...`);
+    log(`Copying BlazorDebugProxy assets from ${srcDirectory} to ${targetDirectory}...`);
     fs.readdirSync(srcDirectory).forEach(function(file) {
         log(`Copying ${file} to target directory...`);
         fs.copyFileSync(path.join(srcDirectory, file), path.join(targetDirectory, file));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -69,7 +69,7 @@ async function copyDebugProxyAssets(version) {
 
     log(`Using ${targetDirectory} as targetDirectory...`);
     log(`Cleaning ${targetDirectory}...`);
-    fs.rmSync(targetDirectory, { recursive: true, force: true });
+    fs.rmdirSync(targetDirectory);
 
     const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
     log(`Moving BlazorDebugProxy assets from ${srcDirectory} to ${targetDirectory}...`);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -77,8 +77,11 @@ async function copyDebugProxyAssets(version) {
     }
 
     const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
-    log(`Moving BlazorDebugProxy assets from ${srcDirectory} to ${targetDirectory}...`);
-    fs.renameSync(srcDirectory, targetDirectory);
+    log(`Copying BlazorDebugProxy assets from ${srcDirectory} to bundle...`);
+    fs.readdirSync(srcDirectory).forEach(function(file) {
+        log(`Copying ${file} to target directory...`);
+        fs.copyFileSync(path.join(srcDirectory, file), path.join(targetDirectory, file));
+    });
 
     fs.writeFileSync(versionMarkerFile, version, { encoding: 'utf-8' });
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -12,15 +12,15 @@ const path = require('path');
 const { spawn } = require("child_process");
 const os = require('os');
 
-var finished = util.promisify(stream.finished);
+const finished = util.promisify(stream.finished);
 
 const formatLog = (text) => `[${new Date()}] ${text}`;
 const log = (text) => console.log(formatLog(text));
 const logError = (text) => console.error(formatLog(text));
 
 async function downloadProxyPackage(version) {
-    var nugetUrl = 'https://api.nuget.org/v3-flatcontainer';
-    var packageName = 'Microsoft.AspNetCore.Components.WebAssembly.DevServer';
+    const nugetUrl = 'https://api.nuget.org/v3-flatcontainer';
+    const packageName = 'Microsoft.AspNetCore.Components.WebAssembly.DevServer';
 
     const tmpDirectory = path.join(os.tmpdir(), 'blazorwasm-companion-tmp');
     if (!fs.existsSync(tmpDirectory)){
@@ -52,7 +52,7 @@ async function downloadProxyPackage(version) {
 }
 
 async function copyDebugProxyAssets(version) {
-    var targetDirectory = path.join(__dirname, '..', 'BlazorDebugProxy');
+    const targetDirectory = path.join(__dirname, '..', 'BlazorDebugProxy');
     const versionMarkerFile = path.join(targetDirectory, '_version');
     if (fs.existsSync(targetDirectory) && fs.existsSync(versionMarkerFile)) {
         const cachedVersion = fs.readFileSync(versionMarkerFile, { encoding: 'utf-8' });
@@ -66,7 +66,7 @@ async function copyDebugProxyAssets(version) {
         log(`No existing BlazorDebugProxy version found, downloading...`);
     }
 
-    var extracted = await downloadProxyPackage(version);
+    const extracted = await downloadProxyPackage(version);
     if (!extracted) {
         return;
     }
@@ -78,10 +78,9 @@ async function copyDebugProxyAssets(version) {
     fs.rmSync(targetDirectory, { recursive: true, force: true });
     fs.mkdirSync(targetDirectory);
 
-    var srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
+    const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
     log(`Looking for installed BlazorDebugProxy in ${srcDirectory}...`);
-    var exists = fs.existsSync(srcDirectory);
-    if (exists) {
+    if (fs.existsSync(srcDirectory)) {
         log(`Copying BlazorDebugProxy assets from ${srcDirectory} to bundle...`);
         fs.readdirSync(srcDirectory).forEach(function(file) {
             log(`Copying ${file} to target directory...`);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -70,14 +70,10 @@ async function copyDebugProxyAssets(version) {
     log(`Using ${targetDirectory} as targetDirectory...`);
     log(`Cleaning ${targetDirectory}...`);
     fs.rmSync(targetDirectory, { recursive: true, force: true });
-    fs.mkdirSync(targetDirectory);
 
     const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
-    log(`Copying BlazorDebugProxy assets from ${srcDirectory} to bundle...`);
-    fs.readdirSync(srcDirectory).forEach(function(file) {
-        log(`Copying ${file} to target directory...`);
-        fs.copyFileSync(path.join(srcDirectory, file), path.join(targetDirectory, file));
-    });
+    log(`Moving BlazorDebugProxy assets from ${srcDirectory} to ${targetDirectory}...`);
+    fs.renameSync(srcDirectory, targetDirectory);
 
     fs.writeFileSync(versionMarkerFile, version, { encoding: 'utf-8' });
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -19,7 +19,7 @@ const logError = (text) => console.error(formatLog(text));
 
 async function downloadProxyPackage(version) {
     const tmpDirectory = path.join(os.tmpdir(), 'blazorwasm-companion-tmp');
-    if (!fs.existsSync(tmpDirectory)){
+    if (!fs.existsSync(tmpDirectory)) {
         fs.mkdirSync(tmpDirectory);
     }
 
@@ -51,31 +51,17 @@ async function downloadProxyPackage(version) {
 }
 
 async function copyDebugProxyAssets(version) {
-    const targetDirectory = path.join(__dirname, '..', 'BlazorDebugProxy');
-    const versionMarkerFile = path.join(targetDirectory, '_version');
-    if (fs.existsSync(targetDirectory) && fs.existsSync(versionMarkerFile)) {
-        const cachedVersion = fs.readFileSync(versionMarkerFile, { encoding: 'utf-8' });
-        if (cachedVersion === version) {
-            log(`Found up-to-date BlazorDebugProxy ${version}, nothing to do.`);
-            return;
-        }
-
-        log(`Cached BlazorDebugProxy ${cachedVersion} is not ${version}, downloading...`);
-    } else {
-        log(`No existing BlazorDebugProxy version found, downloading...`);
+    const targetDirectory = path.join(__dirname, '..', 'BlazorDebugProxy', version);
+    if (fs.existsSync(targetDirectory)) {
+        log(`BlazorDebugProxy ${version} is already downloaded, nothing to do.`);
+        return;
     }
 
+    log(`Downloading BlazorDebugProxy ${version}...`);
     const extracted = await downloadProxyPackage(version);
 
     log(`Using ${targetDirectory} as targetDirectory...`);
-    log(`Cleaning ${targetDirectory}...`);
-
-    // TODO: This can be replaced by fs.rmSync(targetDirectory, { recursive: true, force: true })
-    // on Node 14+. No existsSync check needed.
-    if (fs.existsSync(targetDirectory)) {
-        fs.rmdirSync(targetDirectory);
-    }
-    fs.mkdirSync(targetDirectory);
+    fs.mkdirSync(targetDirectory, { recursive: true });
 
     const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
     log(`Copying BlazorDebugProxy assets from ${srcDirectory} to ${targetDirectory}...`);
@@ -83,8 +69,6 @@ async function copyDebugProxyAssets(version) {
         log(`Copying ${file} to target directory...`);
         fs.copyFileSync(path.join(srcDirectory, file), path.join(targetDirectory, file));
     });
-
-    fs.writeFileSync(versionMarkerFile, version, { encoding: 'utf-8' });
 }
 
 const debugProxyVersion = require('../package.json').debugProxyVersion;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/scripts/retrieveDebugProxy.js
@@ -38,7 +38,7 @@ async function downloadProxyPackage(version) {
 
     if (!response.ok) {
         logError(`Failed to download ${downloadUrl}`);
-        return null;
+        throw new Error(`Unable to download BlazorDebugProxy: ${response.status} ${response.statusText}`);
     }
     const outputStream = fs.createWriteStream(downloadPath);
     response.body.pipe(outputStream);
@@ -66,9 +66,6 @@ async function copyDebugProxyAssets(version) {
     }
 
     const extracted = await downloadProxyPackage(version);
-    if (!extracted) {
-        return;
-    }
 
     fs.rmSync(targetDirectory, { recursive: true, force: true });
 
@@ -78,16 +75,13 @@ async function copyDebugProxyAssets(version) {
     fs.mkdirSync(targetDirectory);
 
     const srcDirectory = path.join(extracted, 'tools', 'BlazorDebugProxy');
-    log(`Looking for installed BlazorDebugProxy in ${srcDirectory}...`);
-    if (fs.existsSync(srcDirectory)) {
-        log(`Copying BlazorDebugProxy assets from ${srcDirectory} to bundle...`);
-        fs.readdirSync(srcDirectory).forEach(function(file) {
-            log(`Copying ${file} to target directory...`);
-            fs.copyFileSync(path.join(srcDirectory, file), path.join(targetDirectory, file));
-        });
+    log(`Copying BlazorDebugProxy assets from ${srcDirectory} to bundle...`);
+    fs.readdirSync(srcDirectory).forEach(function(file) {
+        log(`Copying ${file} to target directory...`);
+        fs.copyFileSync(path.join(srcDirectory, file), path.join(targetDirectory, file));
+    });
 
-        fs.writeFileSync(versionMarkerFile, version, { encoding: 'utf-8' });
-    }
+    fs.writeFileSync(versionMarkerFile, version, { encoding: 'utf-8' });
 }
 
 const debugProxyVersion = require('../package.json').debugProxyVersion;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/src/extension.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { acquireDotnetInstall } from './acquireDotnetInstall';
 import { getAvailablePort } from './getAvailablePort';
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
     const outputChannel = vscode.window.createOutputChannel('Blazor WASM Debug Proxy');
     const pidsByUrl = new Map<string, number>();
 
@@ -17,7 +17,10 @@ export function activate(context: vscode.ExtensionContext) {
             const debuggingPort = await getAvailablePort(9222);
             const debuggingHost = `http://localhost:${debuggingPort}`;
 
-            const debugProxyLocalPath = `${context.extensionPath}/BlazorDebugProxy/BrowserDebugHost.dll`;
+            const extension = vscode.extensions.getExtension('ms-dotnettools.blazorwasm-companion');
+            const version: string = extension?.packageJSON.debugProxyVersion;
+
+            const debugProxyLocalPath = `${context.extensionPath}/BlazorDebugProxy/${version}/BrowserDebugHost.dll`;
             const spawnedProxyArgs = [debugProxyLocalPath , '--DevToolsUrl', debuggingHost];
 
             const dotnet = await acquireDotnetInstall(outputChannel);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/yarn.lock
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/yarn.lock
@@ -77,10 +77,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.1.tgz#88d501e84b6185f6489ecee4ba9e8fcec7f29bb2"
   integrity sha512-NXKvBVUzIbs6ylBwmOwHFkZS2EXCcjnqr8ZCRNaXBkHAf+3mn/rPcJxwrzuc6movh8fxQAsUUfYklJ/EG+hZqQ==
 
-"@types/node@^12.11.7":
-  version "12.20.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.37.tgz#abb38afa9d6e8a2f627a8cb52290b3c80fbe61ed"
-  integrity sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==
+"@types/node@^14.18.12":
+  version "14.18.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.12.tgz#0d4557fd3b94497d793efd4e7d92df2f83b4ef24"
+  integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
 
 "@types/vscode@^1.52.0":
   version "1.63.1"


### PR DESCRIPTION
### Summary of the changes
There's not too many changes overall, so feel free to look at the diff directly. If you want a more detailed breakdown:
- 56c4fba...fe2a54c are the changes that directly address #6020. Everything else is optional and can be rolled back/moved to separate PRs based on feedback.
- 504dd69 adds caching, so that local development doesn't hit the network more than is necessary.
- 504dd69...d6396da (and later on, 047a345 and d283659) is just miscellaneous code cleanup.
- 026aaa1 makes the script fail fast if any part of the download/copy operation fails. This should prevent the script from succeeding even if the download fails - something I think is desirable so that the extension isn't accidentally shipped without a proxy.

There are some more script improvements that can be made if the Node version in CI is updated to a more recent LTS:
- Updating to Node 14 (LTS - 1) adds `fs/promises` for promisified versions of the filesystem API and `fs.rm` for builtin recursive directory removal.
- Updating to Node 16 (active LTS) adds `stream/promises`, removing the need to manually promisify stream.finished.

But I imagine there's extra CI testing and validation that needs to go along with that, so those changes aren't included.

Fixes #6020