### PR TITLE
Port #6088 to vsmac/17.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,21 +15,6 @@
     <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Reference base shared framework at incoming dependency flow version, not bundled sdk version. -->
-    <KnownFrameworkReference Update="Microsoft.NETCore.App">
-      <!-- Always update the 'latest version', whether the repo is servicing or not. -->
-      <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppRuntimeVersion)</LatestRuntimeFrameworkVersion>
-      <!-- Only update the default runtime version for preview builds. -->
-      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRuntimeVersion)</DefaultRuntimeFrameworkVersion>
-      <!-- Only update the targeting pack version for preview builds. -->
-      <TargetingPackVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppRefPackageVersion)</TargetingPackVersion>
-    </KnownFrameworkReference>
-
-    <!-- Remove unneeded reference to AspNetCore.App -->
-    <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <!-- Global Analyzer Config -->
   <ItemGroup>
     <!-- Always include Common.globalconfig -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -10,6 +10,8 @@
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,45 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.AspNetCore.Razor.Symbols.Transport" Version="6.0.2-1.22053.2">
+    <Dependency Name="Microsoft.AspNetCore.Razor.Symbols.Transport" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>f37ce7d93a7858b3775daa8e8773dd2fe79560fc</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="6.0.2-1.22053.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>f37ce7d93a7858b3775daa8e8773dd2fe79560fc</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Testing" Version="6.0.2-servicing.22054.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>21bdd57f266ecda1ed28ac4a2aaf1ecefc0da040</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal" Version="6.0.2-1.22053.2">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>f37ce7d93a7858b3775daa8e8773dd2fe79560fc</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Internal.Transport" Version="6.0.2-1.22053.2">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Internal.Transport" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>f37ce7d93a7858b3775daa8e8773dd2fe79560fc</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Internal.Transport" Version="6.0.2-1.22053.2">
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.Internal.Transport" Version="7.0.0-preview.2.22115.3">
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
-      <Sha>f37ce7d93a7858b3775daa8e8773dd2fe79560fc</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="6.0.0-alpha.1.21072.5">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>20b6779cf3af2fed6a8fe64a0865cfab50b776bb</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+      <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
     <Dependency Name="System.Resources.Extensions" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.Testing">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -53,19 +33,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.1" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="6.0.1-servicing.21567.5" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
-    </Dependency>
-    <!--
-      Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
-      All Runtime.$rid packages should have the same version.
-    -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.1" CoherentParentDependency="Microsoft.AspNetCore.Testing">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,7 +21,7 @@
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
       <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="6.0.1-servicing.21567.5">
+    <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="6.0.2-servicing.22064.6">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,26 +21,14 @@
       <Uri>https://github.com/dotnet/razor-compiler</Uri>
       <Sha>ca1728b83851de4211477ab37a2460bf567544d3</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.Testing">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="6.0.1-servicing.21567.5" CoherentParentDependency="Microsoft.AspNetCore.Testing">
+    <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="6.0.1-servicing.21567.5">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.1" CoherentParentDependency="Microsoft.AspNetCore.Testing">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -104,6 +104,7 @@
     <MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion>$(VisualStudioLanguageServerProtocolVersion)</MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion>
     <MicrosoftVisualStudioLiveSharePackageVersion>0.3.1074</MicrosoftVisualStudioLiveSharePackageVersion>
     <MicrosoftVisualStudioProjectSystemSDKPackageVersion>16.10.81-pre</MicrosoftVisualStudioProjectSystemSDKPackageVersion>
+    <MicrosoftVisualStudioRpcContractsVersion>17.0.50-preview-0001-0001</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualStudioShell150PackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShell150PackageVersion>
     <MicrosoftVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropPackageVersion>
     <MicrosoftVisualStudioTextDataPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextDataPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -142,6 +142,7 @@
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitCombinatorialPackageVersion>1.4.1</XunitCombinatorialPackageVersion>
     <XunitVersion>2.4.1</XunitVersion>
+    <XunitExtensibilityExecutionPackageVersion>$(XunitVersion)</XunitExtensibilityExecutionPackageVersion>
     <!-- Temporary hack to workaround package restrictions for dev17 -->
     <MicrosoftInternalVisualStudioShellFrameworkPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkPackageVersion>
     <MicrosoftIORedistPackageVersion>4.7.1</MicrosoftIORedistPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -126,6 +126,7 @@
     <OmniSharpExtensionsLanguageProtocolPackageVersion>$(OmniSharpExtensionsLanguageServerPackageVersion)</OmniSharpExtensionsLanguageProtocolPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.37.13</OmniSharpMSBuildPackageVersion>
     <StreamJsonRpcPackageVersion>2.8.28</StreamJsonRpcPackageVersion>
+    <SystemRuntimeInteropServicesRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimePackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.2</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>6.0.0-preview3.21158.1</Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
     -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
+    <DefaultNetCoreTargetFramework>net6.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
   <!--
     Versioning for tooling releases.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,30 +51,13 @@
 
   -->
   <PropertyGroup Label="Automated">
-    <MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>6.0.2-1.22053.2</MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>
-    <MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>6.0.2-1.22053.2</MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>6.0.2-servicing.22054.4</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>6.0.2-1.22053.2</MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>6.0.2-1.22053.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>6.0.2-1.22053.2</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>6.0.0</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>6.0.0</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.1-servicing.21567.5</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.1</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>7.0.0-preview.2.22115.3</MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>
+    <MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XInternalTransportPackageVersion>
+    <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>7.0.0-preview.2.22115.3</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XInternalTransportPackageVersion>
+    <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>6.0.1</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemResourcesExtensionsPackageVersion>6.0.0</SystemResourcesExtensionsPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>6.0.0</SystemTextEncodingsWebPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Label="Dependency version settings">
-    <!--
-      Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
-      All Runtime.$rid packages should have the same version.
-    -->
-    <MicrosoftNETCoreAppRuntimeVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimeVersion>
   </PropertyGroup>
   <!--
 
@@ -96,11 +79,18 @@
     <VisualStudioLanguageServerProtocolVersion>17.1.2</VisualStudioLanguageServerProtocolVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
+    <!-- dotnet/runtime packages -->
+    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>6.0.0</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>6.0.0</MicrosoftExtensionsLoggingPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemResourcesExtensionsPackageVersion>6.0.0</SystemResourcesExtensionsPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>6.0.0</SystemTextEncodingsWebPackageVersion>
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
     <BenchmarkDotNetPackageVersion>0.12.1.1466</BenchmarkDotNetPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.8.0</MicrosoftBuildPackageVersion>
-    <MicrosoftNETCoreApp50PackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreApp50PackageVersion>
+    <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>
     <MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,6 +26,7 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <DefaultNetCoreTargetFramework>net6.0</DefaultNetCoreTargetFramework>
+    <DefaultNetCoreWindowsTargetFramework>net6.0-windows</DefaultNetCoreWindowsTargetFramework>
   </PropertyGroup>
   <!--
     Versioning for tooling releases.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100",
+    "dotnet": "6.0.102",
     "runtimes": {
       "dotnet": [
         "2.1.11",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderFactory.cs
@@ -20,10 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         // Internal for testing
         internal static string GetNamespaceFromFQN(string fullyQualifiedName)
         {
-            if (!DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(
-                    fullyQualifiedName,
-                    out var namespaceName,
-                    out _))
+            if (!TrySplitNamespaceAndType(fullyQualifiedName, out var namespaceName, out _))
             {
                 return string.Empty;
             }
@@ -83,6 +80,53 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             }
 
             @namespace = regexMatchedTextEdit.Groups[1].Value;
+            return true;
+        }
+
+        internal static bool TrySplitNamespaceAndType(StringSegment fullTypeName, out StringSegment @namespace, out StringSegment typeName)
+        {
+            @namespace = StringSegment.Empty;
+            typeName = StringSegment.Empty;
+
+            if (fullTypeName.IsEmpty || string.IsNullOrEmpty(fullTypeName.Buffer))
+            {
+                return false;
+            }
+
+            var nestingLevel = 0;
+            var splitLocation = -1;
+            for (var i = fullTypeName.Length - 1; i >= 0; i--)
+            {
+                var c = fullTypeName[i];
+                if (c == Type.Delimiter && nestingLevel == 0)
+                {
+                    splitLocation = i;
+                    break;
+                }
+                else if (c == '>')
+                {
+                    nestingLevel++;
+                }
+                else if (c == '<')
+                {
+                    nestingLevel--;
+                }
+            }
+
+            if (splitLocation == -1)
+            {
+                typeName = fullTypeName;
+                return true;
+            }
+
+            @namespace = fullTypeName.Subsegment(0, splitLocation);
+
+            var typeNameStartLocation = splitLocation + 1;
+            if (typeNameStartLocation < fullTypeName.Length)
+            {
+                typeName = fullTypeName.Subsegment(typeNameStartLocation, fullTypeName.Length - typeNameStartLocation);
+            }
+
             return true;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -54,7 +54,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new ArgumentNullException(nameof(tagHelper));
             }
 
-            if (!DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(tagHelper.Name, out var @namespaceName, out var typeName))
+            var typeName = tagHelper.GetTypeNameIdentifier();
+            var namespaceName = tagHelper.GetTypeNamespace();
+            if (typeName == null || namespaceName == null)
             {
                 _logger.LogWarning($"Could not split namespace and type for name {tagHelper.Name}.");
                 return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RazorComponentRenameEndpoint.cs
@@ -243,7 +243,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 if (originTagHelper?.IsComponentFullyQualifiedNameMatch() == true)
                 {
                     // Fully qualified binding, our "new name" needs to be fully qualified.
-                    if (!DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(originTagHelper.Name, out var @namespace, out _))
+                    var @namespace = originTagHelper.GetTypeNamespace();
+                    if (@namespace == null)
                     {
                         return;
                     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="$(Tooling_MicrosoftCodeAnalysisRemoteServiceHubPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
     <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" Version="$(MicrosoftVisualStudioRpcContractsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
@@ -10,36 +10,36 @@ using Microsoft.VisualStudio.Shell;
     GenerateCodeBase = true,
     PublicKeyToken = "adb9793829ddae60",
     OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "6.0.2.0",
-    NewVersion = "6.0.2.0")]
+    OldVersionUpperBound = "7.0.0.0",
+    NewVersion = "7.0.0.0")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X",
     GenerateCodeBase = true,
     PublicKeyToken = "adb9793829ddae60",
     OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "6.0.2.0",
-    NewVersion = "6.0.2.0")]
+    OldVersionUpperBound = "7.0.0.0",
+    NewVersion = "7.0.0.0")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X",
     GenerateCodeBase = true,
     PublicKeyToken = "adb9793829ddae60",
     OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "6.0.2.0",
