### PR TITLE
Add back polyfill for razor compiler bug

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -32,6 +32,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 .Concat(s_razorTriggerCharacters))
             .ToArray();
 
+        private static readonly IReadOnlyCollection<string> s_keywords = new string[] {
+            "for", "foreach", "while", "switch", "lock",
+            "case", "if", "try", "do", "using"
+        };
+
         private static readonly IReadOnlyCollection<string> s_designTimeHelpers = new string[]
         {
             "__builder",
@@ -43,6 +48,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             "_Imports",
             "BuildRenderTree"
         };
+
+        private static readonly IReadOnlyCollection<CompletionItem> s_keywordCompletionItems = GenerateCompletionItems(s_keywords);
 
         private static readonly IReadOnlyCollection<CompletionItem> s_designTimeHelpersCompletionItems = GenerateCompletionItems(s_designTimeHelpers);
 
@@ -153,6 +160,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(false);
             if (projectionResult is null)
             {
+                if (IsRazorCompilerBugWithCSharpKeywords(request, wordExtent.Value))
+                {
+                    var csharpPolyfilledCompletionList = new CompletionList()
+                    {
+                        Items = Array.Empty<CompletionItem>(),
+                        IsIncomplete = true,
+                    };
+                    csharpPolyfilledCompletionList = IncludeCSharpKeywords(csharpPolyfilledCompletionList);
+                    return csharpPolyfilledCompletionList;
+                }
+
                 return null;
             }
 
@@ -266,6 +284,62 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
                 return true;
             }
+        }
+
+        // Internal for testing
+        internal static bool IsRazorCompilerBugWithCSharpKeywords(CompletionParams request, TextExtent wordExtent)
+        {
+            // This was originally found when users would attempt to type out `@using` in an _Imports.razor file and get 0 completion items at the `g` of `using`.
+            // After lots of investigation it turns out that the Razor compiler will generate 0 C# source for an incomplete using directive. This in turn results
+            // in 0 C# information at `@using|`. This is tracked here: https://github.com/dotnet/aspnetcore/issues/37568
+            //
+            // The entire purpose of this method is to encapsulate this compiler bug and try and make users experiences a little better in a low-risk fashion.
+            return request.Context!.TriggerKind == CompletionTriggerKind.TriggerForIncompleteCompletions &&
+                WordSpanMatchesCSharpPolyfills(wordExtent);
+        }
+
+        private static bool WordSpanMatchesCSharpPolyfills(TextExtent? wordExtent)
+        {
+            if (wordExtent is null || !wordExtent.Value.IsSignificant)
+            {
+                return false;
+            }
+
+            var wordSpan = wordExtent.Value.Span;
+
+            foreach (var keyword in s_keywords)
+            {
+                if (wordSpan.Length != keyword.Length)
+                {
+                    // Word can't match, different length
+                    continue;
+                }
+
+                var allCharactersMatch = true;
+                for (var j = 0; j < keyword.Length; j++)
+                {
+                    var wordSpanIndex = wordSpan.Start.Position + j;
+                    if (wordSpanIndex >= wordSpan.Snapshot.Length)
+                    {
+                        // Don't think this is technically possible but being extra cautious to stay low-risk.
+                        break;
+                    }
+
+                    var wordCharacter = wordSpan.Snapshot[wordSpanIndex];
+                    if (keyword[j] != wordCharacter)
+                    {
+                        allCharactersMatch = false;
+                        break;
+                    }
+                }
+
+                if (allCharactersMatch)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool TryGetWordExtent(CompletionParams request, LSPDocumentSnapshot documentSnapshot, [NotNullWhen(true)] out TextExtent? wordExtent)
@@ -658,6 +732,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 item.Preselect = false;
             }
+
+            return completionList;
+        }
+
+        // C# keywords were previously provided by snippets, but as of now C# LSP doesn't provide snippets.
+        // We're providing these for now to improve the user experience (not having to ESC out of completions to finish),
+        // but once C# starts providing them their completion will be offered instead, at which point we should be able to remove this step.
+        private static CompletionList IncludeCSharpKeywords(CompletionList completionList)
+        {
+            var newList = completionList.Items.Union(s_keywordCompletionItems, CompletionItemComparer.Instance);
+            completionList.Items = newList.ToArray();
 
             return completionList;
         }


### PR DESCRIPTION
### Summary of the changes
 - This was removed in https://github.com/dotnet/razor-tooling/pull/6012/files#diff-052d5834149367e2bcf4d95d0740ddb4b346116cfcd64e568d0b5eca38f7b8aeL162 as we thought it was not necessary.  However this bug in the razor compiler still exists and results in C# not getting called for completions on the "g"

See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1485481

This is just the old code pasted back in with no changes.

Fixes: 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1485481
