### PR TITLE
Add output pane capture

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,7 +98,7 @@
     <MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>
     <OmniSharpMicrosoftExtensionsLoggingPackageVersion>2.0.0</OmniSharpMicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftVisualStudioEditorPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioEditorPackageVersion>
-    <MicrosoftVisualStudioExtensibilityTestingXunitVersion>0.1.124-beta</MicrosoftVisualStudioExtensibilityTestingXunitVersion>
+    <MicrosoftVisualStudioExtensibilityTestingXunitVersion>0.1.135-beta</MicrosoftVisualStudioExtensibilityTestingXunitVersion>
     <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingXunitVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>
     <MicrosoftVisualStudioLanguagePackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioLanguagePackageVersion>
     <MicrosoftVisualStudioLanguageIntellisensePackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioLanguageIntellisensePackageVersion>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Extensions/IVsTextViewExtensions.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Extensions/IVsTextViewExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Editor;
@@ -18,6 +20,18 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests.Extensions
 
             ErrorHandler.ThrowOnFailure(((IVsUserData)textView).GetData(DefGuidList.guidIWpfTextViewHost, out var wpfTextViewHost));
             return (IWpfTextViewHost)wpfTextViewHost;
+        }
+
+        public static async Task<string> GetContentAsync(this IVsTextView vsTextView, JoinableTaskFactory joinableTaskFactory, CancellationToken cancellationToken)
+        {
+            var textViewHost = await vsTextView.GetTextViewHostAsync(joinableTaskFactory, cancellationToken);
+            var lines = textViewHost.TextView.TextViewLines;
+            if (lines.Count < 1)
+            {
+                return string.Empty;
+            }
+
+            return string.Join(Environment.NewLine, lines.Select(l => l.Extent.GetText()));
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Extensions/IVsTextViewExtensions.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Extensions/IVsTextViewExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Editor;
@@ -25,13 +23,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests.Extensions
         public static async Task<string> GetContentAsync(this IVsTextView vsTextView, JoinableTaskFactory joinableTaskFactory, CancellationToken cancellationToken)
         {
             var textViewHost = await vsTextView.GetTextViewHostAsync(joinableTaskFactory, cancellationToken);
-            var lines = textViewHost.TextView.TextViewLines;
-            if (lines.Count < 1)
-            {
-                return string.Empty;
-            }
-
-            return string.Join(Environment.NewLine, lines.Select(l => l.Extent.GetText()));
+            return textViewHost.TextView.TextSnapshot.GetText();
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
@@ -41,19 +41,19 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
             var textView = OutputWindowPaneToIVsTextView(pane, sVSOutputWindow);
 
             return textView;
-        }
 
-        private static IVsTextView OutputWindowPaneToIVsTextView(EnvDTE.OutputWindowPane outputWindowPane, IVsOutputWindow sVsOutputWindow)
-        {
-            var guid = Guid.Parse(outputWindowPane.Guid);
-            ErrorHandler.ThrowOnFailure(sVsOutputWindow.GetPane(guid, out var result));
-
-            if (result is not IVsTextView textView)
+            static IVsTextView OutputWindowPaneToIVsTextView(EnvDTE.OutputWindowPane outputWindowPane, IVsOutputWindow sVsOutputWindow)
             {
-                throw new InvalidOperationException($"{nameof(IVsOutputWindowPane)} should implement {nameof(IVsTextView)}");
-            }
+                var guid = Guid.Parse(outputWindowPane.Guid);
+                ErrorHandler.ThrowOnFailure(sVsOutputWindow.GetPane(guid, out var result));
 
-            return textView;
+                if (result is not IVsTextView textView)
+                {
+                    throw new InvalidOperationException($"{nameof(IVsOutputWindowPane)} should implement {nameof(IVsTextView)}");
+                }
+
+                return textView;
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Razor.IntegrationTests.Extensions;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.Extensibility.Testing
+{
+    [TestService]
+    internal partial class OutputInProcess
+    {
+        private const string RazorPaneName = "Razor Language Server Client";
+
+        public async Task<string> GetOutputContentAsync(CancellationToken cancellationToken)
+        {
+            var outputPaneTextView = GetOutputPaneTextView(RazorPaneName);
+            return await outputPaneTextView.GetContentAsync(JoinableTaskFactory, cancellationToken);
+        }
+
+        private static IVsTextView GetOutputPaneTextView(string paneName)
+        {
+            var sVSOutputWindow = ServiceProvider.GlobalProvider.GetService<SVsOutputWindow, IVsOutputWindow>();
+            if (sVSOutputWindow is not IVsExtensibleObject extensibleObject)
+            {
+                throw new InvalidOperationException($"{nameof(SVsOutputWindow)} should implement {nameof(IVsExtensibleObject)}");
+            }
+
+            extensibleObject.GetAutomationObject(null, out var outputWindowObj);
+            var outputWindow = (EnvDTE.OutputWindow)outputWindowObj;
+
+            var pane = outputWindow.OutputWindowPanes.Item(paneName);
+
+            var guid = Guid.Parse(pane.Guid);
+            sVSOutputWindow.GetPane(guid, out var result);
+
+            if (result is not IVsTextView textView)
+            {
+                throw new InvalidOperationException($"{nameof(IVsOutputWindowPane)} should implement {nameof(IVsTextView)}");
+            }
+
+            return textView;
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes

- This allows you to capture the Output from the `Razor Language Server Client` Output pane. No current usage of it, but I confirmed that it worked so I thought I'd preserve the impl. Would be good to include in the test failure Logs once https://github.com/microsoft/vs-extension-testing/issues/112 is answered/done.

Fixes:

CC @sharwell who figured out a chain that could get us the contents even though the GUID is random.