### PR TITLE
Fix NRE at completion time on incomplete elements.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -367,12 +367,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
                 RazorSyntaxNode? endTag = null;
                 if (node is MarkupTagHelperElementSyntax parentTagHelper)
                 {
-                    potentialStartTagName = parentTagHelper.StartTag.Name.Content;
+                    potentialStartTagName = parentTagHelper.StartTag?.Name.Content ?? parentTagHelper.EndTag?.Name.Content;
                     endTag = parentTagHelper.EndTag;
                 }
                 else if (node is MarkupElementSyntax parentElement)
                 {
-                    potentialStartTagName = parentElement.StartTag.Name.Content;
+                    potentialStartTagName = parentElement.StartTag?.Name.Content ?? parentElement.EndTag?.Name.Content;
                     endTag = parentElement.EndTag;
                 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -166,11 +166,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             string parentTagName = null;
             if (startTag.Parent?.Parent is MarkupElementSyntax parentElement)
             {
-                parentTagName = parentElement.StartTag.Name.Content;
+                parentTagName = parentElement.StartTag?.Name.Content ?? parentElement.EndTag?.Name.Content;
             }
             else if (startTag.Parent?.Parent is MarkupTagHelperElementSyntax parentTagHelperElement)
             {
-                parentTagName = parentTagHelperElement.StartTag.Name.Content;
+                parentTagName = parentTagHelperElement.StartTag?.Name.Content ?? parentTagHelperElement.EndTag?.Name.Content;
             }
 
             var attributes = _tagHelperFactsService.StringifyAttributes(startTag.Attributes).ToList();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 }
 
                 var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>(
-                    n => n.StartTag.Name.Content.Equals("style", StringComparison.Ordinal));
+                    n => n.StartTag?.Name.Content.Equals("style", StringComparison.Ordinal) == true);
                 var cSharp = owner.FirstAncestorOrSelf<CSharpCodeBlockSyntax>();
 
                 return element.Body.Any(c => c is CSharpCodeBlockSyntax) || cSharp is not null;
@@ -291,13 +291,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
                 var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
 
-                if (!element.StartTag.Name.Content.Equals("html", StringComparison.Ordinal))
+                if (element.StartTag?.Name.Content.Equals("html", StringComparison.Ordinal) != true)
                 {
                     return false;
                 }
 
-                var bodyElement = (MarkupElementSyntax)element.ChildNodes().SingleOrDefault(c => c is MarkupElementSyntax tag && tag.StartTag.Name.Content.Equals("body", StringComparison.Ordinal));
-                return bodyElement is not null && bodyElement.StartTag.Bang is not null;
+                var bodyElement = (MarkupElementSyntax)element.ChildNodes().SingleOrDefault(c => c is MarkupElementSyntax tag && tag.StartTag?.Name.Content.Equals("body", StringComparison.Ordinal) == true);
+                return bodyElement is not null && bodyElement.StartTag?.Bang is not null;
             }
 
             // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                     return false;
                 }
 
-                var body = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag.Name.Content.Equals("body", StringComparison.Ordinal));
+                var body = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content.Equals("body", StringComparison.Ordinal) == true);
 
                 if (ReferenceEquals(body, owner))
                 {
@@ -367,7 +367,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                     return false;
                 }
 
-                return d.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag.Bang != null;
+                return d.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag?.Bang != null;
             }
         }
 #nullable disable

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     return true;
                 case MarkupEndTagSyntax { Parent: MarkupElementSyntax parent } endTag:
                     containingTagNameToken = endTag.Name;
-                    attributeNodes = parent.StartTag.Attributes;
+                    attributeNodes = parent.StartTag?.Attributes ?? new SyntaxList<RazorSyntaxNode>();
                     return true;
                 case MarkupTagHelperStartTagSyntax startTagHelper:
                     containingTagNameToken = startTagHelper.Name;
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     return true;
                 case MarkupTagHelperEndTagSyntax { Parent: MarkupTagHelperElementSyntax parent } endTagHelper:
                     containingTagNameToken = endTagHelper.Name;
-                    attributeNodes = parent.StartTag.Attributes;
+                    attributeNodes = parent.StartTag?.Attributes ?? new SyntaxList<RazorSyntaxNode>();
                     return true;
                 default:
                     containingTagNameToken = null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -127,6 +127,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void GetCompletionAt_MalformedElement()
+        {
+            // Arrange
+            var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}</t", DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(32 + Environment.NewLine.Length, 0);
+            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+
+            // Act
+            var completions = service.GetCompletionItems(context, sourceSpan);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("test1", completion.InsertText);
+                },
+                completion =>
+                {
+                    Assert.Equal("test2", completion.InsertText);
+                });
+        }
+
+        [Fact]
         public void GetCompletionAt_AtHtmlElementNameEdge_ReturnsNoCompletions()
         {
             // Arrange


### PR DESCRIPTION
- The gist of this changeset is that we should never expect an element syntax to have a `StartTag` (whether it's an HTML or TagHelper element). Reason being is that the compiler wraps incomplete tags like `</div>` in its own HTML element which means start tags are `null`.
- Added a test for this scenario and went through all of our `StartTag` access and added protections across the board.

Fixes #6096