-    NewVersion = "6.0.2.0")]
+    OldVersionUpperBound = "7.0.0.0",
+    NewVersion = "7.0.0.0")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.AspNetCore.Razor.Language",
     GenerateCodeBase = true,
     PublicKeyToken = "adb9793829ddae60",
     OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "6.0.2.0",
-    NewVersion = "6.0.2.0")]
+    OldVersionUpperBound = "7.0.0.0",
+    NewVersion = "7.0.0.0")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.Razor",
     GenerateCodeBase = true,
     PublicKeyToken = "adb9793829ddae60",
     OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "6.0.2.0",
-    NewVersion = "6.0.2.0")]
+    OldVersionUpperBound = "7.0.0.0",
+    NewVersion = "7.0.0.0")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.Extensions.Configuration.Abstractions",
     GenerateCodeBase = true,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -3,15 +3,13 @@
 
 #nullable disable
 
-using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
     public class FilePathNormalizerTest
     {
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Test only valid on Windows boxes")]
+        [OSSkipConditionFact(new[] { "OSX", "Linux" })]
         public void Normalize_Windows_StripsPrecedingSlash()
         {
             // Arrange
@@ -151,8 +149,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             Assert.Equal("/", normalized);
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Test only valid on non-Windows boxes")]
+
+        [OSSkipConditionFact(new[] { "Windows" })]
         public void Normalize_NonWindows_AddsLeadingForwardSlash()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="..\OSSkipConditionFactAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultProjectResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultProjectResolverTest.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Moq;
 using Xunit;
@@ -158,8 +157,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             Assert.Same(ownerProject, project);
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "Linux/Mac have case sensitive file comparers.")]
+        [OSSkipConditionFact(new[] { "OSX", "Linux" })]
         public void TryResolveProject_OwnerProjectDifferentCasing_ReturnsTrue()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -131,6 +131,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
             var fullyQualifiedName = $"{namespaceName}.{typeName}";
             var builder1 = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             builder1.TagMatchingRule(rule => rule.TagName = tagName);
+            builder1.SetTypeNameIdentifier(typeName);
+            builder1.SetTypeNamespace(namespaceName);
             return builder1.Build();
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapFromProjectedDocumentPosition)} should have returned true");
             }
         }
 
@@ -526,7 +526,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapFromProjectedDocumentPosition)} should have returned true");
             }
         }
 
@@ -556,7 +556,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapFromProjectedDocumentPosition} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapFromProjectedDocumentPosition)} should have returned true");
             }
         }
 
@@ -587,7 +587,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapToProjectedDocumentRange} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapToProjectedDocumentRange)} should have returned true");
             }
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else
             {
-                Assert.False(true, $"{service.TryMapToProjectedDocumentPosition} should have returned true");
+                Assert.False(true, $"{nameof(service.TryMapToProjectedDocumentPosition)} should have returned true");
             }
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -393,7 +393,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             using var streamReader = new StreamReader(stream);
             using var reader = new JsonTextReader(streamReader);
 
