### PR TITLE
Add logging to semantic tokens

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensCache.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -85,8 +84,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         /// <param name="uri">The URI associated with the cached tokens.</param>
         /// <param name="semanticVersion">The semantic version associated with the cached tokens.</param>
         /// <param name="requestedRange">The requested range for the desired tokens.</param>
-        /// <param name="cachedTokens">If found, contains the cached range and cached tokens.</param>
         /// <param name="logger">Optional logger to record outcome of cache lookup.</param>
+        /// <param name="cachedTokens">If found, contains the cached range and cached tokens.</param>
         /// <returns>
         /// True if at least a partial match for the range was found. The 'Range' out var specifies the subset of
         /// the requested range that was found, and the 'Tokens' out var contains the tokens for that subset range.
@@ -96,8 +95,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             DocumentUri uri,
             VersionStamp semanticVersion,
             Range requestedRange,
-            [NotNullWhen(true)] out (Range Range, ImmutableArray<int> Tokens)? cachedTokens,
-            ILogger? logger = null)
+            ILogger? logger,
+            [NotNullWhen(true)] out (Range Range, ImmutableArray<int> Tokens)? cachedTokens)
         {
             // Don't return results for partial lines, we don't handle them currently due to
             // the need for extra logic and computation.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             var semanticVersion = await GetDocumentSemanticVersionAsync(documentSnapshot).ConfigureAwait(false);
 
             // See if we can use our cache to at least partially avoid recomputation.
-            if (!_tokensCache.TryGetCachedTokens(textDocumentIdentifier.Uri, semanticVersion, range, out var cachedResult))
+            if (!_tokensCache.TryGetCachedTokens(textDocumentIdentifier.Uri, semanticVersion, range, out var cachedResult, _logger))
             {
                 // No cache results found, so we'll recompute tokens for the entire range and then hopefully cache the
                 // results to use next time around.
@@ -347,6 +347,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             // We return null (which to the LSP is a no-op) to prevent flashing of CSharp elements.
             if (combinedSemanticRanges is null)
             {
+                _logger.LogWarning("Incomplete view of document. C# may be ahead of us in document versions.");
                 return null;
             }
 
@@ -421,6 +422,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             // Unrecoverable, return default to indicate no change. It will retry in a bit.
             if (csharpResponse is null)
             {
+                _logger.LogWarning($"Issue with retrieving C# response for Razor range: {razorRange}");
                 return SemanticRangeResponse.Default;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             var semanticVersion = await GetDocumentSemanticVersionAsync(documentSnapshot).ConfigureAwait(false);
 
             // See if we can use our cache to at least partially avoid recomputation.
-            if (!_tokensCache.TryGetCachedTokens(textDocumentIdentifier.Uri, semanticVersion, range, out var cachedResult, _logger))
+            if (!_tokensCache.TryGetCachedTokens(textDocumentIdentifier.Uri, semanticVersion, range, _logger, out var cachedResult))
             {
                 // No cache results found, so we'll recompute tokens for the entire range and then hopefully cache the
                 // results to use next time around.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensCacheTest.cs
@@ -31,7 +31,7 @@ public class SemanticTokensCacheTest
         semanticTokensCache.CacheTokens(uri, semanticVersion, requestedRange, tokens);
 
         // Act
-        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, requestedRange, out var cachedResult))
+        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, requestedRange, logger: null, out var cachedResult))
         {
             Assert.True(false, "Cached Tokens were not found");
             throw new NotImplementedException();
@@ -59,7 +59,7 @@ public class SemanticTokensCacheTest
         semanticTokensCache.CacheTokens(uri, semanticVersion, requestedRange, tokens);
 
         // Act
-        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 2, startCharacter: 0, endLine: 8, endCharacter: 0), out var cachedResult))
+        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 2, startCharacter: 0, endLine: 8, endCharacter: 0), logger: null, out var cachedResult))
         {
             Assert.True(false, "Cached Tokens were not found");
             throw new NotImplementedException();
@@ -90,7 +90,7 @@ public class SemanticTokensCacheTest
         semanticTokensCache.CacheTokens(uri, semanticVersion, requestedRange, tokens);
 
         // Act
-        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, requestedRange, out var cachedResult))
+        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, requestedRange, logger: null, out var cachedResult))
         {
             Assert.True(false, "Cached Tokens were not found");
             throw new NotImplementedException();
@@ -111,7 +111,7 @@ public class SemanticTokensCacheTest
         semanticTokensCache.CacheTokens(uri, semanticVersion, new Range(startLine: 4, startCharacter: 0, endLine: 5, endCharacter: 0), new int[] { 4, 5, 6, 7, 0, });
 
         // Act
-        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 0, startCharacter: 0, endLine: 9, endCharacter: 0), out var cachedResult))
+        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 0, startCharacter: 0, endLine: 9, endCharacter: 0), logger: null, out var cachedResult))
         {
             Assert.True(false, "Cached Tokens were not found");
             throw new NotImplementedException();
@@ -134,7 +134,7 @@ public class SemanticTokensCacheTest
         semanticTokensCache.CacheTokens(uri, semanticVersion, new Range(startLine: 4, startCharacter: 0, endLine: 4, endCharacter: 20), new int[] { 4, 5, 6, 7, 0, });
 
         // Act
-        if (semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 6, startCharacter: 0, endLine: 8, endCharacter: 20), out var _))
+        if (semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 6, startCharacter: 0, endLine: 8, endCharacter: 20), logger: null, out var _))
         {
             Assert.True(false, "Cached Tokens were found but should not have been.");
             throw new NotImplementedException();
@@ -163,7 +163,7 @@ public class SemanticTokensCacheTest
         semanticTokensCache.CacheTokens(uri, semanticVersion, new Range(startLine: 4, startCharacter: 0, endLine: 5, endCharacter: 0), new int[] { 4, 5, 6, 7, 0, });
 
         // Act
-        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 0, startCharacter: 0, endLine: 9, endCharacter: 0), out var cachedResult))
+        if (!semanticTokensCache.TryGetCachedTokens(uri, semanticVersion, new Range(startLine: 0, startCharacter: 0, endLine: 9, endCharacter: 0), logger: null, out var cachedResult))
         {
             Assert.True(false, "Cached Tokens were not found");
             throw new NotImplementedException();


### PR DESCRIPTION
### Summary of the changes
 - Added logging to our semantic tokens logic. It would likely be helpful to add even more logging, but since we're currently inundated with tons of range requests this would likely create unnecessary noise. Due to this, I only added logging for uncommon cases that we aren't expected to hit often.