### PR TITLE
Restrict 24/7 typing C# completions to start of word.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -495,24 +495,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         {
             if (context.TriggerKind != CompletionTriggerKind.TriggerCharacter)
             {
-                // Non-triggered based completion
-
-                if (languageKind == RazorLanguageKind.CSharp &&
-                    context is VSInternalCompletionContext internalContext &&
-                    internalContext.InvokeKind == VSInternalCompletionInvokeKind.Typing)
-                {
-                    // We're in the midst of doing a C# typing completion. We consider this 24/7 completion and HTML & C# only offer 24/7 completion at the
-                    // beginning of a word. Meaning, completions will be provided at `|D` but not for `|Da` which brings us to an interesting cross-roads.
-                    // Razor is currently designed with two language servers:
-                    //   1. HTML C#: Powers the HTML / C# experience
-                    //   2. Razor: Has all of the Razor understanding / powers the generated C# & HTML for a document
-                    // Because of this split, in the middle of completion requests it's possible for additional generated content (C# or HTML) to flow into the client.
-                    // When additional content flows to the client we could mean to ask for completions at `|D` but in practice it'd ask C# for `|Da` (resulting
-                    // in 0 completions). Therefore, to counteract this point-in-time design flaw we translate typing completion requests to explicit in order
-                    // to ensure that we still get completion results at `|Da`.
-                    internalContext.InvokeKind = VSInternalCompletionInvokeKind.Explicit;
-                }
-
+                // Non-triggered based completion, the existing context is valid.
                 return context;
             }
 


### PR DESCRIPTION
- Reverts "Allow C# completion in middle of words." This reverts commit 55f03ed4387b69199c1c6b1edaef85c1f7defc62.
- Ultimately this changeset brings the C# completion experience back to 17.0-GA behavior. We initially did this changeset because there were super rare circumstances in which completion could come up incorrectly.  Turns out this ended up breaking a few other non-trivial C# cases like doc comment typing.
- Given we haven't had any feedback in 17.1 or 17.0 regarding completion in middle or start of words we'll bring things back to consistency with the core C# experience.

### Before
![devenv_kbDM5EQzXP](https://user-images.githubusercontent.com/2008729/155772196-f5cd9e59-d37b-4a18-9fd7-84f5731f49e3.gif)

### After

![image](https://i.imgur.com/A69DA9k.gif)

Fixes #6126