### PR TITLE
Add ability to resolve capabilities for projects without document.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -111,6 +111,7 @@
     <MicrosoftVisualStudioRpcContractsVersion>17.0.51</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualStudioShell150PackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShell150PackageVersion>
     <MicrosoftVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropPackageVersion>
+    <MicrosoftInternalVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioInteropPackageVersion>
     <MicrosoftVisualStudioTextDataPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextDataPackageVersion>
     <MicrosoftVisualStudioTextImplementationPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextImplementationPackageVersion>
     <MicrosoftVisualStudioTextLogicPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextLogicPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/AggregateProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/AggregateProjectCapabilityResolver.cs
@@ -3,9 +3,8 @@
 
 using System.Collections.Generic;
 using System.Composition;
-using Microsoft.VisualStudio.Editor.Razor;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+namespace Microsoft.VisualStudio.Editor.Razor
 {
     [Shared]
     [Export(typeof(AggregateProjectCapabilityResolver))]
@@ -17,6 +16,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public AggregateProjectCapabilityResolver([ImportMany] IEnumerable<ProjectCapabilityResolver> projectCapabilityResolvers)
         {
             _projectCapabilityResolvers = projectCapabilityResolvers;
+        }
+
+        public override bool HasCapability(object project, string capability)
+        {
+            foreach (var capabilityResolver in _projectCapabilityResolvers)
+            {
+                if (capabilityResolver.HasCapability(project, capability))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public override bool HasCapability(string documentFilePath, object project, string capability)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ProjectCapabilityResolver.cs
@@ -5,6 +5,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 {
     internal abstract class ProjectCapabilityResolver
     {
+        public abstract bool HasCapability(object project, string capability);
+
         public abstract bool HasCapability(string documentFilePath, object project, string capability);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TextBufferProjectService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TextBufferProjectService.cs
@@ -11,6 +11,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public abstract object GetHostProject(ITextBuffer textBuffer);
 
+        public abstract object GetHostProject(string documentFilePath);
+
         public abstract bool IsSupportedProject(object project);
 
         public abstract string GetProjectPath(object project);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Microsoft.VisualStudio.LanguageServerClient.Razor.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(OmniSharpMicrosoftExtensionsLoggingPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop" Version="$(MicrosoftInternalVisualStudioInteropPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLSPEditorFeatureDetector.cs
@@ -5,15 +5,16 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     [Shared]
     [Export(typeof(LSPEditorFeatureDetector))]
-    internal class DefaultLSPEditorFeatureDetector : LSPEditorFeatureDetector
+    internal class VisualStudioWindowsLSPEditorFeatureDetector : LSPEditorFeatureDetector
     {
         private const string LegacyRazorEditorFeatureFlag = "Razor.LSP.LegacyEditor";
         private const string DotNetCoreCSharpCapability = "CSharp&CPS";
@@ -28,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private readonly Lazy<bool> _useLegacyEditor;
 
         [ImportingConstructor]
-        public DefaultLSPEditorFeatureDetector(AggregateProjectCapabilityResolver projectCapabilityResolver)
+        public VisualStudioWindowsLSPEditorFeatureDetector(AggregateProjectCapabilityResolver projectCapabilityResolver)
         {
             _projectCapabilityResolver = projectCapabilityResolver;
             _vsUIShellOpenDocument = new Lazy<IVsUIShellOpenDocument>(() =>
@@ -58,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [Obsolete("Test constructor")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal DefaultLSPEditorFeatureDetector()
+        internal VisualStudioWindowsLSPEditorFeatureDetector()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsProjectCapabilityResolver.cs
@@ -16,12 +16,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         private readonly RazorLogger _razorLogger;
 
         [ImportingConstructor]
-        public VisualStudioWindowsProjectCapabilityResolver(RazorLogger razorLogger)
+        public VisualStudioWindowsProjectCapabilityResolver(RazorLogger razorLogger!!)
         {
             _razorLogger = razorLogger;
         }
 
-        public override bool HasCapability(string documentFilePath, object project, string capability)
+        public override bool HasCapability(object project, string capability)
         {
             if (project is not IVsHierarchy vsHierarchy)
             {
@@ -31,6 +31,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             var localHasCapability = LocalHasCapability(vsHierarchy, capability);
             return localHasCapability;
         }
+
+        public override bool HasCapability(string documentFilePath, object project, string capability) => HasCapability(project, capability);
 
         private bool LocalHasCapability(IVsHierarchy hierarchy, string capability)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/LiveShareProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/LiveShareProjectCapabilityResolver.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using Microsoft.VisualStudio.Editor.Razor;
@@ -23,6 +22,12 @@ namespace Microsoft.VisualStudio.LiveShare.Razor
         {
             _sessionAccessor = sessionAccessor;
             _joinableTaskFactory = joinableTaskContext.Factory;
+        }
+
+        public override bool HasCapability(object project, string capability)
+        {
+            // In LiveShare scenarios we need a document file path to be able to make reasonable assumptions on if a project has a capability
+            return false;
         }
 
         public override bool HasCapability(string documentFilePath, object project, string capability)

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.Editor.Razor;
+using MonoDevelop.Core.FeatureConfiguration;
+using MonoDevelop.Projects;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Shared]
+    [Export(typeof(LSPEditorFeatureDetector))]
+    internal class VisualStudioMacLSPEditorFeatureDetector : LSPEditorFeatureDetector
+    {
+        private const string RazorLSPEditorFeatureFlag = "Razor.LSP.Editor";
+        private const string DotNetCoreCSharpProjectCapability = "CSharp&CPS";
+        private const string LegacyRazorEditorProjectCapability = "LegacyRazorEditor";
+
+        private readonly AggregateProjectCapabilityResolver _projectCapabilityResolver;
+        private readonly TextBufferProjectService _textBufferProjectService;
+        private readonly Lazy<bool> _useLegacyEditor;
+
+        [ImportingConstructor]
+        public VisualStudioMacLSPEditorFeatureDetector(
+            AggregateProjectCapabilityResolver projectCapabilityResolver,
+            TextBufferProjectService textBufferProjectService)
+        {
+            _projectCapabilityResolver = projectCapabilityResolver;
+            _textBufferProjectService = textBufferProjectService;
+
+            _useLegacyEditor = new Lazy<bool>(() =>
+            {
+                // TODO: Pull from preview features collection
+
+                if (FeatureSwitchService.IsFeatureEnabled(RazorLSPEditorFeatureFlag) == true)
+                {
+                    return false;
+                }
+
+                return true;
+            });
+        }
+
+        [Obsolete("Test constructor")]
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        internal VisualStudioMacLSPEditorFeatureDetector()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+        }
+
+        public override bool IsLSPEditorAvailable(string documentFilePath, object hierarchy)
+        {
+            if (documentFilePath is null)
+            {
+                return false;
+            }
+
+            if (!IsLSPEditorAvailable())
+            {
+                return false;
+            }
+
+            var dotnetProject = hierarchy as DotNetProject;
+            if (!ProjectSupportsLSPEditor(documentFilePath, dotnetProject))
+            {
+                // Current project hierarchy doesn't support the LSP Razor editor
+                return false;
+            }
+
+            return true;
+        }
+
+        public override bool IsLSPEditorAvailable() => !_useLegacyEditor.Value;
+
+        // LiveShare / CodeSpaces is not supported in VS4Mac
+        public override bool IsRemoteClient() => false;
+
+        // LiveShare / CodeSpaces is not supported in VS4Mac
+        public override bool IsLiveShareHost() => false;
+
+        // Private protected virtual for testing
+        private protected virtual bool ProjectSupportsLSPEditor(string documentFilePath, DotNetProject? project)
+        {
+            if (project is null)
+            {
+                project = _textBufferProjectService.GetHostProject(documentFilePath) as DotNetProject;
+
+                if (project is null)
+                {
+                    return false;
+                }
+            }
+
+            // We alow projects to specifically opt-out of the legacy Razor editor because there are legacy scenarios which would rely on behind-the-scenes
+            // opt-out mechanics to enable the .NET Core editor in non-.NET Core scenarios. Therefore, we need a similar mechanic to continue supporting
+            // those types of scenarios for the new .NET Core Razor editor.
+            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, LegacyRazorEditorProjectCapability))
+            {
+                // CPS project that requires the legacy editor
+                return false;
+            }
+
+            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, DotNetCoreCSharpProjectCapability))
+            {
+                // .NET Core project that supports C#
+                return true;
+            }
+
+            // Not a C# .NET Core project. This typically happens for legacy Razor scenarios
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacProjectCapabilityResolver.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Editor.Razor;
+using MonoDevelop.Projects;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Export(typeof(ProjectCapabilityResolver))]
+    internal class VisualStudioMacProjectCapabilityResolver : ProjectCapabilityResolver
+    {
+        private readonly RazorLogger _razorLogger;
+
+        [ImportingConstructor]
+        public VisualStudioMacProjectCapabilityResolver(RazorLogger razorLogger)
+        {
+            _razorLogger = razorLogger;
+        }
+
+        public override bool HasCapability(object project, string capability)
+        {
+            if (project is not DotNetProject dotnetProject)
+            {
+                return false;
+            }
+
+            try
+            {
+                var hasCapability = dotnetProject.IsCapabilityMatch(capability);
+                return hasCapability;
+            }
+            catch (NotSupportedException)
+            {
+                // IsCapabilityMatch throws a NotSupportedException if it can't create a
+                // BooleanSymbolExpressionEvaluator COM object
+                _razorLogger.LogWarning("Could not resolve project capability for hierarchy due to NotSupportedException.");
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                // IsCapabilityMatch throws an ObjectDisposedException if the underlying hierarchy has been disposed
+                _razorLogger.LogWarning("Could not resolve project capability for hierarchy due to hierarchy being disposed.");
+                return false;
+            }
+        }
+
+        public override bool HasCapability(string documentFilePath, object project, string capability) => HasCapability(project, capability);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -26,4 +26,9 @@
   <Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
     <Class class="Microsoft.VisualStudio.Mac.RazorAddin.RazorProjectExtension" insertafter="FinalStep" />
   </Extension>
+
+  <!-- Feature Switches -->
+  <Extension path="/MonoDevelop/Core/FeatureSwitches">
+    <FeatureSwitch id="Razor.LSP.Editor" _description="Enables the Razor LSP editor for ASP.NET Core scenarios" defaultValue="false" />
+  </Extension>
 </ExtensionModel>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VisualStudioWindowsLSPEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VisualStudioWindowsLSPEditorFeatureDetectorTest.cs
@@ -6,9 +6,9 @@
 using Microsoft.VisualStudio.Shell.Interop;
 using Xunit;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
-    public class DefaultLSPEditorFeatureDetectorTest
+    public class VisualStudioWindowsLSPEditorFeatureDetectorTest
     {
         [Fact]
         public void IsLSPEditorAvailable_ProjectSupported_ReturnsTrue()
@@ -121,8 +121,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             Assert.False(result);
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        private class TestLSPEditorFeatureDetector : DefaultLSPEditorFeatureDetector
+#pragma warning disable CS0618 // Type or member is obsolete (Test constructor)
+        private class TestLSPEditorFeatureDetector : VisualStudioWindowsLSPEditorFeatureDetector
         {
             public bool UseLegacyEditor { get; set; }
 
@@ -144,6 +144,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             private protected override bool ProjectSupportsLSPEditor(string documentMoniker, IVsHierarchy hierarchy) => ProjectSupportsLSPEditorValue;
         }
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete (Test constructor)
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/VisualStudioMacLSPEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/VisualStudioMacLSPEditorFeatureDetectorTest.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using MonoDevelop.Projects;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public class VisualStudioMacLSPEditorFeatureDetectorTest
+    {
+        [Fact]
+        public void IsLSPEditorAvailable_ProjectSupported_ReturnsTrue()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                ProjectSupportsLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsLSPEditorAvailable_LegacyEditorEnabled_ReturnsFalse()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                UseLegacyEditor = true,
+                ProjectSupportsLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsLSPEditorAvailable_IsVSRemoteClient_ReturnsTrue()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                IsRemoteClientValue = true,
+                ProjectSupportsLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsLSPEditorAvailable_UnsupportedProject_ReturnsFalse()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                ProjectSupportsLSPEditorValue = false,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsRemoteClient_VSRemoteClient_ReturnsTrue()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                IsRemoteClientValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsRemoteClient();
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsRemoteClient_UnknownEnvironment_ReturnsFalse()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector();
+
+            // Act
+            var result = featureDetector.IsRemoteClient();
+
+            // Assert
+            Assert.False(result);
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete (Test constructor)
+        private class TestLSPEditorFeatureDetector : VisualStudioMacLSPEditorFeatureDetector
+        {
+            public bool UseLegacyEditor { get; set; }
+
+            public bool IsLiveShareHostValue { get; set; }
+
+            public bool IsRemoteClientValue { get; set; }
+
+            public bool ProjectSupportsLSPEditorValue { get; set; }
+
+            public override bool IsLSPEditorAvailable() => !UseLegacyEditor;
+
+            public override bool IsLiveShareHost() => IsLiveShareHostValue;
+
+            public override bool IsRemoteClient() => IsRemoteClientValue;
+
+            private protected override bool ProjectSupportsLSPEditor(string documentFilePath, DotNetProject project) => ProjectSupportsLSPEditorValue;
+        }
+#pragma warning restore CS0618 // Type or member is obsolete (Test constructor)
+    }
+}


### PR DESCRIPTION
- LiveShare is the only project capability resolver that actually requires documents and I didn't want to put the expectation on all capability resolution mechanisms to require documents. Therefore I added a new overload of the `HasCapability` check that only requires a project.
- In VS4Mac landscape we also don't need document file paths so this also sets us up for being able to resolve capabilities there.

Part of #6038
