### PR TITLE
Fix Dependency Tree, Update Dependencies & Consume `TrySplitNamespace` Breaking Change

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,8 +22,6 @@
       <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppRuntimeVersion)</LatestRuntimeFrameworkVersion>
       <!-- Only update the default runtime version for preview builds. -->
       <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRuntimeVersion)</DefaultRuntimeFrameworkVersion>
-      <!-- Only update the targeting pack version for preview builds. -->
-      <TargetingPackVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRefPackageVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
 
     <!-- Remove unneeded reference to AspNetCore.App -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,19 +15,6 @@
     <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Reference base shared framework at incoming dependency flow version, not bundled sdk version. -->
-    <KnownFrameworkReference Update="Microsoft.NETCore.App">
-      <!-- Always update the 'latest version', whether the repo is servicing or not. -->
-      <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppRuntimeVersion)</LatestRuntimeFrameworkVersion>
-      <!-- Only update the default runtime version for preview builds. -->
-      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRuntimeVersion)</DefaultRuntimeFrameworkVersion>
-    </KnownFrameworkReference>
-
-    <!-- Remove unneeded reference to AspNetCore.App -->
-    <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <!-- Global Analyzer Config -->
   <ItemGroup>
     <!-- Always include Common.globalconfig -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -25,14 +25,6 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
     </Dependency>
-    <!--
-      Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
-      All Runtime.$rid packages should have the same version.
-    -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.2">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,14 +31,14 @@
     -->
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
+      <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
     <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
+      <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22103.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,7 +22,7 @@
       <Sha>427991ec87d4df83fdb7a24425c3cce550cf2423</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Razor" Version="6.0.0-alpha.1.21072.5">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>20b6779cf3af2fed6a8fe64a0865cfab50b776bb</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.AspNetCore.Razor.Symbols.Transport" Version="7.0.0-preview.2.22081.4">
+    <Dependency Name="Microsoft.AspNetCore.Razor.Symbols.Transport" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>427991ec87d4df83fdb7a24425c3cce550cf2423</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="7.0.0-preview.2.22081.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>427991ec87d4df83fdb7a24425c3cce550cf2423</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal" Version="7.0.0-preview.2.22081.4">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>427991ec87d4df83fdb7a24425c3cce550cf2423</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Internal.Transport" Version="7.0.0-preview.2.22081.4">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Internal.Transport" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>427991ec87d4df83fdb7a24425c3cce550cf2423</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Internal.Transport" Version="7.0.0-preview.2.22081.4">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Internal.Transport" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>427991ec87d4df83fdb7a24425c3cce550cf2423</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="6.0.0-alpha.1.21072.5">
+    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="7.0.100-preview.2.22115.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>20b6779cf3af2fed6a8fe64a0865cfab50b776bb</Sha>
+      <Sha>aa09e11f1af4d4fc6334a31876e64e658074dbfc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.2.22113.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="6.0.2-servicing.22064.6">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
@@ -37,16 +37,16 @@
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
       All Runtime.$rid packages should have the same version.
     -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.2.22113.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.1" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="7.0.0-preview.2.22113.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22103.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,14 +21,6 @@
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
       <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="7.0.100-preview.2.22115.8">
-      <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>aa09e11f1af4d4fc6334a31876e64e658074dbfc</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.2.22113.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="6.0.2-servicing.22064.6">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
@@ -37,14 +29,14 @@
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
       All Runtime.$rid packages should have the same version.
     -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.2.22113.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.2.22113.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="7.0.0-preview.2.22113.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="7.0.0-preview.2.22113.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -25,7 +25,7 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>20b6779cf3af2fed6a8fe64a0865cfab50b776bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.2" CoherentParentDependency="Microsoft.AspNetCore.Testing">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
     </Dependency>
