### PR TITLE
Fix caching logic in semantic tokens endpoint

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
 {
@@ -46,6 +47,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             var amount = semanticTokens is null ? "no" : (semanticTokens.Data.Length / 5).ToString(Thread.CurrentThread.CurrentCulture);
 
             _logger.LogInformation($"Returned {amount} semantic tokens for range {request.Range} in {request.TextDocument.Uri}.");
+
+            if (semanticTokens is not null)
+            {
+                Debug.Assert(semanticTokens.Data.Length % 5 == 0, $"Number of semantic token-ints should be divisible by 5. Actual number: {semanticTokens.Data.Length}");
+            }
 
             return semanticTokens;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensCache.cs
@@ -109,10 +109,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (!_cache.TryGetValue(uri, out var documentCache) ||
                 !documentCache.TryGetValue(semanticVersion, out var lineToTokensDict))
             {
-                if (logger is not null)
-                {
-                    logger.LogInformation($"No cached results found for range: {requestedRange}");
-                }
+                logger?.LogInformation($"Cache missing for range: {requestedRange}");
 
                 // No cached results found
                 cachedTokens = null;
@@ -122,10 +119,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var tokens = GetCachedTokens(requestedRange, lineToTokensDict, out var cachedRangeStart, out var numLinesInCachedRange);
             if (tokens.Length == 0)
             {
-                if (logger is not null)
-                {
-                    logger.LogInformation($"No cached results found for range: {requestedRange}");
-                }
+                logger?.LogInformation($"Cache lookup returned no results for range: {requestedRange}");
 
                 // We couldn't find any tokens associated with the passed-in range
                 cachedTokens = null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -238,10 +238,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                         finalTokens.Add(startingTokens.Data[tokenIndex]);
                     }
 
-                    finalTokens.Add(startingTokens.Data[tokenIndex + 1]);
-                    finalTokens.Add(startingTokens.Data[tokenIndex + 2]);
-                    finalTokens.Add(startingTokens.Data[tokenIndex + 3]);
-                    finalTokens.Add(startingTokens.Data[tokenIndex + 4]);
+                    // Add the rest of the ints in the token
+                    for (var i = 1; i < TokenSize; i++)
+                    {
+                        finalTokens.Add(startingTokens.Data[tokenIndex + i]);
+                    }
                 }
 
                 return absoluteLine;
@@ -300,10 +301,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                         finalTokens.Add(endingTokens.Data[tokenIndex]);
                     }
 
-                    finalTokens.Add(endingTokens.Data[tokenIndex + 1]);
-                    finalTokens.Add(endingTokens.Data[tokenIndex + 2]);
-                    finalTokens.Add(endingTokens.Data[tokenIndex + 3]);
-                    finalTokens.Add(endingTokens.Data[tokenIndex + 4]);
+                    // Add the rest of the ints in the token
+                    for (var i = 1; i < TokenSize; i++)
+                    {
+                        finalTokens.Add(endingTokens.Data[tokenIndex + i]);
+                    }
                 }
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -226,6 +226,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                         // Skip tokens that are out of the range
                         if (absoluteLine < requestedRange.Start.Line || absoluteLine >= cachedRange.Start.Line)
                         {
+                            // Skip the rest of the token
+                            tokenIndex += TokenSize - 1;
                             continue;
                         }
 
