### PR TITLE
Tease LogHub dependencies apart in VS4Mac.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/RazorLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/RazorLogHubTraceProvider.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Logging
+{
+    internal abstract class RazorLogHubTraceProvider
+    {
+        public abstract Task<TraceSource?> InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/HTMLCSharpLanguageServerLogHubLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/HTMLCSharpLanguageServerLogHubLoggerProviderFactory.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Composition;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/LogHubLoggerProviderFactoryBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/LogHubLoggerProviderFactoryBase.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLanguageServerLogHubLoggerProviderFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLanguageServerLogHubLoggerProviderFactory.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Composition;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
@@ -3,18 +3,18 @@
 
 using System.Composition;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 using Microsoft.VisualStudio.RpcContracts.Logging;
 using VSShell = Microsoft.VisualStudio.Shell;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging
 {
     [Shared]
     [Export(typeof(RazorLogHubTraceProvider))]
-    internal class RazorLogHubTraceProvider
+    internal class VisualStudioWindowsLogHubTraceProvider : RazorLogHubTraceProvider
     {
         private static readonly LoggerOptions s_logOptions = new(
             requestedLoggingLevel: new LoggingLevelSettings(SourceLevels.Information | SourceLevels.ActivityTracing),
@@ -23,12 +23,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
         private readonly SemaphoreSlim _initializationSemaphore;
         private IServiceBroker? _serviceBroker = null;
 
-        public RazorLogHubTraceProvider()
+        public VisualStudioWindowsLogHubTraceProvider()
         {
             _initializationSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
         }
 
-        public async Task<TraceSource?> InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken)
+        public override async Task<TraceSource?> InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken)
         {
             if ((await TryInitializeServiceBrokerAsync(cancellationToken).ConfigureAwait(false)) is false)
             {
@@ -45,7 +45,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
             return traceSource;
         }
 
-        [MemberNotNullWhen(returnValue: true, member: $"{nameof(_serviceBroker)}")]
         public async Task<bool> TryInitializeServiceBrokerAsync(CancellationToken cancellationToken)
         {
             await _initializationSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Logging/VisualStudioMacLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Logging/VisualStudioMacLogHubTraceProvider.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
+
+namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.Logging
+{
+    [Shared]
+    [Export(typeof(RazorLogHubTraceProvider))]
+    internal class VisualStudioMacLogHubTraceProvider : RazorLogHubTraceProvider
+    {
+        public override Task<TraceSource?> InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken)
+        {
+            // VS4Mac doesn't really support trace source logging today well. For now we'll generate a dummy trace source to ensure dependencies don't fall over.
+            return Task.FromResult<TraceSource?>(new TraceSource(logIdentifier));
+        }
+    }
+}


### PR DESCRIPTION
- The LSP client LogHub tech used to be tied to windows  due to how the LogHub bits were acquired. I moved that component to have a win/mac separate impl.
- There's now a shared "RazorLogHubTraceProvider" at the core VS.Editor layer (platform agnostic VS). Hopefully we get LogHub in VS4Mac eventually!

Part of #6038