### PR TITLE
Add VS4Mac LSP Editor feature detector.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TextBufferProjectService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TextBufferProjectService.cs
@@ -11,6 +11,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public abstract object GetHostProject(ITextBuffer textBuffer);
 
+        public abstract object GetHostProject(string documentFilePath);
+
         public abstract bool IsSupportedProject(object project);
 
         public abstract string GetProjectPath(object project);

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
@@ -6,7 +6,6 @@ using System.Composition;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor.Razor;
 using MonoDevelop.Core.FeatureConfiguration;
-using MonoDevelop.Ide;
 using MonoDevelop.Projects;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
@@ -16,8 +15,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     internal class VisualStudioMacLSPEditorFeatureDetector : LSPEditorFeatureDetector
     {
         private const string RazorLSPEditorFeatureFlag = "Razor.LSP.Editor";
-        private const string DotNetCoreCSharpCapability = "CSharp&CPS";
-        private const string LegacyRazorEditorCapability = "LegacyRazorEditor";
+        private const string DotNetCoreCSharpProjectCapability = "CSharp&CPS";
+        private const string LegacyRazorEditorProjectCapability = "LegacyRazorEditor";
 
         private readonly AggregateProjectCapabilityResolver _projectCapabilityResolver;
         private readonly TextBufferProjectService _textBufferProjectService;
@@ -97,13 +96,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             // We alow projects to specifically opt-out of the legacy Razor editor because there are legacy scenarios which would rely on behind-the-scenes
             // opt-out mechanics to enable the .NET Core editor in non-.NET Core scenarios. Therefore, we need a similar mechanic to continue supporting
             // those types of scenarios for the new .NET Core Razor editor.
-            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, LegacyRazorEditorCapability))
+            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, LegacyRazorEditorProjectCapability))
             {
                 // CPS project that requires the legacy editor
                 return false;
             }
 
