### PR TITLE
Remove isFinalized semantic tokens logic

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -133,7 +134,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
             }
 
             // We can't get C# responses without significant amounts of extra work, so let's just shim it for now, any non-Null result is fine.
-            internal override Task<SemanticRangeResponse> GetCSharpSemanticRangesAsync(
+            internal override Task<SemanticRange[]> GetCSharpSemanticRangesAsync(
                 RazorCodeDocument codeDocument,
                 TextDocumentIdentifier textDocumentIdentifier,
                 Range range,
@@ -141,7 +142,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
                 CancellationToken cancellationToken,
                 string previousResultId = null)
             {
-                var result = SemanticRangeResponse.Default;
+                var result = Array.Empty<SemanticRange>();
                 return Task.FromResult(result);
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensResponse.cs
@@ -11,24 +11,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
     /// </summary>
     internal class ProvideSemanticTokensResponse
     {
-        public ProvideSemanticTokensResponse(int[]? tokens, bool isFinalized, long? hostDocumentSyncVersion)
+        public ProvideSemanticTokensResponse(int[]? tokens, long? hostDocumentSyncVersion)
         {
             Tokens = tokens;
-            IsFinalized = isFinalized;
             HostDocumentSyncVersion = hostDocumentSyncVersion;
         }
 
         public int[]? Tokens { get; }
 
-        public bool IsFinalized { get; }
-
         public long? HostDocumentSyncVersion { get; }
 
         public override bool Equals(object obj)
         {
-            if (obj is not ProvideSemanticTokensResponse other ||
-                other.IsFinalized != IsFinalized ||
-                other.HostDocumentSyncVersion != HostDocumentSyncVersion)
+            if (obj is not ProvideSemanticTokensResponse other || other.HostDocumentSyncVersion != HostDocumentSyncVersion)
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -373,8 +373,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 // If we're unable to synchronize we won't produce useful results, but we have to indicate
                 // it's due to out of sync by providing the old version
-                return new ProvideSemanticTokensResponse(
-                    tokens: null, isFinalized: false, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
+                return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
             }
 
             var csharpTextDocument = semanticTokensParams.TextDocument with { Uri = csharpDoc.Uri };
@@ -399,12 +398,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             if (result is null)
             {
                 // Weren't able to re-invoke C# semantic tokens but we have to indicate it's due to out of sync by providing the old version
-                return new ProvideSemanticTokensResponse(
-                    tokens: null, isFinalized: false, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
+                return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
             }
 
-            var response = new ProvideSemanticTokensResponse(
-                result.Data, result.IsFinalized, semanticTokensParams.RequiredHostDocumentVersion);
+            var response = new ProvideSemanticTokensResponse(result.Data, semanticTokensParams.RequiredHostDocumentVersion);
 
             return response;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -41,8 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 End = new OSharp.Position { Line = 3, Character = 0 }
             };
 
-            var csharpTokens = new ProvideSemanticTokensResponse(
-                tokens: Array.Empty<int>(), isFinalized: false, hostDocumentSyncVersion: 1);
+            var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: 1);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 1);
         }
 
@@ -95,8 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 End = new OSharp.Position { Line = 2, Character = 0 }
             };
 
-            var csharpTokens = new ProvideSemanticTokensResponse(
-                tokens: Array.Empty<int>(), isFinalized: true, hostDocumentSyncVersion: null);
+            var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: null);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 1);
         }
 
@@ -782,7 +780,7 @@ things *@
 
             if (csharpTokens is null)
             {
-                csharpTokens = new ProvideSemanticTokensResponse(tokens: null, isFinalized: true, documentVersion);
+                csharpTokens = new ProvideSemanticTokensResponse(tokens: null, documentVersion);
             }
 
             var (documentSnapshots, textDocumentIdentifiers) = CreateDocumentSnapshot(documentTexts, isRazorArray, DefaultTagHelpers);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -473,7 +473,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 requiredHostDocumentVersion: 0,
                 range: new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range());
             var expectedResults = new ProvideSemanticTokensResponse(
-                expectedcSharpResults.Data, expectedcSharpResults.IsFinalized, documentVersion);
+                expectedcSharpResults.Data, documentVersion);
 
             // Act
             var result = await target.ProvideSemanticTokensRangeAsync(request, CancellationToken.None);


### PR DESCRIPTION
### Summary of the changes
- This is unfortunate, but after talking with Cyrus, it turns out Roslyn doesn't have an accurate way to tell if frozen partial semantics have been finalized. Occasionally, this issue results in C# continually returning false for the `isFinalized` property, which in turn means we never cache tokens.
- Currently, the only options here are to (1) remove frozen partial semantics or (2) don't use caching. This PR opts for (1), since frozen partial semantics are most valuable at document open, while caching should be valuable throughout the use the document. (1) also means that we don't have to ask the C# server for tokens every time the LSP server sends us a request.
- I tested and besides for the initial colorization potentially seeming a bit more delayed, there don't seem to be other noticeable drawbacks.
- There will also be a Roslyn side PR that will have to be dual inserted with this one: [to-do: add link]

- Fixes:
https://github.com/dotnet/roslyn/issues/59777