-            return serializer.Deserialize<IReadOnlyList<TagHelperDescriptor>>(reader);
+            return serializer.Deserialize<IReadOnlyList<TagHelperDescriptor>>(reader)!;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreWindowsTargetFramework)</TargetFrameworks>
 
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
@@ -25,6 +25,19 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Web" Version="$(MicrosoftVisualStudioWebPackageVersion)" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.WebTools.Shared" Version="$(MicrosoftWebToolsSharedPackageVersion)" NoWarn="NU1701" />
+
+    <!--
+        Nuget changed behaviour and now validates transitive references, so the NU1701 suppressions above don't affect those
+        packages dependencies. We reference them here directly in order to do so, and set ExcludeAssets and PrivateAssets so
+        the references have no other affect on build etc.
+    -->
+    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioShellPackagesVersion)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioPackagesVersion)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Internal" Version="$(MicrosoftVisualStudioPackagesVersion)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioPackagesVersion)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.WebTools.Languages.Css" Version="$(MicrosoftWebToolsLanguagesHtmlPackageVersion)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.WebTools.Languages.Css.Editor" Version="$(MicrosoftWebToolsLanguagesHtmlPackageVersion)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.WebTools.Languages.Html.Editor" Version="$(MicrosoftWebToolsLanguagesHtmlPackageVersion)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <None Include="..\test.taghelpers.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="..\OSSkipConditionFactAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RazorComponentRenameEndpointTest.cs
@@ -381,11 +381,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             builder.TagMatchingRule(rule => rule.TagName = tagName);
             builder.SetTypeName(fullyQualifiedName);
+            builder.SetTypeNameIdentifier(tagName);
+            builder.SetTypeNamespace(namespaceName);
             yield return builder.Build();
 
             var fullyQualifiedBuilder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, fullyQualifiedName, assemblyName);
             fullyQualifiedBuilder.TagMatchingRule(rule => rule.TagName = fullyQualifiedName);
             fullyQualifiedBuilder.SetTypeName(fullyQualifiedName);
+            fullyQualifiedBuilder.SetTypeNameIdentifier(tagName);
+            fullyQualifiedBuilder.SetTypeNamespace(namespaceName);
             fullyQualifiedBuilder.AddMetadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
             yield return fullyQualifiedBuilder.Build();
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(Tooling_MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="$(MicrosoftCodeAnalysisRazorToolingInternalPackageVersion)" />
@@ -23,6 +22,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationPackageVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XunitExtensibilityExecutionPackageVersion)" />
     <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialPackageVersion)" />
   </ItemGroup>
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\test.taghelpers.json" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="..\OSSkipConditionFactAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +21,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(Tooling_MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
@@ -4,15 +4,14 @@
 #nullable disable
 
 using System;
-using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Razor;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
     public class UriExtensionsTest
     {
-        [Fact]
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Test only valid on Windows boxes")]
+        [OSSkipConditionFact(new[] { "OSX", "Linux" })]
         public void GetAbsoluteOrUNCPath_ReturnsAbsolutePath()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Microsoft.VisualStudio.LiveShare.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Microsoft.VisualStudio.LiveShare.Razor.Test.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
   </ItemGroup>
 

--- a/src/Razor/test/OSSkipConditionFactAttribute.cs
+++ b/src/Razor/test/OSSkipConditionFactAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor;
+
+public class OSSkipConditionFactAttribute : FactAttribute
+{
+    /// <summary>
+    /// A <see cref="FactAttribute"/> that configures <see cref="FactAttribute.Skip"/> on the specified platforms.
+    /// </summary>
+    /// <param name="skippedPlatforms">Valid values include <c>WINDOWS</c>, <c>LINUX</c>, <c>OSX</c>, and <c>FREEBSD</c>.
+    /// <see href="https://source.dot.net/#System.Runtime.InteropServices.RuntimeInformation/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs,26fa53454c093915"/></param>
+    public OSSkipConditionFactAttribute(string[] skippedPlatforms)
+    {
+        foreach (var platform in skippedPlatforms)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create(platform)))
+            {
+                Skip = $"Ignored on {platform}";
+                break;
+            }
+        }
+    }
+}

--- a/src/Razor/test/testapps/Directory.Build.targets
+++ b/src/Razor/test/testapps/Directory.Build.targets
@@ -1,9 +1,3 @@
 <Project>
   <Import Project="RazorTest.Introspection.targets" />
-
-  <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' ">$(MicrosoftNETCoreApp50PackageVersion)</RuntimeFrameworkVersion>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Cherry picking https://github.com/dotnet/razor-tooling/commit/6ecc0084ef43e7d8c26cd077798133f05d9fc3bc from https://github.com/dotnet/razor-tooling/pull/6088 to vsmac/17.0

/cc @KirillOsenkov and @TanayParikh to check if this is expected - this is bumping a lot of stuff to 7.0. Are we sure the compiler fix shouldn't have been a 6.0.2 servicing??