### PR TITLE
Don't send any edits when there are no changes, and only send minimal…

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
@@ -24,12 +24,6 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
         Unformatted
     }
 
-    public enum DifferType
-    {
-        GetTextChanges,
-        SourceTextDiffer,
-    }
-
     [CsvExporter]
     [RPlotExporter]
     public class RazorCSharpFormattingBenchmark : RazorLanguageServerBenchmarkBase
@@ -55,9 +49,6 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
         [ParamsAllValues]
         public InputType InputType { get; set; }
 
-        [ParamsAllValues]
-        public DifferType DifferType { get; set; }
-
         [GlobalSetup(Target = nameof(RazorCSharpFormattingAsync))]
         public async Task InitializeRazorCSharpFormattingAsync()
         {
@@ -76,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
             DocumentText = await DocumentSnapshot.GetTextAsync();
         }
 
-        private void WriteSampleFormattingFile(string filePath, bool preformatted, int blocks)
+        private static void WriteSampleFormattingFile(string filePath, bool preformatted, int blocks)
         {
             var data = @"
 @{
@@ -128,9 +119,6 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
                 TabSize = 4,
                 InsertSpaces = true
             };
-
-            var useSourceTextDiffer = DifferType != DifferType.GetTextChanges;
-            options["UseSourceTextDiffer"] = new OmniSharp.Extensions.LanguageServer.Protocol.Models.BooleanNumberString(useSourceTextDiffer);
 
             var range = TextSpan.FromBounds(0, DocumentText.Length).AsRange(DocumentText);
             var edits = await RazorFormattingService.FormatAsync(DocumentUri, DocumentSnapshot, range, options, CancellationToken.None);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -71,13 +70,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 changedText = changedText.WithChanges(indentationChanges);
             }
 
-            // Allow benchmarks to specify a different diff algorithm
-            if (!context.Options.TryGetValue("UseSourceTextDiffer", out var useSourceTextDiffer))
-            {
-                useSourceTextDiffer = new BooleanNumberString(false);
-            }
-
-            var finalChanges = useSourceTextDiffer.Bool ? SourceTextDiffer.GetMinimalTextChanges(originalText, changedText, lineDiffOnly: false) : changedText.GetTextChanges(originalText);
+            var finalChanges = changedText.GetTextChanges(originalText);
             var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
 
             return new FormattingResult(finalEdits);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -64,13 +63,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var formattingChanges = edits.Select(e => e.AsTextChange(changedText));
             changedText = changedText.WithChanges(formattingChanges);
 
-            // Allow benchmarks to specify a different diff algorithm
-            if (!context.Options.TryGetValue("UseSourceTextDiffer", out var useSourceTextDiffer))
-            {
-                useSourceTextDiffer = new BooleanNumberString(false);
-            }
-
-            var finalChanges = useSourceTextDiffer.Bool ? SourceTextDiffer.GetMinimalTextChanges(originalText, changedText, lineDiffOnly: false) : changedText.GetTextChanges(originalText);
+            var finalChanges = changedText.GetTextChanges(originalText);
             var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
 
             return new FormattingResult(finalEdits);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -1419,6 +1419,23 @@ line 1
 ");
         }
 
