### PR TITLE
Bring back VSMac addin assembly attributes

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -10,6 +10,34 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="Mono.Addins.AddinAttribute">
+      <_Parameter1>$(AddinId)</_Parameter1>
+      <Namespace>$(AddinNamespace)</Namespace>
+      <Version>$(AddinMajorVersion)</Version>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinNameAttribute">
+      <_Parameter1>$(AddinDetailedName)</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinCategoryAttribute">
+      <_Parameter1>$(AddinCategory)</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinDescriptionAttribute">
+      <_Parameter1>$(Description)</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinAuthorAttribute">
+      <_Parameter1>$(Authors)</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
+      <_Parameter1>::MonoDevelop.Core</_Parameter1>
+      <_Parameter2>17.0</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
+      <_Parameter1>::MonoDevelop.Ide</_Parameter1>
+      <_Parameter2>17.0</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Properties\_Manifest.addin.xml" LogicalName="_Manifest.addin.xml" />
   </ItemGroup>
 


### PR DESCRIPTION
Turns out these were necessary (esp. the addin, addin name and version)

Without these, we're getting:

```
WARNING: The add-in 'Microsoft.VisualStudio.WebTools.WebEditors,17.0' could not be updated because some of its dependencies are missing or not compatible:
  missing: Microsoft.VisualStudio.Mac.RazorAddin,17.0
```