### PR TITLE
Tactically fix caching compiler issue at TagHelper resolution times

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -53,6 +53,11 @@ namespace Microsoft.CodeAnalysis.Razor
                 provider.Execute(context);
             }
 
+            foreach (var tagHelper in results)
+            {
+                DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.TrySplitNamespaceAndType(tagHelper, out _);
+            }
+
             return new TagHelperResolutionResult(results, Array.Empty<RazorDiagnostic>());
         }
 


### PR DESCRIPTION
- This changeset should not be ported to VS windows.
- The gist of what this changeset is doing is that at TagHelper resolution time, right before we return results, we call into a compiler utility method that will populate a cache in the TagHelperDescriptor. This cache is known tohave concurrency issues that result in VS4Mac crashing. Therefore to avoid this we pre-populate that cache before any concurrency scenario can happen.

Tactical fix of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1468241