### PR TITLE
Use code action title instead of resolving edits for add usings. 

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal static class AddUsingsCodeActionProviderHelper
     {
-        internal static readonly Regex AddUsingVSCodeAction = new Regex("^using (.+);$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+        internal static readonly Regex AddUsingVSCodeAction = new Regex("^@?using ([^;]+);?$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         // Internal for testing
         internal static string GetNamespaceFromFQN(string fullyQualifiedName)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
@@ -56,34 +56,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var resolvedCodeAction = await ResolveCodeActionWithServerAsync(csharpParams.RazorFileUri, codeAction, cancellationToken).ConfigureAwait(false);
-            if (resolvedCodeAction?.Edit?.DocumentChanges is null)
-            {
-                // Unable to resolve code action with server, return original code action
-                return codeAction;
-            }
-
-            if (resolvedCodeAction.Edit.DocumentChanges.Count() != 1)
-            {
-                // We don't yet support multi-document code actions, return original code action
-                return codeAction;
-            }
-
-            var documentChanged = resolvedCodeAction.Edit.DocumentChanges.First();
-            if (!documentChanged.IsTextDocumentEdit)
-            {
-                // Only Text Document Edit changes are supported currently, return original code action
-                return codeAction;
-            }
-
-            var addUsingTextEdit = documentChanged.TextDocumentEdit?.Edits.FirstOrDefault();
-            if (addUsingTextEdit is null)
-            {
-                // No text edit available
-                return codeAction;
-            }
-
-            if (!AddUsingsCodeActionProviderHelper.TryExtractNamespace(addUsingTextEdit.NewText, out var @namespace))
+            if (!AddUsingsCodeActionProviderHelper.TryExtractNamespace(codeAction.Title, out var @namespace))
             {
                 // Invalid text edit, missing namespace
                 return codeAction;
@@ -124,9 +97,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             var edit = AddUsingsCodeActionResolver.CreateAddUsingWorkspaceEdit(@namespace, codeDocument, codeDocumentIdentifier);
-            resolvedCodeAction = resolvedCodeAction with { Edit = edit };
+            codeAction = codeAction with { Edit = edit };
 
-            return resolvedCodeAction;
+            return codeAction;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -392,7 +392,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 Methods.CodeActionResolveName,
                 SupportsCSharpCodeActions,
                 codeAction,
-                CancellationToken.None).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             await foreach (var response in requests)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -392,7 +392,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 Methods.CodeActionResolveName,
                 SupportsCSharpCodeActions,
                 codeAction,
-                cancellationToken).ConfigureAwait(false);
+                CancellationToken.None).ConfigureAwait(false);
 
             await foreach (var response in requests)
             {


### PR DESCRIPTION
 This works around a bug where the edits returned by C# may not be well structured.  Proper solution is tracked by https://github.com/dotnet/razor-tooling/issues/6159 (the ability for Razor to apply arbitrary C# edits).

If anyone asks, I blame Taylor for making me write this.

Note - this hack is already present in the actual code action endpoint as well - https://github.com/dotnet/razor-tooling/commit/034f6fe9c31e0d5d9679b489a3362de765a08a02#diff-0be4ed27bb2b83f2a3854b8612e1c9b8d1779a500984a97102d074a6afec2f70R200

### Summary of the changes
 - Uses code action title to retrieve the appropriate using to add
 - Stops calling C# to resolve as we would literally just throw away everything resolved anyway.

Fixes: 
https://github.com/dotnet/roslyn/issues/58091