### PR TITLE
Attribute snippet

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
@@ -25,8 +25,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             data[ResultIdKey] = resultId;
             completionItem = completionItem with { Data = data };
 
-            var result = completionItem.ToVSCompletionItem();
-            return result;
+            return completionItem;
         }
 
         public static bool TryGetCompletionListResultId(this CompletionItem completion, [NotNullWhen(true)] out int? resultId)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -30,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             return result;
         }
 
-        public static bool TryGetCompletionListResultId(this CompletionItem completion, out int resultId)
+        public static bool TryGetCompletionListResultId(this CompletionItem completion, [NotNullWhen(true)] out int? resultId)
         {
             if (completion is null)
             {
@@ -39,8 +38,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             if (completion.Data is JObject data && data.ContainsKey(ResultIdKey))
             {
-                resultId = data[ResultIdKey].ToObject<int>();
-                return true;
+                resultId = data[ResultIdKey]?.ToObject<int>();
+                return resultId is not null;
             }
 
             resultId = default;
@@ -76,8 +75,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 TextEdit = completion.TextEdit,
                 VsCommitCharacters = vsCommitCharacters,
             };
-#nullable enable
-            static IEnumerable<CommitCharacter>? GetVSCommitCharacters(CompletionItem completion)
+
+            static IEnumerable<VSCommitCharacter> GetVSCommitCharacters(CompletionItem completion)
             {
                 if (completion.CommitCharacters is null)
                 {
@@ -86,14 +85,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
                 foreach (var commitCharacter in completion.CommitCharacters)
                 {
-                    yield return new CommitCharacter
+                    yield return new VSCommitCharacter
                     {
                         Character = commitCharacter,
                         Insert = completion.InsertTextFormat != InsertTextFormat.Snippet,
                     };
                 }
             }
-#nullable disable
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             return false;
         }
 
-        public static VSCompletionItem ToVSCompletionItem(this CompletionItem completion, VSCompletionListCapability? vSCompletionListCapability)
+        public static VSCompletionItem ToVSCompletionItem(this CompletionItem completion, VSCompletionListCapability? vsCompletionListCapability)
         {
             if (completion is null)
             {
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 TextEdit = completion.TextEdit,
             };
 
-            if (vSCompletionListCapability is not null && vSCompletionListCapability.CommitCharacters)
+            if (vsCompletionListCapability is not null && vsCompletionListCapability.CommitCharacters)
             {
                 var vsCommitCharacters = GetVSCommitCharacters(completion);
                 result.VsCommitCharacters = vsCommitCharacters is null ? null : vsCommitCharacters;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         public class OptimizedCompletionListJsonConverter : JsonConverter
         {
-            public static readonly OptimizedCompletionListJsonConverter Instance = new OptimizedCompletionListJsonConverter();
+            public static readonly OptimizedCompletionListJsonConverter Instance = new();
             private static readonly ConcurrentDictionary<object, string> s_commitCharactersRawJson;
             private static readonly JsonSerializer s_defaultSerializer;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public class OptimizedCompletionListJsonConverter : JsonConverter
         {
             public static readonly OptimizedCompletionListJsonConverter Instance = new();
-            private static readonly ConcurrentDictionary<object, string> s_commitCharactersRawJson;
+            protected static readonly ConcurrentDictionary<object, string> s_commitCharactersRawJson;
             private static readonly JsonSerializer s_defaultSerializer;
 
             static OptimizedCompletionListJsonConverter()
@@ -84,6 +84,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             {
                 writer.WriteStartObject();
 
+                WriteCompletionItemProperties(writer, completionItem, serializer, suppressData);
+
+                writer.WriteEndObject();
+            }
+
+            protected virtual void WriteCompletionItemProperties(JsonWriter writer, CompletionItem completionItem, JsonSerializer serializer, bool suppressData)
+            {
                 var label = completionItem.Label;
                 if (label != null)
                 {
@@ -173,23 +180,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     writer.WritePropertyName("data");
                     serializer.Serialize(writer, completionItem.Data);
                 }
-
-                if (completionItem is VSCompletionItem vSCompletionItem &&
-                    vSCompletionItem.VsCommitCharacters is not null &&
-                    vSCompletionItem.VsCommitCharacters.Any())
-                {
-                    writer.WritePropertyName("_vs_commitCharacters");
-
-                    if (!s_commitCharactersRawJson.TryGetValue(vSCompletionItem.VsCommitCharacters, out var jsonString))
-                    {
-                        jsonString = JsonConvert.SerializeObject(vSCompletionItem.VsCommitCharacters);
-                        s_commitCharactersRawJson.TryAdd(vSCompletionItem.VsCommitCharacters, jsonString);
-                    }
-
-                    writer.WriteRawValue(jsonString);
-                }
-
-                writer.WriteEndObject();
             }
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
@@ -174,6 +174,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     serializer.Serialize(writer, completionItem.Data);
                 }
 
+                if (completionItem is VSCompletionItem vSCompletionItem && vSCompletionItem.VsCommitCharacters is not null)
+                {
+                    writer.WritePropertyName("_vs_commitCharacters");
+                    serializer.Serialize(writer, vSCompletionItem.VsCommitCharacters);
+                }
+
                 writer.WriteEndObject();
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/OptimizedCompletionList.cs
@@ -174,10 +174,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     serializer.Serialize(writer, completionItem.Data);
                 }
 
-                if (completionItem is VSCompletionItem vSCompletionItem && vSCompletionItem.VsCommitCharacters is not null)
+                if (completionItem is VSCompletionItem vSCompletionItem &&
+                    vSCompletionItem.VsCommitCharacters is not null &&
+                    vSCompletionItem.VsCommitCharacters.Any())
                 {
                     writer.WritePropertyName("_vs_commitCharacters");
-                    serializer.Serialize(writer, vSCompletionItem.VsCommitCharacters);
+
+                    if (!s_commitCharactersRawJson.TryGetValue(vSCompletionItem.VsCommitCharacters, out var jsonString))
+                    {
+                        jsonString = JsonConvert.SerializeObject(vSCompletionItem.VsCommitCharacters);
+                        s_commitCharactersRawJson.TryAdd(vSCompletionItem.VsCommitCharacters, jsonString);
+                    }
+
+                    writer.WriteRawValue(jsonString);
                 }
 
                 writer.WriteEndObject();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return Task.FromResult(completionItem);
             }
 
-            if (!_completionListCache.TryGet(resultId, out var cachedCompletionItems))
+            if (!_completionListCache.TryGet(resultId.Value, out var cachedCompletionItems))
             {
                 return Task.FromResult(completionItem);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -267,7 +267,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             if (tagHelperClassifiedTextTooltip != null)
             {
                 // We might strip out the commitcharacters for speed, bring them back
-                var container = new Container<string>(associatedRazorCompletion.CommitCharacters);
+                var container = associatedRazorCompletion.CommitCharacters != null ? new Container<string>(associatedRazorCompletion.CommitCharacters) : null;
                 var withCommit = completionItem with { CommitCharacters = container };
                 var vsCompletionItem = withCommit.ToVSCompletionItem(_capability?.VSCompletionList);
                 completionItem = completionItem with { Documentation = string.Empty };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -266,7 +266,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             if (tagHelperClassifiedTextTooltip != null)
             {
-                var vsCompletionItem = completionItem.ToVSCompletionItem();
+                // We might strip out the commitcharacters for speed, bring them back
+                var container = new Container<string>(associatedRazorCompletion.CommitCharacters);
+                var withCommit = completionItem with { CommitCharacters = container };
+                var vsCompletionItem = withCommit.ToVSCompletionItem(_capability?.VSCompletionList);
                 completionItem = completionItem with { Documentation = string.Empty };
                 vsCompletionItem.Description = tagHelperClassifiedTextTooltip;
                 return Task.FromResult<CompletionItem>(vsCompletionItem);
@@ -312,7 +315,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 if (TryConvert(razorCompletionItem, supportedItemKinds, out var completionItem))
                 {
                     // The completion items are cached and can be retrieved via this result id to enable the "resolve" completion functionality.
-                    completionItem = completionItem.CreateWithCompletionListResultId(resultId);
+                    completionItem = completionItem.CreateWithCompletionListResultId(resultId, completionCapability);
                     completionItems.Add(completionItem);
                 }
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -232,13 +232,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             return completionItems;
         }
 
-        private IReadOnlyCollection<string> ResolveAttributeCommitCharacters(IEnumerable<BoundAttributeDescriptor> boundAttributes, bool indexerCompletion)
+        private const string BooleanTypeString = "System.Boolean";
+
+        private static IReadOnlyCollection<string> ResolveAttributeCommitCharacters(IEnumerable<BoundAttributeDescriptor> boundAttributes, bool indexerCompletion)
         {
             if (indexerCompletion)
             {
                 return s_noCommitCharacters;
             }
-            else if (boundAttributes.Any(b => b.TypeName == "System.Boolean"))
+            else if (boundAttributes.Any(b => b.TypeName == BooleanTypeString))
             {
                 // Have to use string type because IsBooleanProperty isn't set
                 return MinimizedAttributeCommitCharacters;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCommitCharacter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCommitCharacter.cs
@@ -3,16 +3,22 @@
 
 #nullable disable
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
-    internal class VSCommitCharacter
+    internal class VSCommitCharacter : IEquatable<string>
     {
         [JsonProperty("_vs_character")]
         public string Character { get; set; }
 
         [JsonProperty("_vs_insert")]
         public bool Insert { get; set; }
+
+        public bool Equals(string other)
+        {
+            return other == Character;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCommitCharacter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCommitCharacter.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class VSCommitCharacter
+    {
+        [JsonProperty("_vs_character")]
+        public string Character { get; set; }
+
+        [JsonProperty("_vs_insert")]
+        public bool Insert { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionItem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionItem.cs
@@ -16,5 +16,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
     {
         [JsonProperty("_vs_description")]
         public VSClassifiedTextElement Description { get; set; }
+
+        [JsonProperty("_vs_commitCharacters")]
+        public CommitCharacter[] VsCommitCharacters { get; set; }
+    }
+
+    internal class CommitCharacter
+    {
+        [JsonProperty("_vs_character")]
+        public string Character { get; set; }
+
+        [JsonProperty("_vs_insert")]
+        public bool Insert { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionItem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionItem.cs
@@ -18,15 +18,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public VSClassifiedTextElement Description { get; set; }
 
         [JsonProperty("_vs_commitCharacters")]
-        public CommitCharacter[] VsCommitCharacters { get; set; }
-    }
-
-    internal class CommitCharacter
-    {
-        [JsonProperty("_vs_character")]
-        public string Character { get; set; }
-
-        [JsonProperty("_vs_insert")]
-        public bool Insert { get; set; }
+        public VSCommitCharacter[] VsCommitCharacters { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionItem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -15,9 +13,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
     internal record VSCompletionItem : CompletionItem
     {
         [JsonProperty("_vs_description")]
-        public VSClassifiedTextElement Description { get; set; }
+        public VSClassifiedTextElement? Description { get; set; }
 
         [JsonProperty("_vs_commitCharacters")]
-        public VSCommitCharacter[] VsCommitCharacters { get; set; }
+        public Container<VSCommitCharacter>? VsCommitCharacters { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
@@ -88,7 +88,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     var clearedCompletionItem = completionItem with { CommitCharacters = null };
                     promotedCompletionItems.Add(clearedCompletionItem);
                 }
-                else if (completionItem is VSCompletionItem vsCompletionItem &&
+
+                if (completionItem is VSCompletionItem vsCompletionItem &&
                     vsCompletionItem.VsCommitCharacters != null &&
                     vsCompletionItem.VsCommitCharacters.Equals(mostUsedCommitCharacters))
                 {
@@ -115,12 +116,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     return false;
                 }
 
-                for(var i = 0; i < a.Count(); i++)
+                for (var i = 0; i < a.Count(); i++)
                 {
                     var str = a.ElementAt(i);
                     var vs = b.ElementAt(i);
 
-                    if(!vs.Equals(str))
+                    if (!vs.Equals(str))
                     {
                         return false;
                     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSCompletionList.cs
@@ -83,10 +83,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var promotedCompletionItems = new List<CompletionItem>();
             foreach (var completionItem in completionList.Items)
             {
+                var hasPromoted = false;
                 if (completionItem.CommitCharacters != null && SequenceEqual(completionItem.CommitCharacters, mostUsedCommitCharacters))
                 {
                     var clearedCompletionItem = completionItem with { CommitCharacters = null };
                     promotedCompletionItems.Add(clearedCompletionItem);
+                    hasPromoted = true;
                 }
 
                 if (completionItem is VSCompletionItem vsCompletionItem &&
@@ -95,8 +97,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     var clearedCompletionItem = vsCompletionItem with { VsCommitCharacters = null };
                     promotedCompletionItems.Add(clearedCompletionItem);
+                    hasPromoted = true;
                 }
-                else
+
+                if (!hasPromoted)
                 {
                     promotedCompletionItems.Add(completionItem);
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
@@ -24,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             completionItem.Items[s_attributeCompletionDescriptionKey] = attributeCompletionDescription;
         }
 
-        public static AggregateBoundAttributeDescription GetAttributeCompletionDescription(this RazorCompletionItem completionItem)
+        public static AggregateBoundAttributeDescription? GetAttributeCompletionDescription(this RazorCompletionItem completionItem)
         {
             if (completionItem is null)
             {
@@ -45,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             completionItem.Items[s_directiveCompletionDescriptionKey] = attributeCompletionDescription;
         }
 
-        public static DirectiveCompletionDescription GetDirectiveCompletionDescription(this RazorCompletionItem completionItem)
+        public static DirectiveCompletionDescription? GetDirectiveCompletionDescription(this RazorCompletionItem completionItem)
         {
             if (completionItem is null)
             {
@@ -66,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             completionItem.Items[s_markupTransitionDescriptionKey] = markupTransitionCompletionDescription;
         }
 
-        public static MarkupTransitionCompletionDescription GetMarkupTransitionCompletionDescription(this RazorCompletionItem completionItem)
+        public static MarkupTransitionCompletionDescription? GetMarkupTransitionCompletionDescription(this RazorCompletionItem completionItem)
         {
             if (completionItem is null)
             {
@@ -75,6 +74,21 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
             var markupTransitionCompletionDescription = completionItem.Items[s_markupTransitionDescriptionKey] as MarkupTransitionCompletionDescription;
             return markupTransitionCompletionDescription;
+        }
+
+        public static IEnumerable<string> GetAttributeCompletionTypes(this RazorCompletionItem completionItem)
+        {
+            var attributeCompletionDescription = completionItem.GetAttributeCompletionDescription();
+
+            if( attributeCompletionDescription is null)
+            {
+                yield break;
+            }
+
+            foreach(var descriptionInfo in attributeCompletionDescription.DescriptionInfos)
+            {
+                yield return descriptionInfo.ReturnTypeName;
+            }
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
@@ -80,12 +80,12 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             var attributeCompletionDescription = completionItem.GetAttributeCompletionDescription();
 
-            if( attributeCompletionDescription is null)
+            if (attributeCompletionDescription is null)
             {
                 yield break;
             }
 
-            foreach(var descriptionInfo in attributeCompletionDescription.DescriptionInfos)
+            foreach (var descriptionInfo in attributeCompletionDescription.DescriptionInfos)
             {
                 yield return descriptionInfo.ReturnTypeName;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -267,6 +267,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void TryConvert_TagHelperAttribute_ForBool_ReturnsTrue()
+        {
+            // Arrange
+            var completionItem = new RazorCompletionItem("format", "format", RazorCompletionItemKind.TagHelperAttribute);
+            var attributeCompletionDescription = new AggregateBoundAttributeDescription(new[] {
+                new BoundAttributeDescriptionInfo("System.Boolean", "Stuff", "format", "SomeDocs")
+            });
+            completionItem.SetAttributeCompletionDescription(attributeCompletionDescription);
+
+            // Act
+            var result = RazorCompletionEndpoint.TryConvert(completionItem, _supportedCompletionItemKinds, out var converted);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(completionItem.DisplayText, converted.Label);
+            Assert.Equal("format", converted.InsertText);
+            Assert.Equal(InsertTextFormat.PlainText, converted.InsertTextFormat);
+            Assert.Equal(completionItem.InsertText, converted.FilterText);
+            Assert.Equal(completionItem.InsertText, converted.SortText);
+            Assert.Null(converted.Detail);
+            Assert.Null(converted.Documentation);
+            Assert.Null(converted.Command);
+        }
+
+        [Fact]
         public void TryConvert_TagHelperAttribute_ReturnsTrue()
         {
             // Arrange
@@ -278,7 +303,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Assert
             Assert.True(result);
             Assert.Equal(completionItem.DisplayText, converted.Label);
-            Assert.Equal(completionItem.InsertText, converted.InsertText);
+            Assert.Equal("format=\"$0\"", converted.InsertText);
+            Assert.Equal(InsertTextFormat.Snippet, converted.InsertTextFormat);
             Assert.Equal(completionItem.InsertText, converted.FilterText);
             Assert.Equal(completionItem.InsertText, converted.SortText);
             Assert.Null(converted.Detail);
@@ -689,7 +715,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await Task.Run(() => completionEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Contains(completionList, item => item.InsertText == "testAttribute");
+            Assert.Contains(completionList, item => item.InsertText == "testAttribute=\"$0\"");
         }
 
         private static DocumentResolver CreateDocumentResolver(string documentPath, RazorCodeDocument codeDocument)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/VSCompletionListTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/VSCompletionListTest.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
@@ -85,8 +86,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var vsCompletionList = VSCompletionList.Convert(completionList, capabilities);
 
             // Assert
-            Assert.Collection(vsCompletionList.Items, item => Assert.Null(item.CommitCharacters));
-            Assert.Equal(commitCharacters, vsCompletionList.CommitCharacters);
+            Assert.Collection(vsCompletionList.Items, (item) => Assert.Null(item.CommitCharacters));
+
+            Assert.Collection(vsCompletionList.CommitCharacters, (e) =>
+            {
+                e.Insert = true;
+                e.Character = "<";
+            });
         }
 
         [Fact]


### PR DESCRIPTION
### Summary of the changes
 - The overwrite section of this won't work broadly until the relevant VS commits are fully merged. I've tested some builds of it t though and it did work.
 - Start returning snippets like `<attribute>="$0"` for TagHelper/Component Attribute completion.
 - We also need HTML LSP to react this for a consistent experience.

Fixes part of https://github.com/dotnet/razor-tooling/issues/4436.