### PR TITLE
Make RazorUIContextManager no-op in Mac scenarios.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorUIContextManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorUIContextManager.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+namespace Microsoft.VisualStudio.Editor.Razor
 {
     internal abstract class RazorUIContextManager
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Folding;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Extensions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsRazorUIContextManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsRazorUIContextManager.cs
@@ -1,26 +1,25 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     [Export(typeof(RazorUIContextManager))]
-    internal class DefaultRazorUIContextManager : RazorUIContextManager
+    internal class VisualStudioWindowsRazorUIContextManager : RazorUIContextManager
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly JoinableTaskFactory _joinableTaskFactory;
 
         [ImportingConstructor]
-        public DefaultRazorUIContextManager(SVsServiceProvider serviceProvider!!, JoinableTaskContext joinableTaskContext!!)
+        public VisualStudioWindowsRazorUIContextManager(SVsServiceProvider serviceProvider!!, JoinableTaskContext joinableTaskContext!!)
         {
             _serviceProvider = serviceProvider;
             _joinableTaskFactory = joinableTaskContext.Factory;

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacRazorUIContextManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacRazorUIContextManager.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Editor.Razor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Export(typeof(RazorUIContextManager))]
+    internal class VisualStudioMacRazorUIContextManager : RazorUIContextManager
+    {
+        public override Task SetUIContextAsync(Guid uiContextGuid, bool isActive, CancellationToken cancellationToken)
+        {
+            // UIContext's aren't a thing in VS4Mac.
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;


### PR DESCRIPTION
- The classical UIContextManager requires shell APIs to operate, those don't exist in VS4Mac but more importantly UIContext's in general don't exist in VS4Mac land.
- Moved the `RazorUIContextManager` to the Editor.Razor layer and created a Windows / Mac implementation in the corresponding impl dlls.

Part of #6038