@@ -285,6 +287,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                         // Skip tokens that are out of the range
                         if (absoluteLine < cachedRange.End.Line || absoluteLine >= requestedRange.End.Line)
                         {
+                            // Skip the rest of the token
+                            tokenIndex += TokenSize - 1;
                             continue;
                         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -215,32 +215,33 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                 // absolute line index to use later when combining results.
                 var absoluteLine = 0;
                 var isFirstTokenInRange = true;
-                for (var tokenIndex = 0; tokenIndex < startingTokens.Data.Length; tokenIndex++)
+                for (var tokenIndex = 0; tokenIndex < startingTokens.Data.Length; tokenIndex += TokenSize)
                 {
                     // The first int of each token represents the line offset. We use this info to keep track of the
                     // absolute line for use later on when computing relative token positions.
-                    if (tokenIndex % TokenSize == 0)
+                    absoluteLine += startingTokens.Data[tokenIndex];
+
+                    // Skip tokens that are out of the range
+                    if (absoluteLine < requestedRange.Start.Line || absoluteLine >= cachedRange.Start.Line)
                     {
-                        absoluteLine += startingTokens.Data[tokenIndex];
-
-                        // Skip tokens that are out of the range
-                        if (absoluteLine < requestedRange.Start.Line || absoluteLine >= cachedRange.Start.Line)
-                        {
-                            // Skip the rest of the token
-                            tokenIndex += TokenSize - 1;
-                            continue;
-                        }
-
-                        // First token of the starting set should be relative to the start of the document
-                        if (isFirstTokenInRange)
-                        {
-                            finalTokens.Add(absoluteLine);
-                            isFirstTokenInRange = false;
-                            continue;
-                        }
+                        continue;
                     }
 
-                    finalTokens.Add(startingTokens.Data[tokenIndex]);
+                    // First token of the starting set should be relative to the start of the document
+                    if (isFirstTokenInRange)
+                    {
+                        finalTokens.Add(absoluteLine);
+                        isFirstTokenInRange = false;
+                    }
+                    else
+                    {
+                        finalTokens.Add(startingTokens.Data[tokenIndex]);
+                    }
+
+                    finalTokens.Add(startingTokens.Data[tokenIndex + 1]);
+                    finalTokens.Add(startingTokens.Data[tokenIndex + 2]);
+                    finalTokens.Add(startingTokens.Data[tokenIndex + 3]);
+                    finalTokens.Add(startingTokens.Data[tokenIndex + 4]);
                 }
 
                 return absoluteLine;
@@ -276,32 +277,33 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             {
                 var isFirstTokenInRange = true;
                 var absoluteLine = 0;
-                for (var tokenIndex = 0; tokenIndex < endingTokens.Data.Length; tokenIndex++)
+                for (var tokenIndex = 0; tokenIndex < endingTokens.Data.Length; tokenIndex += TokenSize)
                 {
                     // The first int of each token represents the line offset. We use this info to keep track of the
                     // absolute line for use later on when computing relative token positions.
-                    if (tokenIndex % TokenSize == 0)
+                    absoluteLine = tokenIndex == 0 ? endingTokens.Data[0] : absoluteLine + endingTokens.Data[tokenIndex];
+
+                    // Skip tokens that are out of the range
+                    if (absoluteLine < cachedRange.End.Line || absoluteLine >= requestedRange.End.Line)
                     {
-                        absoluteLine = tokenIndex == 0 ? endingTokens.Data[0] : absoluteLine + endingTokens.Data[tokenIndex];
-
-                        // Skip tokens that are out of the range
-                        if (absoluteLine < cachedRange.End.Line || absoluteLine >= requestedRange.End.Line)
-                        {
-                            // Skip the rest of the token
-                            tokenIndex += TokenSize - 1;
-                            continue;
-                        }
-
-                        // First token of the ending set should be relative to the end line of the cached tokens set
-                        if (isFirstTokenInRange)
-                        {
-                            finalTokens.Add(absoluteLine - cachedTokensAbsoluteEndLine);
-                            isFirstTokenInRange = false;
-                            continue;
-                        }
+                        continue;
                     }
 
-                    finalTokens.Add(endingTokens.Data[tokenIndex]);
+                    // First token of the ending set should be relative to the end line of the cached tokens set
+                    if (isFirstTokenInRange)
+                    {
+                        finalTokens.Add(absoluteLine - cachedTokensAbsoluteEndLine);
+                        isFirstTokenInRange = false;
+                    }
+                    else
+                    {
+                        finalTokens.Add(endingTokens.Data[tokenIndex]);
+                    }
+
+                    finalTokens.Add(endingTokens.Data[tokenIndex + 1]);
+                    finalTokens.Add(endingTokens.Data[tokenIndex + 2]);
+                    finalTokens.Add(endingTokens.Data[tokenIndex + 3]);
+                    finalTokens.Add(endingTokens.Data[tokenIndex + 4]);
                 }
             }
         }


### PR DESCRIPTION
### Summary of the changes
 - @ryanbrandenburg and I discovered this bug while verifying semantic tokens yesterday:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/16968319/156430308-4acec17b-7036-44f6-b44a-85dfaa9c48b5.png)
- This is because of an error in the caching logic. After this fix, I verified we only return token-ints divisible by 5. Also changed the logic to operate on full tokens instead of individual ints based on Ryan's recommendation.
- We lack tests in this area (still in progress), but tests will be added after the C# LSP server is integrated with Razor tests.

EDIT: Probably best to view changes with whitespace turned off