### PR TITLE
Use project.razor.vs.json in VS scenario to avoid clashes.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
     {
         public const int VSCompletionItemKindOffset = 118115;
 
-        public const string ProjectConfigurationFile = "project.razor.json";
+        public const string DefaultProjectConfigurationFile = "project.razor.json";
 
         public const string RazorSemanticTokensLegendEndpoint = "_vs_/textDocument/semanticTokensLegend";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
@@ -10,5 +11,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOptions
     {
         public override bool SupportsFileManipulation { get; } = true;
+
+        public override string ProjectConfigurationFileName { get; } = LanguageServerConstants.DefaultProjectConfigurationFile;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
@@ -19,6 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
         private readonly FilePathNormalizer _filePathNormalizer;
         private readonly IEnumerable<IProjectConfigurationFileChangeListener> _listeners;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private readonly ILogger _logger;
         private FileSystemWatcher _watcher;
 
@@ -33,11 +35,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher!!,
             FilePathNormalizer filePathNormalizer!!,
             IEnumerable<IProjectConfigurationFileChangeListener> listeners!!,
+            LanguageServerFeatureOptions languageServerFeatureOptions!!,
             ILoggerFactory loggerFactory = null)
         {
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
             _filePathNormalizer = filePathNormalizer;
             _listeners = listeners;
+            _languageServerFeatureOptions = languageServerFeatureOptions;
             _logger = loggerFactory?.CreateLogger<ProjectConfigurationFileChangeDetector>();
         }
 
@@ -66,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return;
             }
 
-            _watcher = new RazorFileSystemWatcher(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile)
+            _watcher = new RazorFileSystemWatcher(workspaceDirectory, _languageServerFeatureOptions.ProjectConfigurationFileName)
             {
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime,
                 IncludeSubdirectories = true,
@@ -79,14 +83,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 // Translate file renames into remove / add
 
-                if (args.OldFullPath.EndsWith(LanguageServerConstants.ProjectConfigurationFile, FilePathComparison.Instance))
+                if (args.OldFullPath.EndsWith(_languageServerFeatureOptions.ProjectConfigurationFileName, FilePathComparison.Instance))
                 {
-                    // Renaming from project.razor.json to something else. Just remove the configuration file.
+                    // Renaming from project configuration file to something else. Just remove the configuration file.
                     FileSystemWatcher_ProjectConfigurationFileEvent_Background(args.OldFullPath, RazorFileChangeKind.Removed);
                 }
-                else if (args.FullPath.EndsWith(LanguageServerConstants.ProjectConfigurationFile, FilePathComparison.Instance))
+                else if (args.FullPath.EndsWith(_languageServerFeatureOptions.ProjectConfigurationFileName, FilePathComparison.Instance))
                 {
-                    // Renaming from a non-project.razor.json file to project.razor.json. Just add the configuration file.
+                    // Renaming from a non-project configuration file file to a real one. Just add the configuration file.
                     FileSystemWatcher_ProjectConfigurationFileEvent_Background(args.FullPath, RazorFileChangeKind.Added);
                 }
             };
