### PR TITLE
Remove Unneeded publish step

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -39,12 +39,3 @@ steps:
       publishLocation: Container
     continueOnError: true
     condition: succeededOrFailed()
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Screenshots
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.Razor.IntegrationTests\${{ parameters.configuration }}\net472\xUnitResults'
-      ArtifactName: '$(System.JobAttempt)-Screenshots ${{ parameters.configuration }} $(Build.BuildNumber)'
-      publishLocation: Container
-    continueOnError: true
-    condition: succeededOrFailed()


### PR DESCRIPTION
### Summary of the changes
 - This step is unnecessary since Screenshots get included in `Publish Logs`.
 - Since the folder doesn't ever exist the step gives a warning, making the run yellow instead of green.