### PR TITLE
Fix Completion of Markup Attributes in MVC scenarios

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -236,7 +236,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             if (tagHelperClassifiedTextTooltip != null)
             {
-                completionItem = completionItem with { Documentation = string.Empty };
                 vsCompletionItem.Description = tagHelperClassifiedTextTooltip;
                 return Task.FromResult<CompletionItem>(vsCompletionItem);
             }
@@ -449,7 +448,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             {
                 var attributeCompletionTypes = razorCompletionItem.GetAttributeCompletionTypes();
                 // If the attribute is a boolean than just its name is a legal response. Therefor don't do the snippet
-                if (attributeCompletionTypes.Any() && attributeCompletionTypes.Any(type => string.Equals(type, typeof(bool).ToString(), StringComparison.Ordinal)))
+                if (attributeCompletionTypes.Any(type => string.Equals(type, typeof(bool).ToString(), StringComparison.Ordinal)))
                 {
                     insertText = razorCompletionItem.InsertText;
                     return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -229,18 +229,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 completionItem = completionItem with { Documentation = documentation };
             }
 
+            // We might strip out the commitcharacters for speed, bring them back
+            var container = associatedRazorCompletion.CommitCharacters != null ? new Container<string>(associatedRazorCompletion.CommitCharacters) : null;
+            completionItem = completionItem with { CommitCharacters = container };
+            var vsCompletionItem = completionItem.ToVSCompletionItem(_capability?.VSCompletionList);
+
             if (tagHelperClassifiedTextTooltip != null)
             {
-                // We might strip out the commitcharacters for speed, bring them back
-                var container = associatedRazorCompletion.CommitCharacters != null ? new Container<string>(associatedRazorCompletion.CommitCharacters) : null;
-                var withCommit = completionItem with { CommitCharacters = container };
-                var vsCompletionItem = withCommit.ToVSCompletionItem(_capability?.VSCompletionList);
                 completionItem = completionItem with { Documentation = string.Empty };
                 vsCompletionItem.Description = tagHelperClassifiedTextTooltip;
                 return Task.FromResult<CompletionItem>(vsCompletionItem);
             }
 
-            return Task.FromResult(completionItem);
+            return Task.FromResult<CompletionItem>(vsCompletionItem);
         }
 
         // Internal for testing
@@ -448,7 +449,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             {
                 var attributeCompletionTypes = razorCompletionItem.GetAttributeCompletionTypes();
                 // If the attribute is a boolean than just its name is a legal response. Therefor don't do the snippet
-                if (attributeCompletionTypes.Any(type => string.Equals(type, typeof(bool).ToString(), StringComparison.Ordinal)))
+                if (attributeCompletionTypes.Any() && attributeCompletionTypes.Any(type => string.Equals(type, typeof(bool).ToString(), StringComparison.Ordinal)))
                 {
                     insertText = razorCompletionItem.InsertText;
                     return false;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -292,6 +292,30 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void TryConvert_TagHelperAttribute_ForHtml_ReturnsTrue()
+        {
+            // Arrange
+            var completionItem = new RazorCompletionItem("format", "format", RazorCompletionItemKind.TagHelperAttribute);
+            var attributeCompletionDescription = new AggregateBoundAttributeDescription(new BoundAttributeDescriptionInfo[] { });
+            completionItem.SetAttributeCompletionDescription(attributeCompletionDescription);
+
+            // Act
+            var result = RazorCompletionEndpoint.TryConvert(completionItem, _supportedCompletionItemKinds, out var converted);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(completionItem.DisplayText, converted.Label);
+            Assert.Equal("format=\"$0\"", converted.InsertText);
+            Assert.Equal(InsertTextFormat.Snippet, converted.InsertTextFormat);
+            Assert.Equal(completionItem.InsertText, converted.FilterText);
+            Assert.Equal(completionItem.InsertText, converted.SortText);
+            Assert.Null(converted.Detail);
+            Assert.Null(converted.Documentation);
+            Assert.Null(converted.Command);
+
+        }
+
+        [Fact]
         public void TryConvert_TagHelperAttribute_ReturnsTrue()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -312,7 +312,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);
-
         }
 
         [Fact]


### PR DESCRIPTION
### Summary of the changes

- Basically for MVC scenarios we were returning completions which were getting converted into snippets, but didn't re-constitute their CommitCharacters.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1501302