### PR TITLE
Fix VSIX deployment in build.cmd scenairos

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,7 +191,6 @@ stages:
             -configuration $(_BuildConfig)
             -msbuildEngine dotnet
             -prepareMachine
-            -integrationTest
             $(_BuildArgs)
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,7 +208,7 @@ stages:
           name: Build_Vsix
           displayName: Build and Deploy Vsix
           condition: succeeded()
-        - script: eng\CIBuild.ps1
+        - script: eng\CIBuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
             -test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,13 +182,12 @@ stages:
               arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - script: eng\common\Build.ps1
+        - script: eng\CIBuild.cmd
             -restore
             -build
             -sign
             -pack
             -publish
-            -ci
             -configuration $(_BuildConfig)
             -msbuildEngine dotnet
             -prepareMachine
@@ -210,10 +209,9 @@ stages:
           name: Build_Vsix
           displayName: Build and Deploy Vsix
           condition: succeeded()
-        - script: eng\common\Build.ps1
+        - script: eng\CIBuild.ps1
             -test
             -integrationTest
-            -ci
           name: Run_Tests
           displayName: Run Unit and Integration tests
           condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,13 @@ stages:
               arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - script: eng\common\cibuild.cmd
+        - script: eng\common\Build.ps1
+            -restore
+            -build
+            -sign
+            -pack
+            -publish
+            -ci
             -configuration $(_BuildConfig)
             -msbuildEngine dotnet
             -prepareMachine
@@ -202,7 +208,14 @@ stages:
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Build_Vsix
-          displayName: Build Vsix
+          displayName: Build and Deploy Vsix
+          condition: succeeded()
+        - script: eng\common\Build.ps1
+            -test
+            -integrationTest
+            -ci
+          name: Run_Tests
+          displayName: Run Unit and Integration tests
           condition: succeeded()
         # Run VSCode functional tests
         # - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,6 +209,8 @@ stages:
           displayName: Build and Deploy Vsix
           condition: succeeded()
         - script: eng\CIBuild.ps1
+            -configuration $(_BuildConfig)
+            -prepareMachine
             -test
             -integrationTest
           name: Run_Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,9 +197,12 @@ stages:
           name: Build
           displayName: Build
           condition: succeeded()
-        - script: eng\common\cibuild.cmd
+        - script: eng\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
+            -restore
+            -build
+            -pack
             /p:BuildVsix=true
             /p:BuildProjectReferences=false
             $(_BuildArgs)

--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0\common\Build.ps1""" -ci %*"

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -9,17 +9,42 @@ parameters:
 steps:
   - ${{ if eq(parameters.shallowCheckout, true) }}:
     - template: checkout-windows-task.yml
+
   - task: NodeTool@0
     displayName: Install Node 10.x
     inputs:
       versionSpec: 10.x
-  - script: eng\common\cibuild.cmd
+
+  - script: eng\cibuild.cmd
+      -configuration ${{ parameters.configuration }}
+      -msbuildEngine dotnet
+      -prepareMachine
+      -restore
+      -build
+      -pack
+      -sign
+      -publish
+    name: Build
+    displayName: Build
+    condition: succeeded()
+
+  - script: eng\cibuild.cmd
+      -configuration ${{ parameters.configuration }}
+      -msbuildEngine dotnet
+      -prepareMachine
+      /p:BuildVsix=true
+      /p:BuildProjectReferences=false
+    name: BuildVSIX
+    displayName: Build and Deploy VSIX
+    condition: succeeded()
+
+  - script: eng\cibuild.cmd
       -configuration ${{ parameters.configuration }}
       -msbuildEngine dotnet
       -prepareMachine
       -integrationTest
-    name: BuildAndTest
-    displayName: Build and Test
+    name: RunIntegrationTests
+    displayName: Run Integration Tests
     condition: succeeded()
 
   - task: PublishTestResults@2

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnEnterRulesTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnEnterRulesTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests;
 
 public class OnEnterRulesTests : AbstractRazorEditorTest
 {
-    [IdeFact(Skip = "VSIX Deployment issues")]
+    [IdeFact]
     public async Task OnEnterRules_BetweenStartAndEnd()
     {
         // Arrange
@@ -28,7 +28,7 @@ public class OnEnterRulesTests : AbstractRazorEditorTest
 ", HangMitigatingCancellationToken);
     }
 
-    [IdeFact(Skip = "VSIX Deployment issues")]
+    [IdeFact]
     public async Task OnEnterRules_AtEndOfTag()
     {
         // Arrange
@@ -48,7 +48,7 @@ A
 ", HangMitigatingCancellationToken);
     }
 
-    [IdeFact(Skip = "VSIX Deployment issues")]
+    [IdeFact]
     public async Task OnEnterRules_BeforeAttribute()
     {
         // Arrange
@@ -68,7 +68,7 @@ A
 ", HangMitigatingCancellationToken);
     }
 
-    [IdeFact(Skip = "VSIX Deployment issues")]
+    [IdeFact]
     public async Task OnEnterRules_EmptyAttribute()
     {
         // Arrange
@@ -87,7 +87,7 @@ A
 ", HangMitigatingCancellationToken);
     }
 
-    [IdeFact(Skip = "VSIX Deployment issues")]
+    [IdeFact]
     public async Task OnEnterRules_DoubleQuote()
     {
         // Arrange
@@ -106,7 +106,7 @@ A
 ", HangMitigatingCancellationToken);
     }
 
-    [IdeFact(Skip = "VSIX Deployment issues")]
+    [IdeFact]
     public async Task OnEnterRules_DirectiveAttribute()
     {
         // Arrange
@@ -125,7 +125,7 @@ A
 ", HangMitigatingCancellationToken);
     }
 
-    [IdeFact(Skip = "VSIX Deployment issues")]
+    [IdeFact]
     public async Task OnEnterRules_UnfinishedTag()
     {
         // Arrange


### PR DESCRIPTION
### Summary of the changes

- A previous commit marked our VSIX as something to be deployed to the "hive" on build, but now we need to organize the ci build in such as way that it can be actually used.
- Since we don't have the VSIX build available during the "Build" step I had to split the tests and integration tests out into their own step. I prefer this anyway since it gives a better idea of if the BUILD or the TESTS failed before looking more into specifics.
- The tests that I un-skipped should fail if the VSIX isn't being deployed properly because the changes to language-config.json haven't been inserted into VS yet.

Fixes: https://github.com/dotnet/razor-tooling/issues/6198
