### PR TITLE
Include missing assembly declarations in mpack manifest.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -9,6 +9,30 @@
     <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
     <Import assembly="Microsoft.CodeAnalysis.Razor.dll" />
     <Import assembly="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
+
+    <Import assembly="Microsoft.VisualStudio.LanguageServerClient.Razor.dll" />
+    <Import assembly="Microsoft.VisualStudio.LanguageServer.ContainedLanguage.dll" />
+    <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
+    <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.Common.dll" />
+    <Import assembly="MediatR.dll" />
+    <Import assembly="OmniSharp.Extensions.JsonRpc.dll" />
+    <Import assembly="OmniSharp.Extensions.LanguageProtocol.dll" />
+    <Import assembly="OmniSharp.Extensions.LanguageServer.dll" />
+    <Import assembly="OmniSharp.Extensions.LanguageServer.Shared.dll" />
+    <Import assembly="Microsoft.Extensions.Configuration.Binder.dll" />
+    <Import assembly="Microsoft.Extensions.Options.dll" />
+    <Import assembly="Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
+    <Import assembly="Microsoft.Extensions.Primitives.dll" />
+    <Import assembly="Microsoft.Extensions.DependencyInjection.dll" />
+    <Import assembly="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <Import assembly="Microsoft.Extensions.Configuration.dll" />
+    <Import assembly="Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <Import assembly="Microsoft.Extensions.Logging.dll" />
+    <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
+    <Import assembly="System.IO.Pipelines.dll" />
+    <Import assembly="System.Reactive.dll" />
+    <Import assembly="System.Runtime.CompilerServices.Unsafe.dll" />
+    <Import assembly="System.Threading.Channels.dll" />
   </Runtime>
   <Dependencies>
     <Addin id="::MonoDevelop.Core" version="17.0" />
@@ -19,6 +43,8 @@
   <Extension path="/MonoDevelop/Ide/Composition">
     <Assembly file="Microsoft.VisualStudio.Editor.Razor.dll" />
     <Assembly file="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
+    <Assembly file="Microsoft.VisualStudio.LanguageServerClient.Razor.dll" />
+    <Assembly file="Microsoft.VisualStudio.LanguageServer.ContainedLanguage.dll" />
     <Assembly file="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
   </Extension>
 


### PR DESCRIPTION
- WOOPS, totally missed some vital information in our VS4Mac mpack: MEF composition + runtime declarations.