-            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, DotNetCoreCSharpCapability))
+            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, DotNetCoreCSharpProjectCapability))
             {
                 // .NET Core project that supports C#
                 return true;

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.Editor.Razor;
+using MonoDevelop.Core.FeatureConfiguration;
+using MonoDevelop.Ide;
+using MonoDevelop.Projects;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Shared]
+    [Export(typeof(LSPEditorFeatureDetector))]
+    internal class VisualStudioMacLSPEditorFeatureDetector : LSPEditorFeatureDetector
+    {
+        private const string RazorLSPEditorFeatureFlag = "Razor.LSP.Editor";
+        private const string DotNetCoreCSharpCapability = "CSharp&CPS";
+        private const string LegacyRazorEditorCapability = "LegacyRazorEditor";
+
+        private readonly AggregateProjectCapabilityResolver _projectCapabilityResolver;
+        private readonly TextBufferProjectService _textBufferProjectService;
+        private readonly Lazy<bool> _useLegacyEditor;
+
+        [ImportingConstructor]
+        public VisualStudioMacLSPEditorFeatureDetector(
+            AggregateProjectCapabilityResolver projectCapabilityResolver,
+            TextBufferProjectService textBufferProjectService)
+        {
+            _projectCapabilityResolver = projectCapabilityResolver;
+            _textBufferProjectService = textBufferProjectService;
+
+            _useLegacyEditor = new Lazy<bool>(() =>
+            {
+                // TODO: Pull from preview features collection
+
+                if (FeatureSwitchService.IsFeatureEnabled(RazorLSPEditorFeatureFlag) == true)
+                {
+                    return false;
+                }
+
+                return true;
+            });
+        }
+
+        [Obsolete("Test constructor")]
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        internal VisualStudioMacLSPEditorFeatureDetector()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+        }
+
+        public override bool IsLSPEditorAvailable(string documentFilePath, object hierarchy)
+        {
+            if (documentFilePath is null)
+            {
+                return false;
+            }
+
+            if (!IsLSPEditorAvailable())
+            {
+                return false;
+            }
+
+            var dotnetProject = hierarchy as DotNetProject;
+            if (!ProjectSupportsLSPEditor(documentFilePath, dotnetProject))
+            {
+                // Current project hierarchy doesn't support the LSP Razor editor
+                return false;
+            }
+
+            return true;
+        }
+
+        public override bool IsLSPEditorAvailable() => !_useLegacyEditor.Value;
+
+        // LiveShare / CodeSpaces is not supported in VS4Mac
+        public override bool IsRemoteClient() => false;
+
+        // LiveShare / CodeSpaces is not supported in VS4Mac
+        public override bool IsLiveShareHost() => false;
+
+        // Private protected virtual for testing
+        private protected virtual bool ProjectSupportsLSPEditor(string documentFilePath, DotNetProject? project)
+        {
+            if (project is null)
+            {
+                project = _textBufferProjectService.GetHostProject(documentFilePath) as DotNetProject;
+
+                if (project is null)
+                {
+                    return false;
+                }
+            }
+
+            // We alow projects to specifically opt-out of the legacy Razor editor because there are legacy scenarios which would rely on behind-the-scenes
+            // opt-out mechanics to enable the .NET Core editor in non-.NET Core scenarios. Therefore, we need a similar mechanic to continue supporting
+            // those types of scenarios for the new .NET Core Razor editor.
+            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, LegacyRazorEditorCapability))
+            {
+                // CPS project that requires the legacy editor
+                return false;
+            }
+
+            if (_projectCapabilityResolver.HasCapability(documentFilePath, project, DotNetCoreCSharpCapability))
+            {
+                // .NET Core project that supports C#
+                return true;
+            }
+
+            // Not a C# .NET Core project. This typically happens for legacy Razor scenarios
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacProjectCapabilityResolver.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Editor.Razor;
+using MonoDevelop.Projects;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Export(typeof(ProjectCapabilityResolver))]
+    internal class VisualStudioMacProjectCapabilityResolver : ProjectCapabilityResolver
+    {
+        private readonly RazorLogger _razorLogger;
+
+        [ImportingConstructor]
+        public VisualStudioMacProjectCapabilityResolver(RazorLogger razorLogger)
+        {
+            _razorLogger = razorLogger;
+        }
+
+        public override bool HasCapability(object project, string capability)
+        {
+            if (project is not DotNetProject dotnetProject)
+            {
+                return false;
+            }
+
+            try
+            {
+                var hasCapability = dotnetProject.IsCapabilityMatch(capability);
+                return hasCapability;
+            }
+            catch (NotSupportedException)
+            {
+                // IsCapabilityMatch throws a NotSupportedException if it can't create a
+                // BooleanSymbolExpressionEvaluator COM object
+                _razorLogger.LogWarning("Could not resolve project capability for hierarchy due to NotSupportedException.");
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                // IsCapabilityMatch throws an ObjectDisposedException if the underlying hierarchy has been disposed
+                _razorLogger.LogWarning("Could not resolve project capability for hierarchy due to hierarchy being disposed.");
+                return false;
+            }
+        }
+
+        public override bool HasCapability(string documentFilePath, object project, string capability) => HasCapability(project, capability);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -26,4 +26,9 @@
   <Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
     <Class class="Microsoft.VisualStudio.Mac.RazorAddin.RazorProjectExtension" insertafter="FinalStep" />
   </Extension>
+
+  <!-- Feature Switches -->
+  <Extension path="/MonoDevelop/Core/FeatureSwitches">
+    <FeatureSwitch id="Razor.LSP.Editor" _description="Enables the Razor LSP editor for ASP.NET Core scenarios" defaultValue="false" />
+  </Extension>
 </ExtensionModel>

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/VisualStudioMacLSPEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/VisualStudioMacLSPEditorFeatureDetectorTest.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using MonoDevelop.Projects;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public class VisualStudioMacLSPEditorFeatureDetectorTest
+    {
+        [Fact]
+        public void IsLSPEditorAvailable_ProjectSupported_ReturnsTrue()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                ProjectSupportsLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsLSPEditorAvailable_LegacyEditorEnabled_ReturnsFalse()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                UseLegacyEditor = true,
+                ProjectSupportsLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsLSPEditorAvailable_IsVSRemoteClient_ReturnsTrue()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                IsRemoteClientValue = true,
+                ProjectSupportsLSPEditorValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsLSPEditorAvailable_UnsupportedProject_ReturnsFalse()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                ProjectSupportsLSPEditorValue = false,
+            };
+
+            // Act
+            var result = featureDetector.IsLSPEditorAvailable("testMoniker", hierarchy: null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsRemoteClient_VSRemoteClient_ReturnsTrue()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector()
+            {
+                IsRemoteClientValue = true,
+            };
+
+            // Act
+            var result = featureDetector.IsRemoteClient();
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsRemoteClient_UnknownEnvironment_ReturnsFalse()
+        {
+            // Arrange
+            var featureDetector = new TestLSPEditorFeatureDetector();
+
+            // Act
+            var result = featureDetector.IsRemoteClient();
+
+            // Assert
+            Assert.False(result);
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete (Test constructor)
+        private class TestLSPEditorFeatureDetector : VisualStudioMacLSPEditorFeatureDetector
+        {
+            public bool UseLegacyEditor { get; set; }
+
+            public bool IsLiveShareHostValue { get; set; }
+
+            public bool IsRemoteClientValue { get; set; }
+
+            public bool ProjectSupportsLSPEditorValue { get; set; }
+
+            public override bool IsLSPEditorAvailable() => !UseLegacyEditor;
+
+            public override bool IsLiveShareHost() => IsLiveShareHostValue;
+
+            public override bool IsRemoteClient() => IsRemoteClientValue;
+
+            private protected override bool ProjectSupportsLSPEditor(string documentFilePath, DotNetProject project) => ProjectSupportsLSPEditorValue;
+        }
+#pragma warning restore CS0618 // Type or member is obsolete (Test constructor)
+    }
+}


### PR DESCRIPTION
- The LSP editor feature detector is the key component in the system that decides "should we turn on the LSP editor". Therefore we have to make a VS4mac specific version of the detector because the project types are different (`DotNetProject` instead of `IVsHierarchy`) and the settings / feature flags are different.
- Added a feature switch for the VS4Mac LSP editor. This doesn't come with UI because adding UI has to be done in the VSMac platform itself + is an entirely different system (preview features). To unblock our inability to add UI / preview features the feature switch should enable us to turn on the new editor. Once we get the green light to add a preview feature we'll add the UI / understanding.
- Updated the existing `TextBufferProjectService` to understand resolving a documents project. The underlying code for this was already written I just needed to refactor it.
- Added tests.

#6038