@@ -37,7 +37,7 @@
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
       All Runtime.$rid packages should have the same version.
     -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.2" CoherentParentDependency="Microsoft.AspNetCore.Testing">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.2" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -44,7 +44,7 @@
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.1">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.1" CoherentParentDependency="Microsoft.NET.Sdk.Razor">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,15 +29,15 @@
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
       All Runtime.$rid packages should have the same version.
     -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.2.22113.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.2">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="7.0.0-preview.2.22113.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.1">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>6e05d78deba320a54ef10a265c6025bbb686efe6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22103.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETSdkRazorPackageVersion>7.0.100-preview.2.22115.8</MicrosoftNETSdkRazorPackageVersion>
+    <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,7 +58,6 @@
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>7.0.100-preview.2.22115.8</MicrosoftNETSdkRazorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,6 @@
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>6.0.1</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--
@@ -101,6 +100,7 @@
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.8.0</MicrosoftBuildPackageVersion>
     <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
+    <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>
     <MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,8 +58,8 @@
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCorePlatformsPackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>6.0.1</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,16 +52,16 @@
 
   -->
   <PropertyGroup Label="Automated">
-    <MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>7.0.0-preview.2.22081.4</MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>
-    <MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>7.0.0-preview.2.22081.4</MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>7.0.0-preview.2.22081.4</MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>7.0.0-preview.2.22081.4</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>7.0.0-preview.2.22081.4</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>
+    <MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>7.0.0-preview.2.22115.3</MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>
+    <MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.2</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.1</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>7.0.0-preview.2.22113.2</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETSdkRazorPackageVersion>7.0.100-preview.2.22115.8</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--
@@ -97,7 +97,6 @@
     <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemResourcesExtensionsPackageVersion>6.0.0</SystemResourcesExtensionsPackageVersion>
     <SystemTextEncodingsWebPackageVersion>6.0.0</SystemTextEncodingsWebPackageVersion>
-
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <BenchmarkDotNetPackageVersion>0.12.1.1466</BenchmarkDotNetPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,15 +58,7 @@
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>6.0.1</MicrosoftNETCorePlatformsPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Label="Dependency version settings">
-    <!--
-      Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
-      All Runtime.$rid packages should have the same version.
-    -->
-    <MicrosoftNETCoreAppRuntimeVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimeVersion>
   </PropertyGroup>
   <!--
 
@@ -99,7 +91,6 @@
     <BenchmarkDotNetPackageVersion>0.12.1.1466</BenchmarkDotNetPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.8.0</MicrosoftBuildPackageVersion>
-    <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100",
+    "dotnet": "6.0.102",
     "runtimes": {
       "dotnet": [
         "2.1.11",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             @namespace = StringSegment.Empty;
             typeName = StringSegment.Empty;
 
-            if (fullTypeName.IsEmpty)
+            if (fullTypeName.IsEmpty || string.IsNullOrEmpty(fullTypeName.Buffer))
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
@@ -19,10 +19,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         // Internal for testing
         internal static string GetNamespaceFromFQN(string fullyQualifiedName)
         {
-            if (!DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(
-                    fullyQualifiedName,
-                    out var namespaceName,
-                    out _))
+            if (!TrySplitNamespaceAndType(fullyQualifiedName, out var namespaceName, out _))
             {
                 return string.Empty;
             }
@@ -80,6 +77,53 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             }
 
             @namespace = regexMatchedTextEdit.Groups[1].Value;
+            return true;
+        }
+
+        internal static bool TrySplitNamespaceAndType(StringSegment fullTypeName, out StringSegment @namespace, out StringSegment typeName)
+        {
+            @namespace = StringSegment.Empty;
+            typeName = StringSegment.Empty;
+
+            if (fullTypeName.IsEmpty)
+            {
+                return false;
+            }
+
+            var nestingLevel = 0;
+            var splitLocation = -1;
+            for (var i = fullTypeName.Length - 1; i >= 0; i--)
+            {
+                var c = fullTypeName[i];
+                if (c == Type.Delimiter && nestingLevel == 0)
+                {
+                    splitLocation = i;
+                    break;
+                }
+                else if (c == '>')
+                {
+                    nestingLevel++;
+                }
+                else if (c == '<')
+                {
+                    nestingLevel--;
+                }
+            }
+
+            if (splitLocation == -1)
+            {
+                typeName = fullTypeName;
+                return true;
+            }
+
+            @namespace = fullTypeName.Subsegment(0, splitLocation);
+
+            var typeNameStartLocation = splitLocation + 1;
+            if (typeNameStartLocation < fullTypeName.Length)
+            {
+                typeName = fullTypeName.Subsegment(typeNameStartLocation, fullTypeName.Length - typeNameStartLocation);
+            }
+
             return true;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -54,7 +54,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(tagHelper));
             }
 
