### PR TITLE
Add Language Server binaries to MPack.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -48,6 +48,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Symbols.Transport" Version="$(MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion)" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="$(MicrosoftCodeAnalysisRazorToolingInternalPackageVersion)" GeneratePathProperty="true"/>
     <PackageReference Include="Mono.Addins" Version="$(MonoAddinsPackageVersion)" />
+
+    <!-- We need to directly reference the O# language server here because we mark it as PrivateAssets="All" in our language server itself -->
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="$(OmniSharpExtensionsLanguageServerPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,6 +62,31 @@
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Razor.Workspaces\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Editor.Razor\$(Configuration)\net472\Microsoft.VisualStudio.Editor.Razor.dll" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.LanguageServices.Razor\$(Configuration)\net472\Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
+
+    <!-- Language Server Dependencies -->
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.LanguageServerClient.Razor\$(Configuration)\net472\Microsoft.VisualStudio.LanguageServerClient.Razor.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.LanguageServer.ContainedLanguage\$(Configuration)\net472\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.LanguageServer.Common\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Razor.LanguageServer.Common.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.LanguageServer\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Razor.LanguageServer.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\MediatR.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\OmniSharp.Extensions.JsonRpc.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\OmniSharp.Extensions.LanguageProtocol.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\OmniSharp.Extensions.LanguageServer.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\OmniSharp.Extensions.LanguageServer.Shared.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Configuration.Binder.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Options.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Primitives.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.DependencyInjection.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Configuration.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Logging.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Logging.Abstractions.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\System.IO.Pipelines.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\System.Reactive.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\System.Runtime.CompilerServices.Unsafe.dll" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\System.Threading.Channels.dll" />
   </ItemGroup>
 
   <ItemGroup Condition="$(DebugType) != 'embedded'">
@@ -66,9 +94,16 @@
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Razor.Workspaces\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.Razor.Workspaces.pdb" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Editor.Razor\$(Configuration)\net472\Microsoft.VisualStudio.Editor.Razor.pdb" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.LanguageServices.Razor\$(Configuration)\net472\Microsoft.VisualStudio.Mac.LanguageServices.Razor.pdb" />
+
+    <!-- Language Server Dependencies-->
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.LanguageServerClient.Razor\$(Configuration)\net472\Microsoft.VisualStudio.LanguageServerClient.Razor.pdb" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.LanguageServer.ContainedLanguage\$(Configuration)\net472\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.pdb" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.LanguageServer.Common\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Razor.LanguageServer.Common.pdb" />
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.LanguageServer\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Razor.LanguageServer.pdb" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Mac.LanguageServices.Razor\Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
@@ -1,17 +1,41 @@
 <Addin id="RazorAddin" namespace="Microsoft.VisualStudio.Mac" version="17.0" name="Razor Language Services" author="Microsoft" description="Language services for ASP.NET Core Razor" category="Web Development">
-<Runtime>
-<Import assembly="Microsoft.VisualStudio.Editor.Razor.dll" />
-<Import assembly="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
-<Import assembly="Microsoft.AspNetCore.Razor.Language.dll" />
-<Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
-<Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />
-<Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
-<Import assembly="Microsoft.CodeAnalysis.Razor.dll" />
-<Import assembly="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
-<Import assembly="Microsoft.VisualStudio.Mac.RazorAddin.dll" />
-</Runtime>
-<Dependencies>
-<Addin id="::MonoDevelop.Core" version="17.0" />
-<Addin id="::MonoDevelop.Ide" version="17.0" />
-</Dependencies>
+  <Runtime>
+    <Import assembly="Microsoft.VisualStudio.Editor.Razor.dll" />
+    <Import assembly="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
+    <Import assembly="Microsoft.AspNetCore.Razor.Language.dll" />
+    <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
+    <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />
+    <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
+    <Import assembly="Microsoft.CodeAnalysis.Razor.dll" />
+    <Import assembly="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
+    <Import assembly="Microsoft.VisualStudio.Mac.RazorAddin.dll" />
+
+    <Import assembly="Microsoft.VisualStudio.LanguageServerClient.Razor.dll" />
+    <Import assembly="Microsoft.VisualStudio.LanguageServer.ContainedLanguage.dll" />
+    <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
+    <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.Common.dll" />
+    <Import assembly="MediatR.dll" />
+    <Import assembly="OmniSharp.Extensions.JsonRpc.dll" />
+    <Import assembly="OmniSharp.Extensions.LanguageProtocol.dll" />
+    <Import assembly="OmniSharp.Extensions.LanguageServer.dll" />
+    <Import assembly="OmniSharp.Extensions.LanguageServer.Shared.dll" />
+    <Import assembly="Microsoft.Extensions.Configuration.Binder.dll" />
+    <Import assembly="Microsoft.Extensions.Options.dll" />
+    <Import assembly="Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
+    <Import assembly="Microsoft.Extensions.Primitives.dll" />
+    <Import assembly="Microsoft.Extensions.DependencyInjection.dll" />
+    <Import assembly="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <Import assembly="Microsoft.Extensions.Configuration.dll" />
+    <Import assembly="Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <Import assembly="Microsoft.Extensions.Logging.dll" />
+    <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
+    <Import assembly="System.IO.Pipelines.dll" />
+    <Import assembly="System.Reactive.dll" />
+    <Import assembly="System.Runtime.CompilerServices.Unsafe.dll" />
+    <Import assembly="System.Threading.Channels.dll" />
+  </Runtime>
+  <Dependencies>
+    <Addin id="::MonoDevelop.Core" version="17.0" />
+    <Addin id="::MonoDevelop.Ide" version="17.0" />
+  </Dependencies>
 </Addin>


### PR DESCRIPTION
- This publishes all language server and dependent language server information to our MPack. Technically this shouljd be the last change for VS4Mac compatibility.

Fixes #6038

/cc @KirillOsenkov / @gundermanc this should be the last changeset for getting Razor compatible for VS4Mac. I haven't actually tested this bit end-to-end so we may want to sit down and see if everything is good once this gets merged.