+        [Theory]
+        [CombinatorialData]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/6192")]
+        public async Task Formats_NoEditsForNoChanges(bool useSourceTextDiffer)
+        {
+            var input = @"@code {
+    public void M()
+    {
+        Console.WriteLine(""Hello"");
+        Console.WriteLine(""World""); // <-- type/replace semicolon here
+    }
+}
+";
+
+            await RunFormattingTestAsync(input, input, useSourceTextDiffer: useSourceTextDiffer, fileKind: FileKinds.Component);
+        }
+
         private IReadOnlyList<TagHelperDescriptor> GetComponentWithCascadingTypeParameter()
         {
             var input = @"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -23,11 +23,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsCodeBlockDirective(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsCodeBlockDirective()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{}
@@ -44,11 +43,10 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Format_DocumentWithDiagnostics(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Format_DocumentWithDiagnostics()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @page
 @model BlazorApp58.Pages.Index2Model
@@ -95,11 +93,10 @@ expected: @"@page
             allowDiagnostics: true);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_MultipleBlocksInADirective(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_MultipleBlocksInADirective()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @{
 void Method(){
@@ -126,11 +123,10 @@ expected: @"@{
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_NonCodeBlockDirectives(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_NonCodeBlockDirectives()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @{
 var x = ""foo"";
@@ -146,11 +142,10 @@ expected: @"@{
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_CodeBlockDirectiveWithMarkup_NonBraced(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_CodeBlockDirectiveWithMarkup_NonBraced()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -172,11 +167,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_CodeBlockDirectiveWithMarkup(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_CodeBlockDirectiveWithMarkup()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -196,11 +190,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_CodeBlockDirectiveWithImplicitExpressions(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_CodeBlockDirectiveWithImplicitExpressions()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{
@@ -220,11 +213,10 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task DoesNotFormat_CodeBlockDirectiveWithExplicitExpressions(bool useSourceTextDiffer)
+        [Fact]
+        public async Task DoesNotFormat_CodeBlockDirectiveWithExplicitExpressions()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -245,11 +237,10 @@ expected: @"@functions {
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Format_SectionDirectiveBlock1(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Format_SectionDirectiveBlock1()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -275,11 +266,10 @@ expected: @"@functions {
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Format_SectionDirectiveBlock2(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Format_SectionDirectiveBlock2()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -311,11 +301,10 @@ expected: @"@functions {
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Format_SectionDirectiveBlock3(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Format_SectionDirectiveBlock3()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -349,11 +338,10 @@ expected: @"@functions {
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_CodeBlockDirectiveWithRazorComments(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_CodeBlockDirectiveWithRazorComments()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -372,11 +360,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_CodeBlockDirectiveWithRazorStatements(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_CodeBlockDirectiveWithRazorStatements()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{
@@ -393,11 +380,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task DoesNotFormat_CodeBlockDirective_NotInSelectedRange(bool useSourceTextDiffer)
+        [Fact]
+        public async Task DoesNotFormat_CodeBlockDirective_NotInSelectedRange()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 [|<div>Foo</div>|]
 @functions {
@@ -416,11 +402,10 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task OnlyFormatsWithinRange(bool useSourceTextDiffer)
+        [Fact]
+        public async Task OnlyFormatsWithinRange()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{}
@@ -438,11 +423,10 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task MultipleCodeBlockDirectives(bool useSourceTextDiffer)
+        [Fact]
+        public async Task MultipleCodeBlockDirectives()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
  public class Foo{}
@@ -475,11 +459,10 @@ Hello World
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task MultipleCodeBlockDirectives2(bool useSourceTextDiffer)
+        [Fact]
+        public async Task MultipleCodeBlockDirectives2()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 Hello World
 @code {
@@ -507,11 +490,10 @@ expected: @"Hello World
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeOnTheSameLineAsCodeBlockDirectiveStart(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeOnTheSameLineAsCodeBlockDirectiveStart()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {public class Foo{
 }
@@ -525,11 +507,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeOnTheSameLineAsCodeBlockDirectiveEnd(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeOnTheSameLineAsCodeBlockDirectiveEnd()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {
 public class Foo{
@@ -543,11 +524,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task SingleLineCodeBlockDirective(bool useSourceTextDiffer)
+        [Fact]
+        public async Task SingleLineCodeBlockDirective()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions {public class Foo{}
 }
@@ -558,11 +538,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task IndentsCodeBlockDirectiveStart(bool useSourceTextDiffer)
+        [Fact]
+        public async Task IndentsCodeBlockDirectiveStart()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 Hello World
      @functions {public class Foo{}
@@ -575,11 +554,10 @@ expected: @"Hello World
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task IndentsCodeBlockDirectiveEnd(bool useSourceTextDiffer)
+        [Fact]
+        public async Task IndentsCodeBlockDirectiveEnd()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
  @functions {
 public class Foo{}
@@ -591,11 +569,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task ComplexCodeBlockDirective(bool useSourceTextDiffer)
+        [Fact]
+        public async Task ComplexCodeBlockDirective()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @using System.Buffers
 @functions{
@@ -652,11 +629,10 @@ be indented.
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Strings(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Strings()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions{
 private string str1 = ""hello world"";
@@ -704,11 +680,10 @@ expected: @"@functions {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlockDirective_UseTabs(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlockDirective_UseTabs()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{}
@@ -726,11 +701,10 @@ expected: @"@code {
 insertSpaces: false);
 
         }
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlockDirective_UseTabsWithTabSize8_HTML(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlockDirective_UseTabsWithTabSize8_HTML()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{}
@@ -750,11 +724,10 @@ tabSize: 8,
 insertSpaces: false);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlockDirective_UseTabsWithTabSize8(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlockDirective_UseTabsWithTabSize8()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{}
@@ -773,11 +746,10 @@ tabSize: 8,
 insertSpaces: false);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlockDirective_WithTabSize3(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlockDirective_WithTabSize3()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{}
@@ -795,11 +767,10 @@ expected: @"@code {
 tabSize: 3);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlockDirective_WithTabSize8(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlockDirective_WithTabSize8()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{}
@@ -817,11 +788,10 @@ expected: @"@code {
 tabSize: 8);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlockDirective_WithTabSize12(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlockDirective_WithTabSize12()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
  public class Foo{}
@@ -839,12 +809,11 @@ expected: @"@code {
 tabSize: 12);
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/27102")]
-        public async Task CodeBlock_SemiColon_SingleLine(bool useSourceTextDiffer)
+        public async Task CodeBlock_SemiColon_SingleLine()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <div></div>
 @{ Debugger.Launch()$$;}
@@ -859,12 +828,11 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/29837")]
-        public async Task CodeBlock_NestedComponents(bool useSourceTextDiffer)
+        public async Task CodeBlock_NestedComponents()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
     private WeatherForecast[] forecasts;
@@ -898,14 +866,13 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/34320")]
-        public async Task CodeBlock_ObjectCollectionArrayInitializers(bool useSourceTextDiffer)
+        public async Task CodeBlock_ObjectCollectionArrayInitializers()
         {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
     public List<object> AList = new List<object>()
@@ -957,14 +924,13 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6092")]
-        public async Task CodeBlock_ArrayInitializers(bool useSourceTextDiffer)
+        public async Task CodeBlock_ArrayInitializers()
         {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
     private void M()
@@ -992,14 +958,13 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6092")]
-        public async Task CodeBlock_ObjectInitializers(bool useSourceTextDiffer)
+        public async Task CodeBlock_ObjectInitializers()
         {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
     private void M()
@@ -1025,14 +990,13 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6092")]
-        public async Task CodeBlock_CollectionInitializers(bool useSourceTextDiffer)
+        public async Task CodeBlock_CollectionInitializers()
         {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
     private void M()
@@ -1060,13 +1024,12 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/5618")]
-        public async Task CodeBlock_EmptyObjectCollectionInitializers(bool useSourceTextDiffer)
+        public async Task CodeBlock_EmptyObjectCollectionInitializers()
         {
             // The C# Formatter _does_ touch these types of initializers if they're empty. Who knew ¯\_(ツ)_/¯
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code {
     public void Foo()
@@ -1100,12 +1063,11 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
-        public async Task IfBlock_TopLevel(bool useSourceTextDiffer)
+        public async Task IfBlock_TopLevel()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
         @if (true)
 {
@@ -1117,12 +1079,11 @@ expected: @"@if (true)
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
-        public async Task IfBlock_TopLevel_WithOtherCode(bool useSourceTextDiffer)
+        public async Task IfBlock_TopLevel_WithOtherCode()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @{
     // foo
@@ -1142,12 +1103,11 @@ expected: @"@{
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
-        public async Task IfBlock_Nested(bool useSourceTextDiffer)
+        public async Task IfBlock_Nested()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <div>
         @if (true)
@@ -1164,12 +1124,11 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/5648")]
-        public async Task GenericComponentWithCascadingTypeParameter(bool useSourceTextDiffer)
+        public async Task GenericComponentWithCascadingTypeParameter()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @page ""/counter""
 
@@ -1220,12 +1179,11 @@ expected: @"@page ""/counter""
 tagHelpers: GetComponentWithCascadingTypeParameter());
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/5648")]
-        public async Task GenericComponentWithCascadingTypeParameter_Nested(bool useSourceTextDiffer)
+        public async Task GenericComponentWithCascadingTypeParameter_Nested()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @page ""/counter""
 
@@ -1268,12 +1226,11 @@ expected: @"@page ""/counter""
 tagHelpers: GetComponentWithCascadingTypeParameter());
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/5648")]
-        public async Task GenericComponentWithCascadingTypeParameter_MultipleParameters(bool useSourceTextDiffer)
+        public async Task GenericComponentWithCascadingTypeParameter_MultipleParameters()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @page ""/counter""
 
@@ -1306,11 +1263,10 @@ expected: @"@page ""/counter""
 tagHelpers: GetComponentWithTwoCascadingTypeParameter());
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_MultilineExpressionAtStartOfBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_MultilineExpressionAtStartOfBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @{
     var x = DateTime
@@ -1326,11 +1282,10 @@ expected: @"@{
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_MultilineExpressionAfterWhitespaceAtStartOfBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_MultilineExpressionAfterWhitespaceAtStartOfBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @{
     
@@ -1352,11 +1307,10 @@ expected: @"@{
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_MultilineExpressionNotAtStartOfBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_MultilineExpressionNotAtStartOfBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @{
     //
@@ -1374,11 +1328,10 @@ expected: @"@{
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Formats_MultilineRazorComment(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Formats_MultilineRazorComment()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <div></div>
     @*
@@ -1419,10 +1372,9 @@ line 1
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6192")]
-        public async Task Formats_NoEditsForNoChanges(bool useSourceTextDiffer)
+        public async Task Formats_NoEditsForNoChanges()
         {
             var input = @"@code {
     public void M()
@@ -1433,7 +1385,7 @@ line 1
 }
 ";
 
-            await RunFormattingTestAsync(input, input, useSourceTextDiffer: useSourceTextDiffer, fileKind: FileKinds.Component);
+            await RunFormattingTestAsync(input, input, fileKind: FileKinds.Component);
         }
 
         private IReadOnlyList<TagHelperDescriptor> GetComponentWithCascadingTypeParameter()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -70,7 +70,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             bool insertSpaces = true,
             string? fileKind = null,
             IReadOnlyList<TagHelperDescriptor>? tagHelpers = null,
-            bool useSourceTextDiffer = false,
             bool allowDiagnostics = false)
         {
             // Arrange
@@ -90,11 +89,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 TabSize = tabSize,
                 InsertSpaces = insertSpaces,
             };
-
-            if (useSourceTextDiffer)
-            {
-                options["UseSourceTextDiffer"] = true;
-            }
 
             var formattingService = CreateFormattingService(codeDocument);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -101,11 +101,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Act
             var edits = await formattingService.FormatAsync(uri, documentSnapshot, range, options, CancellationToken.None);
 
-            // Assert
-            var edited = ApplyEdits(source, edits);
-            var actual = edited.ToString();
+            if (input.Equals(expected))
+            {
+                Assert.Empty(edits);
+            }
+            else
+            {
+                // Assert
+                var edited = ApplyEdits(source, edits);
+                var actual = edited.ToString();
 
-            new XUnitVerifier().EqualOrDiff(expected, actual);
+                new XUnitVerifier().EqualOrDiff(expected, actual);
+            }
         }
 
         protected async Task RunOnTypeFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -23,11 +23,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsSimpleHtmlTag(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsSimpleHtmlTag()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
    <html>
 <head>
@@ -50,11 +49,10 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsSimpleHtmlTag_Range(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsSimpleHtmlTag_Range()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <html>
 <head>
@@ -79,11 +77,10 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsRazorHtmlBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsRazorHtmlBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"@page ""/error""
 
         <h1 class=
@@ -135,11 +132,10 @@ expected: @"@page ""/error""
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsMixedHtmlBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsMixedHtmlBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"@page ""/test""
 @{
 <p>
@@ -186,11 +182,10 @@ expected: @"@page ""/test""
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsMixedRazorBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsMixedRazorBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"@page ""/test""
 
 <div class=@className>Some Text</div>
@@ -237,11 +232,10 @@ expected: @"@page ""/test""
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsMixedContentWithMultilineExpressions(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsMixedContentWithMultilineExpressions()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"@page ""/test""
 
 <div
@@ -302,11 +296,10 @@ expected: @"@page ""/test""
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsComplexBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsComplexBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"@page ""/""
 
 <h1>Hello, world!</h1>
@@ -387,12 +380,11 @@ expected: @"@page ""/""
 ", tagHelpers: GetSurveyPrompt());
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsComponentTags(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsComponentTags()
         {
             var tagHelpers = GetComponents();
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
    <Counter>
     @if(true){
@@ -431,23 +423,21 @@ expected: @"
 tagHelpers: tagHelpers);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FormatsShortBlock(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FormatsShortBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
                 input: @"@{<p></p>}",
                 expected: @"@{
     <p></p>
 }");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/26836")]
-        public async Task FormatNestedBlock(bool useSourceTextDiffer)
+        public async Task FormatNestedBlock()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"@code {
     public string DoSomething()
     {
@@ -472,12 +462,11 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/26836")]
-        public async Task FormatNestedBlock_Tabs(bool useSourceTextDiffer)
+        public async Task FormatNestedBlock_Tabs()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"@code {
     public string DoSomething()
     {
@@ -504,12 +493,11 @@ tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
 insertSpaces: false);
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1273468/")]
-        public async Task FormatHtmlWithTabs1(bool useSourceTextDiffer)
+        public async Task FormatHtmlWithTabs1()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @page ""/""
 @{
@@ -550,12 +538,11 @@ insertSpaces: false,
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1273468/")]
-        public async Task FormatHtmlWithTabs2(bool useSourceTextDiffer)
+        public async Task FormatHtmlWithTabs2()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @page ""/""
 
@@ -592,12 +579,11 @@ insertSpaces: false,
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/30382")]
-        public async Task FormatNestedComponents(bool useSourceTextDiffer)
+        public async Task FormatNestedComponents()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <CascadingAuthenticationState>
 <Router AppAssembly=""@typeof(Program).Assembly"">
@@ -638,12 +624,11 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/30382")]
-        public async Task FormatNestedComponents2(bool useSourceTextDiffer)
+        public async Task FormatNestedComponents2()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <GridTable>
 <ChildContent>
@@ -686,12 +671,11 @@ expected: @"
 ", tagHelpers: GetComponents());
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/30382")]
-        public async Task FormatNestedComponents2_Range(bool useSourceTextDiffer)
+        public async Task FormatNestedComponents2_Range()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <GridTable>
 <ChildContent>
@@ -734,12 +718,11 @@ expected: @"
 ", tagHelpers: GetComponents());
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/29645")]
-        public async Task FormatHtmlInIf(bool useSourceTextDiffer)
+        public async Task FormatHtmlInIf()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @if (true)
 {
@@ -779,12 +762,11 @@ else
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/29645")]
-        public async Task FormatHtmlInIf_Range(bool useSourceTextDiffer)
+        public async Task FormatHtmlInIf_Range()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @if (true)
 {
@@ -825,10 +807,9 @@ else
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/5749")]
-        public async Task FormatRenderFragmentInCSharpCodeBlock(bool useSourceTextDiffer)
+        public async Task FormatRenderFragmentInCSharpCodeBlock()
         {
             // Sadly the first thing the HTML formatter does with this input
             // is put a newline after the @, which means <SurveyPrompt /> won't be
@@ -836,7 +817,7 @@ else
             // or the test fails before we have a chance to fix the formatting.
             FormattingContext.SkipValidateComponents = true;
 
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code
 {
@@ -868,12 +849,11 @@ expected: @"@code
 tagHelpers: GetSurveyPrompt());
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6090")]
-        public async Task FormatHtmlCommentsInsideCSharp1(bool useSourceTextDiffer)
+        public async Task FormatHtmlCommentsInsideCSharp1()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @foreach (var num in Enumerable.Range(1, 10))
 {
@@ -903,12 +883,11 @@ expected: @"@foreach (var num in Enumerable.Range(1, 10))
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6090")]
-        public async Task FormatHtmlCommentsInsideCSharp2(bool useSourceTextDiffer)
+        public async Task FormatHtmlCommentsInsideCSharp2()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @foreach (var num in Enumerable.Range(1, 10))
 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
@@ -17,11 +17,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlock_SpansMultipleLines(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlock_SpansMultipleLines()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code
         {
@@ -45,11 +44,10 @@ expected: @"@code
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlock_IndentedBlock_MaintainsIndent(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlock_IndentedBlock_MaintainsIndent()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 <boo>
     @code
@@ -78,11 +76,10 @@ expected: @"
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlock_TooMuchWhitespace(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlock_TooMuchWhitespace()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code        {
     private int currentCount = 0;
@@ -104,11 +101,10 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlock_NonSpaceWhitespace(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlock_NonSpaceWhitespace()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code	{
     private int currentCount = 0;
@@ -130,11 +126,10 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task CodeBlock_NoWhitespace(bool useSourceTextDiffer)
+        [Fact]
+        public async Task CodeBlock_NoWhitespace()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @code{
     private int currentCount = 0;
@@ -156,11 +151,10 @@ expected: @"@code {
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FunctionsBlock_BraceOnNewLine(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FunctionsBlock_BraceOnNewLine()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions
         {
@@ -185,11 +179,10 @@ expected: @"@functions
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task FunctionsBlock_TooManySpaces(bool useSourceTextDiffer)
+        [Fact]
+        public async Task FunctionsBlock_TooManySpaces()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @functions        {
     private int currentCount = 0;
@@ -212,11 +205,10 @@ expected: @"@functions {
 fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Layout(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Layout()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @layout    MyLayout
 ",
@@ -224,11 +216,10 @@ expected: @"@layout MyLayout
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Inherits(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Inherits()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @inherits    MyBaseClass
 ",
@@ -236,11 +227,10 @@ expected: @"@inherits MyBaseClass
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Implements(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Implements()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @implements    IDisposable
 ",
@@ -248,11 +238,10 @@ expected: @"@implements IDisposable
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task PreserveWhitespace(bool useSourceTextDiffer)
+        [Fact]
+        public async Task PreserveWhitespace()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @preservewhitespace    true
 ",
@@ -260,11 +249,10 @@ expected: @"@preservewhitespace true
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Inject(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Inject()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @inject    MyClass     myClass
 ",
@@ -272,11 +260,10 @@ expected: @"@inject MyClass myClass
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Inject_TrailingWhitespace(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Inject_TrailingWhitespace()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @inject    MyClass     myClass
 ",
@@ -284,11 +271,10 @@ expected: @"@inject MyClass myClass
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Attribute(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Attribute()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @attribute     [Obsolete(   ""asdf""   , error:    false)]
 ",
@@ -296,11 +282,10 @@ expected: @"@attribute [Obsolete(""asdf"", error: false)]
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Model(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Model()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @model    MyModel
 ",
@@ -309,11 +294,10 @@ expected: @"@model MyModel
             fileKind: FileKinds.Legacy);
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task Page(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Page()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @page    ""MyPage""
 ",
@@ -323,11 +307,10 @@ expected: @"@page ""MyPage""
         }
 
         // Regression prevention tests:
-        [Theory]
-        [CombinatorialData]
-        public async Task Using(bool useSourceTextDiffer)
+        [Fact]
+        public async Task Using()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @using   System;
 ",
@@ -335,11 +318,10 @@ expected: @"@using System;
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task UsingStatic(bool useSourceTextDiffer)
+        [Fact]
+        public async Task UsingStatic()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @using  static   System.Math;
 ",
@@ -347,11 +329,10 @@ expected: @"@using static System.Math;
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task UsingAlias(bool useSourceTextDiffer)
+        [Fact]
+        public async Task UsingAlias()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @using  M   =    System.Math;
 ",
@@ -359,11 +340,10 @@ expected: @"@using M = System.Math;
 ");
         }
 
-        [Theory]
-        [CombinatorialData]
-        public async Task TagHelpers(bool useSourceTextDiffer)
+        [Fact]
+        public async Task TagHelpers()
         {
-            await RunFormattingTestAsync(useSourceTextDiffer: useSourceTextDiffer,
+            await RunFormattingTestAsync(
 input: @"
 @addTagHelper    *,    Microsoft.AspNetCore.Mvc.TagHelpers
 @removeTagHelper    *,     Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6192

I realised this regressed when I changed things to not use `SourceTextDiffer`, for perf reasons. Bringing it back is a little annoying, but at least its only used once instead of 3 or 4 times.

Suggest reviewing the commits separately, the second one removes the `UseSourceTextDiffer` option, since a) its proven to not be a problem and b) turns out _some_ SourceTextDiffer is kinda important :)