@@ -110,7 +114,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         // Protected virtual for testing
         protected virtual IEnumerable<string> GetExistingConfigurationFiles(string workspaceDirectory)
         {
-            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, LanguageServerConstants.ProjectConfigurationFile, s_ignoredDirectories, logger: _logger);
+            var files = DirectoryHelper.GetFilteredFiles(workspaceDirectory, _languageServerFeatureOptions.ProjectConfigurationFileName, s_ignoredDirectories, logger: _logger);
 
             return files;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     }
                     else
                     {
-                        // Stale project.razor.json, most likely a user copy & pasted the project.razor.json and it hasn't
+                        // Stale project configuration file, most likely a user copy & pasted the project configuration file and it hasn't
                         // been re-computed yet. Fail deserialization.
                         projectRazorJson = null;
                         return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         var configurationFilePath = _filePathNormalizer.Normalize(args.ConfigurationFilePath);
                         if (!_configurationToProjectMap.TryGetValue(configurationFilePath, out var projectFilePath))
                         {
-                            // Failed to deserialize the initial project.razor.json on add so we can't remove the configuration file because it doesn't exist in the list.
+                            // Failed to deserialize the initial project configuration file on add so we can't remove the configuration file because it doesn't exist in the list.
                             _logger.LogWarning("Failed to resolve associated project on configuration removed event. Configuration file path: '{0}'", configurationFilePath);
                             return;
                         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
         protected virtual void SerializeToFile(OmniSharpProjectSnapshot projectSnapshot, string publishFilePath)
         {
             // We need to avoid having an incomplete file at any point, but our
-            // project.razor.json is large enough that it will be written as multiple operations.
+            // project configuration is large enough that it will be written as multiple operations.
             var tempFilePath = string.Concat(publishFilePath, TempFileExt);
             var tempFileInfo = new FileInfo(tempFilePath);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
@@ -267,7 +267,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             intermediateOutputPath = intermediateOutputPath
                 .Replace('\\', Path.DirectorySeparatorChar)
                 .Replace('/', Path.DirectorySeparatorChar);
-            path = Path.Combine(intermediateOutputPath, LanguageServerConstants.ProjectConfigurationFile);
+            path = Path.Combine(intermediateOutputPath, LanguageServerConstants.DefaultProjectConfigurationFile);
             return true;
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -8,5 +8,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
     internal abstract class LanguageServerFeatureOptions
     {
         public abstract bool SupportsFileManipulation { get; }
+
+        public abstract string ProjectConfigurationFileName { get; }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/TagHelperDescriptorJsonConverter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/TagHelperDescriptorJsonConverter.cs
@@ -994,7 +994,7 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization
                 return null;
             }
 
-            // Some of the string using in a basic project.razor.json are interned by other processes,
+            // Some of the strings used in TagHelperDescriptors are interned by other processes,
             // so we should avoid duplicating those.
             var interned = string.IsInterned(str);
             if (interned != null)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VSLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/VSLanguageServerFeatureOptions.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
-using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+namespace Microsoft.VisualStudio.Editor.Razor
 {
     [Export(typeof(VSLanguageServerFeatureOptions))]
     internal class VSLanguageServerFeatureOptions : LanguageServerFeatureOptions
@@ -22,6 +19,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         // We don't currently support file creation operations on VS Codespaces or VS Liveshare
         public override bool SupportsFileManipulation => !IsCodespacesOrLiveshare;
+
+        // In VS we override the project configuration file name because we don't want our serialized state to clash with other platforms (VSCode)
+        public override string ProjectConfigurationFileName => "project.razor.vs.json";
 
         private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ProjectRazorJsonPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ProjectRazorJsonPublisher.cs
@@ -218,8 +218,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                     }
 
                     // We don't want to serialize the project until it's ready to avoid flashing as the project loads different parts.
-                    // Since the project.razor.json from last session likely still exists the experience is unlikely to be degraded by this delay.
-                    // An exception is made for when there's no existing project.razor.json because some flashing is preferable to having no TagHelper knowledge.
+                    // Since the project configuration from last session likely still exists the experience is unlikely to be degraded by this delay.
+                    // An exception is made for when there's no existing project configuration file because some flashing is preferable to having no TagHelper knowledge.
                     if (ShouldSerialize(projectSnapshot, configurationFilePath))
                     {
                         SerializeToFile(projectSnapshot, configurationFilePath);
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         protected virtual void SerializeToFile(ProjectSnapshot projectSnapshot, string publishFilePath)
         {
             // We need to avoid having an incomplete file at any point, but our
-            // project.razor.json is large enough that it will be written as multiple operations.
+            // project configuration file is large enough that it will be written as multiple operations.
             var tempFilePath = string.Concat(publishFilePath, TempFileExt);
             var tempFileInfo = new FileInfo(tempFilePath);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -31,15 +32,18 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private IDisposable _subscription;
 
         private const string RootNamespaceProperty = "RootNamespace";
+        private readonly VSLanguageServerFeatureOptions _languageServerFeatureOptions;
 
         [ImportingConstructor]
         public DefaultRazorProjectHost(
             IUnconfiguredProjectCommonServices commonServices,
             [Import(typeof(VisualStudioWorkspace))] Workspace workspace,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            ProjectConfigurationFilePathStore projectConfigurationFilePathStore)
+            ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
+            VSLanguageServerFeatureOptions languageServerFeatureOptions)
             : base(commonServices, workspace, projectSnapshotManagerDispatcher, projectConfigurationFilePathStore)
         {
+            _languageServerFeatureOptions = languageServerFeatureOptions;
         }
 
         // Internal for testing
@@ -117,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
                         if (TryGetIntermediateOutputPath(update.Value.CurrentState, out var intermediatePath))
                         {
-                            var projectRazorJson = Path.Combine(intermediatePath, "project.razor.json");
+                            var projectRazorJson = Path.Combine(intermediatePath, _languageServerFeatureOptions.ProjectConfigurationFileName);
                             ProjectConfigurationFilePathStore.Set(hostProject.FilePath, projectRazorJson);
                         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackRazorProjectHost.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem;
 using ContentItem = Microsoft.CodeAnalysis.Razor.ProjectSystem.ManagedProjectSystemSchema.ContentItem;
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     internal class FallbackRazorProjectHost : RazorProjectHostBase
     {
         private const string MvcAssemblyFileName = "Microsoft.AspNetCore.Mvc.Razor.dll";
-
+        private readonly VSLanguageServerFeatureOptions _languageServerFeatureOptions;
         private IDisposable _subscription;
 
         [ImportingConstructor]
@@ -41,9 +42,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             IUnconfiguredProjectCommonServices commonServices,
             [Import(typeof(VisualStudioWorkspace))] Workspace workspace,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            ProjectConfigurationFilePathStore projectConfigurationFilePathStore)
+            ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
+            VSLanguageServerFeatureOptions languageServerFeatureOptions)
             : base(commonServices, workspace, projectSnapshotManagerDispatcher, projectConfigurationFilePathStore)
         {
+            _languageServerFeatureOptions = languageServerFeatureOptions;
         }
 
         internal FallbackRazorProjectHost(
@@ -144,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
                     if (TryGetIntermediateOutputPath(update.Value.CurrentState, out var intermediatePath))
                     {
-                        var projectRazorJson = Path.Combine(intermediatePath, "project.razor.json");
+                        var projectRazorJson = Path.Combine(intermediatePath, _languageServerFeatureOptions.ProjectConfigurationFileName);
                         ProjectConfigurationFilePathStore.Set(hostProject.FilePath, projectRazorJson);
                     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -39,6 +39,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 FilePathNormalizer,
                 directoryPathResolver.Object,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                TestLanguageServerFeatureOptions.Instance,
                 LoggerFactory);
             configurationFileEndpoint.Dispose();
             var request = new MonitorProjectConfigurationFilePathParams()
@@ -63,6 +64,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 FilePathNormalizer,
                 directoryPathResolver.Object,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+                TestLanguageServerFeatureOptions.Instance,
                 LoggerFactory);
             var request = new MonitorProjectConfigurationFilePathParams()
             {
@@ -345,6 +347,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     filePathNormalizer,
                     workspaceDirectoryPathResolver,
                     listeners,
+                    TestLanguageServerFeatureOptions.Instance,
                     loggerFactory)
             {
                 _fileChangeDetectorFactory = fileChangeDetectorFactory ?? (() => Mock.Of<IFileChangeDetector>(MockBehavior.Strict));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 CancellationTokenSource cancellationTokenSource,
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
                 IEnumerable<IProjectConfigurationFileChangeListener> listeners,
-                IReadOnlyList<string> existingConfigurationFiles) : base(projectSnapshotManagerDispatcher, new FilePathNormalizer(), listeners)
+                IReadOnlyList<string> existingConfigurationFiles) : base(projectSnapshotManagerDispatcher, new FilePathNormalizer(), listeners, TestLanguageServerFeatureOptions.Instance)
             {
                 _cancellationTokenSource = cancellationTokenSource;
                 _existingConfigurationFiles = existingConfigurationFiles;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestLanguageServerFeatureOptions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
+    {
+        public static readonly LanguageServerFeatureOptions Instance = new TestLanguageServerFeatureOptions();
+
+        private TestLanguageServerFeatureOptions()
+        {
+
+        }
+
+        public override bool SupportsFileManipulation => false;
+
+        public override string ProjectConfigurationFileName => LanguageServerConstants.DefaultProjectConfigurationFile;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/MSBuildProjectManagerTest.cs
@@ -292,7 +292,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             var intermediateOutputPath = "C:/project\\obj";
             projectRootElement.AddProperty(MSBuildProjectManager.IntermediateOutputPathPropertyName, intermediateOutputPath);
             var projectInstance = new ProjectInstance(projectRootElement);
-            var expectedPath = string.Format(CultureInfo.InvariantCulture, "C:{0}project{0}obj{0}{1}", Path.DirectorySeparatorChar, LanguageServerConstants.ProjectConfigurationFile);
+            var expectedPath = string.Format(CultureInfo.InvariantCulture, "C:{0}project{0}obj{0}{1}", Path.DirectorySeparatorChar, LanguageServerConstants.DefaultProjectConfigurationFile);
 
             // Act
             var result = MSBuildProjectManager.TryResolveConfigurationOutputPath(projectInstance, out var path);
@@ -324,7 +324,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             var intermediateOutputPath = string.Format(CultureInfo.InvariantCulture, "C:{0}project{0}obj", Path.DirectorySeparatorChar);
             projectRootElement.AddProperty(MSBuildProjectManager.IntermediateOutputPathPropertyName, intermediateOutputPath);
             var projectInstance = new ProjectInstance(projectRootElement);
-            var expectedPath = Path.Combine(intermediateOutputPath, LanguageServerConstants.ProjectConfigurationFile);
+            var expectedPath = Path.Combine(intermediateOutputPath, LanguageServerConstants.DefaultProjectConfigurationFile);
 
             // Act
             var result = MSBuildProjectManager.TryResolveConfigurationOutputPath(projectInstance, out var path);


### PR DESCRIPTION
- Prior to this when VSCode + VS were open simultaneously both IDes would fight for ownership over the project.razor.json file which would break colorization, diagnostics, basically everything IntelliSense related.
- To make the language server use a new file format I expanded the existing language server feature options to include a project configuration file name.
- Updated existing references to project.razor.json in product code to use "configuration file" instead of anything specific.
- All integration tests would fail gloriously if this part of the system fell over so we get testing for free here :).

Fixes #5764