-            if (!DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(tagHelper.Name, out var @namespaceName, out var typeName))
+            var typeName = tagHelper.GetTypeNameIdentifier();
+            var namespaceName = tagHelper.GetTypeNamespace();
+            if (typeName == null || namespaceName == null)
             {
                 _logger.LogWarning($"Could not split namespace and type for name {tagHelper.Name}.");
                 return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -243,7 +243,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 if (originTagHelper?.IsComponentFullyQualifiedNameMatch() == true)
                 {
                     // Fully qualified binding, our "new name" needs to be fully qualified.
-                    if (!DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(originTagHelper.Name, out var @namespace, out _))
+                    var @namespace = originTagHelper.GetTypeNamespace();
+                    if (@namespace == null)
                     {
                         return;
                     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -131,6 +131,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
             var fullyQualifiedName = $"{namespaceName}.{typeName}";
             var builder1 = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             builder1.TagMatchingRule(rule => rule.TagName = tagName);
+            builder1.SetTypeNameIdentifier(typeName);
+            builder1.SetTypeNamespace(namespaceName);
             return builder1.Build();
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapFromProjectedDocumentPosition)} should have returned true");
             }
         }
 
@@ -526,7 +526,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapFromProjectedDocumentPosition)} should have returned true");
             }
         }
 
@@ -556,7 +556,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapFromProjectedDocumentPosition)} should have returned true");
             }
         }
 
@@ -587,7 +587,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapToProjectedDocumentRange} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapToProjectedDocumentRange)} should have returned true");
             }
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -381,11 +381,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             builder.TagMatchingRule(rule => rule.TagName = tagName);
             builder.SetTypeName(fullyQualifiedName);
+            builder.SetTypeNameIdentifier(tagName);
+            builder.SetTypeNamespace(namespaceName);
             yield return builder.Build();
 
             var fullyQualifiedBuilder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             fullyQualifiedBuilder.TagMatchingRule(rule => rule.TagName = fullyQualifiedName);
             fullyQualifiedBuilder.SetTypeName(fullyQualifiedName);
+            builder.SetTypeNameIdentifier(tagName);
+            builder.SetTypeNamespace(namespaceName);
             fullyQualifiedBuilder.AddMetadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
             yield return fullyQualifiedBuilder.Build();
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -388,8 +388,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var fullyQualifiedBuilder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             fullyQualifiedBuilder.TagMatchingRule(rule => rule.TagName = fullyQualifiedName);
             fullyQualifiedBuilder.SetTypeName(fullyQualifiedName);
-            builder.SetTypeNameIdentifier(tagName);
-            builder.SetTypeNamespace(namespaceName);
+            fullyQualifiedBuilder.SetTypeNameIdentifier(tagName);
+            fullyQualifiedBuilder.SetTypeNamespace(namespaceName);
             fullyQualifiedBuilder.AddMetadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
             yield return fullyQualifiedBuilder.Build();
         }

--- a/src/Razor/test/testapps/Directory.Build.targets
+++ b/src/Razor/test/testapps/Directory.Build.targets
@@ -1,9 +1,3 @@
 <Project>
   <Import Project="RazorTest.Introspection.targets" />
-
-  <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' ">$(MicrosoftNETCoreApp50PackageVersion)</RuntimeFrameworkVersion>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
@wtgodbe pointed out that `Microsoft.AspNetCore.Testing` isn't actually a dependency here, which is causing issues with the darc subscription.
