### PR TITLE
Update Visual Studio project system hook names (mac/win)

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     // MSBuild provides configuration support (>= 2.1).
     [AppliesTo("DotNetCoreRazor & DotNetCoreRazorConfiguration")]
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
-    internal class DefaultRazorProjectHost : RazorProjectHostBase
+    internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
     {
         private IDisposable _subscription;
 
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private readonly VSLanguageServerFeatureOptions _languageServerFeatureOptions;
 
         [ImportingConstructor]
-        public DefaultRazorProjectHost(
+        public DefaultWindowsRazorProjectHost(
             IUnconfiguredProjectCommonServices commonServices,
             [Import(typeof(VisualStudioWorkspace))] Workspace workspace,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         // Internal for testing
-        internal DefaultRazorProjectHost(
+        internal DefaultWindowsRazorProjectHost(
             IUnconfiguredProjectCommonServices commonServices,
             Workspace workspace,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -31,14 +31,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     // MSBuild does not provides configuration support (SDK < 2.1).
     [AppliesTo("(DotNetCoreRazor | DotNetCoreWeb) & !DotNetCoreRazorConfiguration")]
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
-    internal class FallbackRazorProjectHost : RazorProjectHostBase
+    internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
     {
         private const string MvcAssemblyFileName = "Microsoft.AspNetCore.Mvc.Razor.dll";
         private readonly VSLanguageServerFeatureOptions _languageServerFeatureOptions;
         private IDisposable _subscription;
 
         [ImportingConstructor]
-        public FallbackRazorProjectHost(
+        public FallbackWindowsRazorProjectHost(
             IUnconfiguredProjectCommonServices commonServices,
             [Import(typeof(VisualStudioWorkspace))] Workspace workspace,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             _languageServerFeatureOptions = languageServerFeatureOptions;
         }
 
-        internal FallbackRazorProjectHost(
+        internal FallbackWindowsRazorProjectHost(
             IUnconfiguredProjectCommonServices commonServices,
             Workspace workspace,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     /// <summary>
     /// Needs to SetPublisherPath for DefaultRazorProjectChangePublisher
     /// </summary>
-    internal abstract class RazorProjectHostBase : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
+    internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
     {
         private readonly Workspace _workspace;
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         // 250ms between publishes to prevent bursts of changes yet still be responsive to changes.
         internal int EnqueueDelay { get; set; } = 250;
 
-        public RazorProjectHostBase(
+        public WindowsRazorProjectHostBase(
             IUnconfiguredProjectCommonServices commonServices!!,
             [Import(typeof(VisualStudioWorkspace))] Workspace workspace!!,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher!!,
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         // Internal for testing
-        protected RazorProjectHostBase(
+        protected WindowsRazorProjectHostBase(
             IUnconfiguredProjectCommonServices commonServices,
             Workspace workspace,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultDotNetProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultDotNetProjectHost.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
         private readonly VisualStudioMacWorkspaceAccessor _workspaceAccessor;
         private readonly TextBufferProjectService _projectService;
-        private RazorProjectHostBase _razorProjectHost;
+        private MacRazorProjectHostBase _razorProjectHost;
 
         public DefaultDotNetProjectHost(
             DotNetProject project!!,
@@ -87,12 +87,12 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
                 if (_project.IsCapabilityMatch(ExplicitRazorConfigurationCapability))
                 {
                     // SDK >= 2.1
-                    _razorProjectHost = new DefaultRazorProjectHost(_project, _projectSnapshotManagerDispatcher, projectSnapshotManager);
+                    _razorProjectHost = new DefaultMacRazorProjectHost(_project, _projectSnapshotManagerDispatcher, projectSnapshotManager);
                     return;
                 }
 
                 // We're an older version of Razor at this point, SDK < 2.1
-                _razorProjectHost = new FallbackRazorProjectHost(_project, _projectSnapshotManagerDispatcher, projectSnapshotManager);
+                _razorProjectHost = new FallbackMacRazorProjectHost(_project, _projectSnapshotManagerDispatcher, projectSnapshotManager);
             }, CancellationToken.None);
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultMacRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/DefaultMacRazorProjectHost.cs
@@ -18,7 +18,7 @@ using MonoDevelop.Projects.MSBuild;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 {
-    internal class DefaultRazorProjectHost : RazorProjectHostBase
+    internal class DefaultMacRazorProjectHost : MacRazorProjectHostBase
     {
         private const string RazorLangVersionProperty = "RazorLangVersion";
         private const string RazorDefaultConfigurationProperty = "RazorDefaultConfiguration";
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 
         private IReadOnlyList<string> _currentRazorFilePaths = Array.Empty<string>();
 
-        public DefaultRazorProjectHost(
+        public DefaultMacRazorProjectHost(
             DotNetProject project,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
             ProjectSnapshotManagerBase projectSnapshotManager)

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/FallbackMacRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/FallbackMacRazorProjectHost.cs
@@ -16,11 +16,11 @@ using AssemblyReference = MonoDevelop.Projects.AssemblyReference;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 {
-    internal class FallbackRazorProjectHost : RazorProjectHostBase
+    internal class FallbackMacRazorProjectHost : MacRazorProjectHostBase
     {
         private const string MvcAssemblyFileName = "Microsoft.AspNetCore.Mvc.Razor.dll";
 
-        public FallbackRazorProjectHost(
+        public FallbackMacRazorProjectHost(
             DotNetProject project,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
             ProjectSnapshotManagerBase projectSnapshotManager)

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/MacRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/MacRazorProjectHostBase.cs
@@ -16,7 +16,7 @@ using MonoDevelop.Projects;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 {
-    internal abstract class RazorProjectHostBase
+    internal abstract class MacRazorProjectHostBase
     {
         // References changes are always triggered when project changes happen.
         private const string ProjectChangedHint = "References";
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
         private readonly AsyncSemaphore _projectChangedSemaphore;
         private readonly Dictionary<string, HostDocument> _currentDocuments;
 
-        public RazorProjectHostBase(
+        public MacRazorProjectHostBase(
             DotNetProject project!!,
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher!!,
             ProjectSnapshotManagerBase projectSnapshotManager!!)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -18,9 +18,9 @@ using ItemCollection = Microsoft.VisualStudio.ProjectSystem.ItemCollection;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class DefaultRazorProjectHostTest : ProjectSnapshotManagerDispatcherWorkspaceTestBase
+    public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatcherWorkspaceTestBase
     {
-        public DefaultRazorProjectHostTest()
+        public DefaultWindowsRazorProjectHostTest()
         {
             ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
 
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+            var result = DefaultWindowsRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
 
             // Assert
             Assert.False(result);
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+            var result = DefaultWindowsRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
 
             // Assert
             Assert.False(result);
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+            var result = DefaultWindowsRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
 
             // Assert
             Assert.False(result);
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
+            var result = DefaultWindowsRazorProjectHost.TryGetDefaultConfiguration(projectState, out var defaultConfiguration);
 
             // Assert
             Assert.True(result);
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+            var result = DefaultWindowsRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
 
             // Assert
             Assert.False(result);
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+            var result = DefaultWindowsRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
 
             // Assert
             Assert.False(result);
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+            var result = DefaultWindowsRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
 
             // Assert
             Assert.False(result);
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+            var result = DefaultWindowsRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
 
             // Assert
             Assert.True(result);
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
+            var result = DefaultWindowsRazorProjectHost.TryGetLanguageVersion(projectState, out var languageVersion);
 
             // Assert
             Assert.True(result);
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
 
             // Assert
             Assert.False(result);
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
 
             // Assert
             Assert.False(result);
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectState, out _);
 
             // Assert
             Assert.False(result);
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfigurationItem(expectedConfiguration, projectState, out var configurationItem);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfigurationItem(expectedConfiguration, projectState, out var configurationItem);
 
             // Assert
             Assert.True(result);
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+            var extensionNames = DefaultWindowsRazorProjectHost.GetExtensionNames(item);
 
             // Assert
             Assert.Empty(extensionNames);
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+            var extensionNames = DefaultWindowsRazorProjectHost.GetExtensionNames(item);
 
             // Assert
             Assert.Empty(extensionNames);
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+            var extensionNames = DefaultWindowsRazorProjectHost.GetExtensionNames(item);
 
             // Assert
             var extensionName = Assert.Single(extensionNames);
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var item = items.ToSnapshot().Items.Single();
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(item);
+            var extensionNames = DefaultWindowsRazorProjectHost.GetExtensionNames(item);
 
             // Assert
             Assert.Collection(
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
+            var result = DefaultWindowsRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
 
             // Assert
             Assert.True(result);
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
+            var result = DefaultWindowsRazorProjectHost.TryGetExtensions(new[] { "Extension1", "Extension2" }, projectState, out var extensions);
 
             // Assert
             Assert.True(result);
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetExtensions(new[] { expectedExtension1Name, expectedExtension2Name }, projectState, out var extensions);
+            var result = DefaultWindowsRazorProjectHost.TryGetExtensions(new[] { expectedExtension1Name, expectedExtension2Name }, projectState, out var extensions);
 
             // Assert
             Assert.True(result);
@@ -447,7 +447,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
             Assert.False(result);
@@ -469,7 +469,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
             Assert.False(result);
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
             Assert.False(result);
@@ -521,7 +521,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
             Assert.True(result);
@@ -555,7 +555,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
             Assert.True(result);
@@ -603,7 +603,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }.ToImmutableDictionary();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+            var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
 
             // Assert
             Assert.True(result);
@@ -620,7 +620,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             // Arrange
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             // Act & Assert
             await host.LoadAsync();
@@ -635,7 +635,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             // Arrange
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             // Act & Assert
             await Task.Run(async () => await host.LoadAsync());
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             };
 
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             // Act & Assert
             await Task.Run(async () => await host.LoadAsync());
@@ -757,7 +757,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             };
 
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             await Task.Run(async () => await host.LoadAsync());
             Assert.Empty(ProjectManager.Projects);
@@ -804,7 +804,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             };
 
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             await Task.Run(async () => await host.LoadAsync());
             Assert.Empty(ProjectManager.Projects);
@@ -850,7 +850,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             };
 
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             await Task.Run(async () => await host.LoadAsync());
             Assert.Empty(ProjectManager.Projects);
@@ -1000,7 +1000,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             };
 
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             await Task.Run(async () => await host.LoadAsync());
             Assert.Empty(ProjectManager.Projects);
@@ -1070,7 +1070,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             };
 
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             await Task.Run(async () => await host.LoadAsync());
             Assert.Empty(ProjectManager.Projects);
@@ -1145,7 +1145,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
-            var host = new DefaultRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
+            var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, ProjectConfigurationFilePathStore, ProjectManager);
 
             await Task.Run(async () => await host.LoadAsync());
             Assert.Empty(ProjectManager.Projects);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
@@ -16,9 +16,9 @@ using ItemReference = Microsoft.CodeAnalysis.Razor.ProjectSystem.ManagedProjectS
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class FallbackRazorProjectHostTest : ProjectSnapshotManagerDispatcherWorkspaceTestBase
+    public class FallbackWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatcherWorkspaceTestBase
     {
-        public FallbackRazorProjectHostTest()
+        public FallbackWindowsRazorProjectHostTest()
         {
             ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
 
@@ -635,7 +635,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.Empty(ProjectManager.Projects);
         }
 
-        private class TestFallbackRazorProjectHost : FallbackRazorProjectHost
+        private class TestFallbackRazorProjectHost : FallbackWindowsRazorProjectHost
         {
             internal TestFallbackRazorProjectHost(
                 IUnconfiguredProjectCommonServices commonServices,

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/DefaultMacRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/DefaultMacRazorProjectHostTest.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 {
-    public class DefaultRazorProjectHostTest
+    public class DefaultMacRazorProjectHostTest
     {
         [Fact]
         public void IsRazorDocumentItem_NonContentItem_ReturnsFalse()
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+            var result = DefaultMacRazorProjectHost.IsRazorDocumentItem(item);
 
             // Assert
             Assert.False(result);
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var item = new TestMSBuildItem("Content");
 
             // Act
-            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+            var result = DefaultMacRazorProjectHost.IsRazorDocumentItem(item);
 
             // Assert
             Assert.False(result);
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+            var result = DefaultMacRazorProjectHost.IsRazorDocumentItem(item);
 
             // Assert
             Assert.False(result);
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+            var result = DefaultMacRazorProjectHost.IsRazorDocumentItem(item);
 
             // Assert
             Assert.True(result);
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var result = DefaultRazorProjectHost.IsRazorDocumentItem(item);
+            var result = DefaultMacRazorProjectHost.IsRazorDocumentItem(item);
 
             // Assert
             Assert.True(result);
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var projectProperties = new MSBuildPropertyGroup();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectProperties, out var defaultConfiguration);
+            var result = DefaultMacRazorProjectHost.TryGetDefaultConfiguration(projectProperties, out var defaultConfiguration);
 
             // Assert
             Assert.False(result);
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             projectProperties.SetValue("RazorDefaultConfiguration", string.Empty);
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectProperties, out var defaultConfiguration);
+            var result = DefaultMacRazorProjectHost.TryGetDefaultConfiguration(projectProperties, out var defaultConfiguration);
 
             // Assert
             Assert.False(result);
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             projectProperties.SetValue("RazorDefaultConfiguration", expectedConfiguration);
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetDefaultConfiguration(projectProperties, out var defaultConfiguration);
+            var result = DefaultMacRazorProjectHost.TryGetDefaultConfiguration(projectProperties, out var defaultConfiguration);
 
             // Assert
             Assert.True(result);
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var projectProperties = new MSBuildPropertyGroup();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
+            var result = DefaultMacRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
 
             // Assert
             Assert.False(result);
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             projectProperties.SetValue("RazorLangVersion", string.Empty);
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
+            var result = DefaultMacRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
 
             // Assert
             Assert.False(result);
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             projectProperties.SetValue("RazorLangVersion", "1.0");
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
+            var result = DefaultMacRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
 
             // Assert
             Assert.True(result);
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             projectProperties.SetValue("RazorLangVersion", "13.37");
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
+            var result = DefaultMacRazorProjectHost.TryGetLanguageVersion(projectProperties, out var languageVersion);
 
             // Assert
             Assert.True(result);
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var projectItems = Enumerable.Empty<IMSBuildItemEvaluated>();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectItems, out var configurationItem);
+            var result = DefaultMacRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectItems, out var configurationItem);
 
             // Assert
             Assert.False(result);
@@ -222,7 +222,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectItems, out var configurationItem);
+            var result = DefaultMacRazorProjectHost.TryGetConfigurationItem("Razor-13.37", projectItems, out var configurationItem);
 
             // Assert
             Assert.False(result);
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfigurationItem(expectedConfiguration, projectItems, out var configurationItem);
+            var result = DefaultMacRazorProjectHost.TryGetConfigurationItem(expectedConfiguration, projectItems, out var configurationItem);
 
             // Assert
             Assert.True(result);
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var configurationItem = new TestMSBuildItem("RazorConfiguration");
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
+            var extensionNames = DefaultMacRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
             Assert.Empty(extensionNames);
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             configurationItem.TestMetadata.SetValue("Extensions", string.Empty);
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
+            var extensionNames = DefaultMacRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
             Assert.Empty(extensionNames);
@@ -291,7 +291,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             configurationItem.TestMetadata.SetValue("Extensions", expectedExtensionName);
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
+            var extensionNames = DefaultMacRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
             var extensionName = Assert.Single(extensionNames);
@@ -306,7 +306,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             configurationItem.TestMetadata.SetValue("Extensions", "SomeExtensionName;SomeOtherExtensionName");
 
             // Act
-            var extensionNames = DefaultRazorProjectHost.GetExtensionNames(configurationItem);
+            var extensionNames = DefaultMacRazorProjectHost.GetExtensionNames(configurationItem);
 
             // Assert
             Assert.Collection(
@@ -328,7 +328,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var extensions = DefaultRazorProjectHost.GetExtensions(new[] { "Extension1", "Extension2" }, projectItems);
+            var extensions = DefaultMacRazorProjectHost.GetExtensions(new[] { "Extension1", "Extension2" }, projectItems);
 
             // Assert
             Assert.Empty(extensions);
@@ -347,7 +347,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var extensions = DefaultRazorProjectHost.GetExtensions(new[] { "Extension1", "Extension2" }, projectItems);
+            var extensions = DefaultMacRazorProjectHost.GetExtensions(new[] { "Extension1", "Extension2" }, projectItems);
 
             // Assert
             Assert.Empty(extensions);
@@ -376,7 +376,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var extensions = DefaultRazorProjectHost.GetExtensions(new[] { expectedExtension1Name, expectedExtension2Name }, projectItems);
+            var extensions = DefaultMacRazorProjectHost.GetExtensions(new[] { expectedExtension1Name, expectedExtension2Name }, projectItems);
 
             // Assert
             Assert.Collection(
@@ -393,7 +393,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var projectItems = Array.Empty<IMSBuildItemEvaluated>();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
+            var result = DefaultMacRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
 
             // Assert
             Assert.False(result);
@@ -409,7 +409,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var projectItems = Array.Empty<IMSBuildItemEvaluated>();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
+            var result = DefaultMacRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
 
             // Assert
             Assert.False(result);
@@ -426,7 +426,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var projectItems = Array.Empty<IMSBuildItemEvaluated>();
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
+            var result = DefaultMacRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
 
             // Assert
             Assert.False(result);
@@ -449,7 +449,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             };
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
+            var result = DefaultMacRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
 
             // Assert
             Assert.True(result);
@@ -495,7 +495,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             projectProperties.SetValue("RazorLangVersion", "1.0");
 
             // Act
-            var result = DefaultRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
+            var result = DefaultMacRazorProjectHost.TryGetConfiguration(projectProperties, projectItems, out var configuration);
 
             // Assert
             Assert.True(result);

--- a/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/FallbackMacRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectSystem/FallbackMacRazorProjectHostTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
 {
-    public class FallbackRazorProjectHostTest
+    public class FallbackMacRazorProjectHostTest
     {
         [Theory]
         [InlineData(null)]
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var assemblyReference = new AssemblyReference(assemblyFilePath);
 
             // Act
-            var result = FallbackRazorProjectHost.IsMvcAssembly(assemblyReference);
+            var result = FallbackMacRazorProjectHost.IsMvcAssembly(assemblyReference);
 
             // Assert
             Assert.False(result);
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var assemblyReference = new AssemblyReference(assemblyFilePath);
 
             // Act
-            var result = FallbackRazorProjectHost.IsMvcAssembly(assemblyReference);
+            var result = FallbackMacRazorProjectHost.IsMvcAssembly(assemblyReference);
 
             // Assert
             Assert.False(result);
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.ProjectSystem
             var assemblyReference = new AssemblyReference(assemblyFilePath);
 
             // Act
-            var result = FallbackRazorProjectHost.IsMvcAssembly(assemblyReference);
+            var result = FallbackMacRazorProjectHost.IsMvcAssembly(assemblyReference);
 
             // Assert
             Assert.True(result);


### PR DESCRIPTION
- Added `Windows` / `Mac` verbiage to each of our project system hooks to ensure they don't get confused with each other. I kept running into situations where i'd do Ctrl + T, search for `DefaultRazorProjectHost` and 9 times out of 10 would select the mac one when I wanted the windows one. Did it enough times where I decided to just make the verbiage change.