### PR TITLE
Don't run publish steps if previous steps were cancelled

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -29,7 +29,7 @@ steps:
       testResultsFiles: $(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}\*.xml
       mergeTestResults: true
       testRunTitle: '$(System.JobAttempt)-Integration ${{ parameters.configuration }}'
-    condition: always()
+    condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Logs
@@ -38,7 +38,7 @@ steps:
       ArtifactName: '$(System.JobAttempt)-Logs ${{ parameters.configuration }} $(Build.BuildNumber)'
       publishLocation: Container
     continueOnError: true
-    condition: not(succeeded())
+    condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Screenshots
@@ -47,4 +47,4 @@ steps:
       ArtifactName: '$(System.JobAttempt)-Screenshots ${{ parameters.configuration }} $(Build.BuildNumber)'
       publishLocation: Container
     continueOnError: true
-    condition: not(succeeded())
+    condition: succeededOrFailed()


### PR DESCRIPTION
### Summary of the changes
 - Change all "Publish" steps to skip if previous steps were cancelled.

Fixes: https://github.com/dotnet/razor-tooling/issues/6138

As suggested by @sharwell.

CC @JoeRobich who maintains the Roslyn version of this.