### PR TITLE
Preemptively compute ParsedTypeDescriptor to avoid issues caused by concurrent invocations

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -607,6 +607,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
             public VisualStudioTagHelperFeature(IReadOnlyList<TagHelperDescriptor> tagHelpers)
             {
                 _tagHelpers = tagHelpers;
+                foreach (var tagHelper in tagHelpers)
+                {
+                    DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(tagHelper, out _);
+                }
             }
 
             public RazorEngine Engine { get; set; }


### PR DESCRIPTION
Precomputes taghelper ParsedTypeInfo to avoid issues caused by concurrent invocations.