### PR TITLE
Fix Legacy Razor editor TagHelper completion regression.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.Serialization
         public CompletionListSerializationBenchmark()
         {
             var tagHelperFactsService = new DefaultTagHelperFactsService();
-            var completionService = new DefaultTagHelperCompletionService(tagHelperFactsService);
+            var completionService = new LanguageServerTagHelperCompletionService(tagHelperFactsService);
             var htmlFactsService = new DefaultHtmlFactsService();
             var tagHelperCompletionProvider = new TagHelperCompletionProvider(completionService, htmlFactsService, tagHelperFactsService);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<VSLSPTagHelperTooltipFactory, DefaultVSLSPTagHelperTooltipFactory>();
 
                         // Completion
-                        services.AddSingleton<TagHelperCompletionService, DefaultTagHelperCompletionService>();
+                        services.AddSingleton<TagHelperCompletionService, LanguageServerTagHelperCompletionService>();
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
                         services.AddSingleton<RazorCompletionItemProvider, DirectiveCompletionItemProvider>();
                         services.AddSingleton<RazorCompletionItemProvider, DirectiveAttributeCompletionItemProvider>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerTagHelperCompletionService.cs
@@ -1,0 +1,383 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    internal class LanguageServerTagHelperCompletionService : TagHelperCompletionService
+    {
+        private readonly TagHelperFactsService _tagHelperFactsService;
+        private static readonly HashSet<TagHelperDescriptor> s_emptyHashSet = new();
+
+        [ImportingConstructor]
+        public LanguageServerTagHelperCompletionService(TagHelperFactsService tagHelperFactsService!!)
+        {
+            _tagHelperFactsService = tagHelperFactsService;
+        }
+
+        // This API attempts to understand a users context as they're typing in a Razor file to provide TagHelper based attribute IntelliSense.
+        //
+        // Scenarios for TagHelper attribute IntelliSense follows:
+        // 1. TagHelperDescriptor's have matching required attribute names
+        //  -> Provide IntelliSense for the required attributes of those descriptors to lead users towards a TagHelperified element.
+        // 2. TagHelperDescriptor entirely applies to current element. Tag name, attributes, everything is fulfilled.
+        //  -> Provide IntelliSense for the bound attributes for the applied descriptors.
+        //
+        // Within each of the above scenarios if an attribute completion has a corresponding bound attribute we associate it with the corresponding
+        // BoundAttributeDescriptor. By doing this a user can see what C# type a TagHelper expects for the attribute.
+        public override AttributeCompletionResult GetAttributeCompletions(AttributeCompletionContext completionContext!!)
+        {
+            var attributeCompletions = completionContext.ExistingCompletions.ToDictionary(
+                completion => completion,
+                _ => new HashSet<BoundAttributeDescriptor>(),
+                StringComparer.OrdinalIgnoreCase);
+
+            var documentContext = completionContext.DocumentContext;
+            var descriptorsForTag = _tagHelperFactsService.GetTagHelpersGivenTag(documentContext, completionContext.CurrentTagName, completionContext.CurrentParentTagName);
+            if (descriptorsForTag.Count == 0)
+            {
+                // If the current tag has no possible descriptors then we can't have any additional attributes.
+                var defaultResult = AttributeCompletionResult.Create(attributeCompletions);
+                return defaultResult;
+            }
+
+            var prefix = documentContext.Prefix ?? string.Empty;
+            Debug.Assert(completionContext.CurrentTagName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+            var applicableTagHelperBinding = _tagHelperFactsService.GetTagHelperBinding(
+                documentContext,
+                completionContext.CurrentTagName,
+                completionContext.Attributes,
+                completionContext.CurrentParentTagName,
+                completionContext.CurrentParentIsTagHelper);
+
+            var applicableDescriptors = applicableTagHelperBinding?.Descriptors ?? Enumerable.Empty<TagHelperDescriptor>();
+            var unprefixedTagName = completionContext.CurrentTagName.Substring(prefix.Length);
+
+            if (!completionContext.InHTMLSchema(unprefixedTagName) &&
+                applicableDescriptors.All(descriptor => descriptor.TagOutputHint is null))
+            {
+                // This isn't a known HTML tag and no descriptor has an output element hint. Remove all previous completions.
+                attributeCompletions.Clear();
+            }
+
+            for (var i = 0; i < descriptorsForTag.Count; i++)
+            {
+                var descriptor = descriptorsForTag[i];
+
+                if (applicableDescriptors.Contains(descriptor))
+                {
+                    foreach (var attributeDescriptor in descriptor.BoundAttributes)
+                    {
+                        if (attributeDescriptor.Name != null)
+                        {
+                            UpdateCompletions(attributeDescriptor.Name, attributeDescriptor);
+                        }
+
+                        if (!string.IsNullOrEmpty(attributeDescriptor.IndexerNamePrefix))
+                        {
+                            UpdateCompletions(attributeDescriptor.IndexerNamePrefix + "...", attributeDescriptor);
+                        }
+                    }
+                }
+                else
+                {
+                    var htmlNameToBoundAttribute = new Dictionary<string, BoundAttributeDescriptor>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var attributeDescriptor in descriptor.BoundAttributes)
+                    {
+                        if (attributeDescriptor.Name != null)
+                        {
+                            htmlNameToBoundAttribute[attributeDescriptor.Name] = attributeDescriptor;
+                        }
+
+                        if (!string.IsNullOrEmpty(attributeDescriptor.IndexerNamePrefix))
+                        {
+                            htmlNameToBoundAttribute[attributeDescriptor.IndexerNamePrefix] = attributeDescriptor;
+                        }
+                    }
+
+                    foreach (var rule in descriptor.TagMatchingRules)
+                    {
+                        foreach (var requiredAttribute in rule.Attributes)
+                        {
+                            if (htmlNameToBoundAttribute.TryGetValue(requiredAttribute.Name, out var attributeDescriptor))
+                            {
+                                UpdateCompletions(requiredAttribute.DisplayName, attributeDescriptor);
+                            }
+                            else
+                            {
+                                UpdateCompletions(requiredAttribute.DisplayName, possibleDescriptor: null);
+                            }
+                        }
+                    }
+                }
+            }
+
+            var completionResult = AttributeCompletionResult.Create(attributeCompletions);
+            return completionResult;
+
+            void UpdateCompletions(string attributeName, BoundAttributeDescriptor? possibleDescriptor)
+            {
+                if (completionContext.Attributes.Any(attribute => string.Equals(attribute.Key, attributeName, StringComparison.OrdinalIgnoreCase)) &&
+                    (completionContext.CurrentAttributeName is null ||
+                    !string.Equals(attributeName, completionContext.CurrentAttributeName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    // Attribute is already present on this element and it is not the attribute in focus.
+                    // It shouldn't exist in the completion list.
+                    return;
+                }
+
+                if (!attributeCompletions.TryGetValue(attributeName, out var rules))
+                {
+                    rules = new HashSet<BoundAttributeDescriptor>();
+                    attributeCompletions[attributeName] = rules;
+                }
+
+                if (possibleDescriptor != null)
+                {
+                    rules.Add(possibleDescriptor);
+                }
+            }
+        }
+
+        public override ElementCompletionResult GetElementCompletions(ElementCompletionContext completionContext!!)
+        {
+            var elementCompletions = new Dictionary<string, HashSet<TagHelperDescriptor>>(StringComparer.OrdinalIgnoreCase);
+
+            AddAllowedChildrenCompletions(completionContext, elementCompletions);
+
+            if (elementCompletions.Count > 0)
+            {
+                // If the containing element is already a TagHelper and only allows certain children.
+                var emptyResult = ElementCompletionResult.Create(elementCompletions);
+                return emptyResult;
+            }
+
+            elementCompletions = completionContext.ExistingCompletions.ToDictionary(
+                completion => completion,
+                _ => new HashSet<TagHelperDescriptor>(),
+                StringComparer.Ordinal);
+
+            var catchAllDescriptors = new HashSet<TagHelperDescriptor>();
+            var prefix = completionContext.DocumentContext.Prefix ?? string.Empty;
+            var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingParentTagName);
+            possibleChildDescriptors = FilterFullyQualifiedCompletions(possibleChildDescriptors);
+            foreach (var possibleDescriptor in possibleChildDescriptors)
+            {
+                var addRuleCompletions = false;
+                var outputHint = possibleDescriptor.TagOutputHint;
+
+                foreach (var rule in possibleDescriptor.TagMatchingRules)
+                {
+                    if (!TagHelperMatchingConventions.SatisfiesParentTag(completionContext.ContainingParentTagName, rule))
+                    {
+                        continue;
+                    }
+
+                    if (rule.TagName == TagHelperMatchingConventions.ElementCatchAllName)
+                    {
+                        catchAllDescriptors.Add(possibleDescriptor);
+                    }
+                    else if (elementCompletions.ContainsKey(rule.TagName))
+                    {
+                        addRuleCompletions = true;
+                    }
+                    else if (outputHint != null)
+                    {
+                        // If the current descriptor has an output hint we need to make sure it shows up only when its output hint would normally show up.
+                        // Example: We have a MyTableTagHelper that has an output hint of "table" and a MyTrTagHelper that has an output hint of "tr".
+                        // If we try typing in a situation like this: <body > | </body>
+                        // We'd expect to only get "my-table" as a completion because the "body" tag doesn't allow "tr" tags.
+                        addRuleCompletions = elementCompletions.ContainsKey(outputHint);
+                    }
+                    else if (!completionContext.InHTMLSchema(rule.TagName) || rule.TagName.Any(c => char.IsUpper(c)))
+                    {
+                        // If there is an unknown HTML schema tag that doesn't exist in the current completion we should add it. This happens for
+                        // TagHelpers that target non-schema oriented tags.
+                        // The second condition is a workaround for the fact that InHTMLSchema does a case insensitive comparison.
+                        // We want completions to not dedupe by casing. E.g, we want to show both <div> and <DIV> completion items separately.
+                        addRuleCompletions = true;
+                    }
+
+                    if (addRuleCompletions)
+                    {
+                        UpdateCompletions(prefix + rule.TagName, possibleDescriptor);
+                    }
+                }
+            }
+
+            // We needed to track all catch-alls and update their completions after all other completions have been completed.
+            // This way, any TagHelper added completions will also have catch-alls listed under their entries.
+            foreach (var catchAllDescriptor in catchAllDescriptors)
+            {
+                foreach (var completionTagName in elementCompletions.Keys)
+                {
+                    if (elementCompletions[completionTagName].Count > 0 ||
+                        (!string.IsNullOrEmpty(prefix) && completionTagName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        // The current completion either has other TagHelper's associated with it or is prefixed with a non-empty
+                        // TagHelper prefix.
+                        UpdateCompletions(completionTagName, catchAllDescriptor);
+                    }
+                }
+            }
+
+            var result = ElementCompletionResult.Create(elementCompletions);
+            return result;
+
+            void UpdateCompletions(string tagName, TagHelperDescriptor possibleDescriptor)
+            {
+                if (possibleDescriptor.BoundAttributes.Any(boundAttribute => boundAttribute.IsDirectiveAttribute()))
+                {
+                    // This is a TagHelper that ultimately represents a DirectiveAttribute. In classic Razor TagHelper land TagHelpers with bound attribute descriptors
+                    // are valuable to show in the completion list to understand what was possible for a certain tag; however, with Blazor directive attributes stand
+                    // on their own and shouldn't be indicated at the element level completion.
+                    return;
+                }
+
+                if (!elementCompletions.TryGetValue(tagName, out var existingRuleDescriptors))
+                {
+                    existingRuleDescriptors = new HashSet<TagHelperDescriptor>();
+                    elementCompletions[tagName] = existingRuleDescriptors;
+                }
+
+                existingRuleDescriptors.Add(possibleDescriptor);
+            }
+        }
+
+        private void AddAllowedChildrenCompletions(
+            ElementCompletionContext completionContext,
+            Dictionary<string, HashSet<TagHelperDescriptor>> elementCompletions)
+        {
+            if (completionContext.ContainingTagName is null)
+            {
+                // If we're at the root then there's no containing TagHelper to specify allowed children.
+                return;
+            }
+
+            var prefix = completionContext.DocumentContext.Prefix ?? string.Empty;
+
+            var binding = _tagHelperFactsService.GetTagHelperBinding(
+                completionContext.DocumentContext,
+                completionContext.ContainingParentTagName,
+                completionContext.Attributes,
+                parentTag: null,
+                parentIsTagHelper: false);
+
+            if (binding is null)
+            {
+                // Containing tag is not a TagHelper; therefore, it allows any children.
+                return;
+            }
+
+            foreach (var descriptor in binding.Descriptors)
+            {
+                foreach (var childTag in descriptor.AllowedChildTags)
+                {
+                    var prefixedName = string.Concat(prefix, childTag.Name);
+                    var descriptors = _tagHelperFactsService.GetTagHelpersGivenTag(
+                        completionContext.DocumentContext,
+                        prefixedName,
+                        completionContext.ContainingParentTagName);
+
+                    if (descriptors.Count == 0)
+                    {
+                        if (!elementCompletions.ContainsKey(prefixedName))
+                        {
+                            elementCompletions[prefixedName] = s_emptyHashSet;
+                        }
+
+                        continue;
+                    }
+
+                    if (!elementCompletions.TryGetValue(prefixedName, out var existingRuleDescriptors))
+                    {
+                        existingRuleDescriptors = new HashSet<TagHelperDescriptor>();
+                        elementCompletions[prefixedName] = existingRuleDescriptors;
+                    }
+
+                    existingRuleDescriptors.UnionWith(descriptors);
+                }
+            }
+        }
+
+        private static IReadOnlyList<TagHelperDescriptor> FilterFullyQualifiedCompletions(IReadOnlyList<TagHelperDescriptor> possibleChildDescriptors)
+        {
+            // Iterate once through the list to tease apart fully qualified and short name TagHelpers
+            var fullyQualifiedTagHelpers = new List<TagHelperDescriptor>();
+            var shortNameTagHelpers = new HashSet<TagHelperDescriptor>(ShortNameToFullyQualifiedComparer.Instance);
+            for (var i = 0; i < possibleChildDescriptors.Count; i++)
+            {
+                var descriptor = possibleChildDescriptors[i];
+
+                if (descriptor.IsComponentFullyQualifiedNameMatch())
+                {
+                    fullyQualifiedTagHelpers.Add(descriptor);
+                }
+                else
+                {
+                    shortNameTagHelpers.Add(descriptor);
+                }
+            }
+
+            // Re-combine the short named & fully qualified TagHelpers but filter out any fully qualified TagHelpers that have a short
+            // named representation already.
+            var filteredList = new List<TagHelperDescriptor>(shortNameTagHelpers);
+            for (var i = 0; i < fullyQualifiedTagHelpers.Count; i++)
+            {
+                var fullyQualifiedTagHelper = fullyQualifiedTagHelpers[i];
+
+                if (!shortNameTagHelpers.Contains(fullyQualifiedTagHelper))
+                {
+                    // Unimported completion item that isn't represented in a short named form.
+                    filteredList.Add(fullyQualifiedTagHelper);
+                }
+                else
+                {
+                    // There's already a shortname variant of this item, don't include it.
+                }
+            }
+
+            return filteredList;
+        }
+
+        private class ShortNameToFullyQualifiedComparer : IEqualityComparer<TagHelperDescriptor>
+        {
+            public static readonly ShortNameToFullyQualifiedComparer Instance = new();
+
+            public bool Equals(TagHelperDescriptor x, TagHelperDescriptor y)
+            {
+                if (object.ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (x is null || y is null)
+                {
+                    return false;
+                }
+
+                if (!string.Equals(x.Name, y.Name, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                if (!string.Equals(x.AssemblyName, y.AssemblyName, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(TagHelperDescriptor obj) => obj.Name.GetHashCode();
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyTagHelperCompletionService.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Razor.Language.Components;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
-    // This class is utilized entirely by the legacy Razor editor and should not be touched to avoid breaking functionality.
+    // This class is utilized entirely by the legacy Razor editor and should not be touched except when specifically working on the legacy editor to avoid breaking functionality.
 
     [Shared]
     [Export(typeof(TagHelperCompletionService))]

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LegacyTagHelperCompletionService.cs
@@ -11,15 +11,17 @@ using Microsoft.AspNetCore.Razor.Language.Components;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
+    // This class is utilized entirely by the legacy Razor editor and should not be touched to avoid breaking functionality.
+
     [Shared]
     [Export(typeof(TagHelperCompletionService))]
-    internal class DefaultTagHelperCompletionService : TagHelperCompletionService
+    internal class LegacyTagHelperCompletionService : TagHelperCompletionService
     {
         private readonly TagHelperFactsService _tagHelperFactsService;
         private static readonly HashSet<TagHelperDescriptor> s_emptyHashSet = new();
 
         [ImportingConstructor]
-        public DefaultTagHelperCompletionService(TagHelperFactsService tagHelperFactsService!!)
+        public LegacyTagHelperCompletionService(TagHelperFactsService tagHelperFactsService!!)
         {
             _tagHelperFactsService = tagHelperFactsService;
         }
@@ -169,7 +171,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             var catchAllDescriptors = new HashSet<TagHelperDescriptor>();
             var prefix = completionContext.DocumentContext.Prefix ?? string.Empty;
-            var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingParentTagName);
+            var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingTagName);
             possibleChildDescriptors = FilterFullyQualifiedCompletions(possibleChildDescriptors);
             foreach (var possibleDescriptor in possibleChildDescriptors)
             {
@@ -178,7 +180,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
                 foreach (var rule in possibleDescriptor.TagMatchingRules)
                 {
-                    if (!TagHelperMatchingConventions.SatisfiesParentTag(completionContext.ContainingParentTagName, rule))
+                    if (!TagHelperMatchingConventions.SatisfiesParentTag(completionContext.ContainingTagName, rule))
                     {
                         continue;
                     }
@@ -268,10 +270,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             var binding = _tagHelperFactsService.GetTagHelperBinding(
                 completionContext.DocumentContext,
-                completionContext.ContainingParentTagName,
+                completionContext.ContainingTagName,
                 completionContext.Attributes,
-                parentTag: null,
-                parentIsTagHelper: false);
+                completionContext.ContainingParentTagName,
+                completionContext.ContainingParentIsTagHelper);
 
             if (binding is null)
             {
@@ -287,7 +289,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     var descriptors = _tagHelperFactsService.GetTagHelpersGivenTag(
                         completionContext.DocumentContext,
                         prefixedName,
-                        completionContext.ContainingParentTagName);
+                        completionContext.ContainingTagName);
 
                     if (descriptors.Count == 0)
                     {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Properties/AssemblyInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using Microsoft.VisualStudio.Editor.Razor;
 [assembly: TypeForwardedTo(typeof(TagHelperFactsService))]
 [assembly: TypeForwardedTo(typeof(DefaultTagHelperFactsService))]
 [assembly: TypeForwardedTo(typeof(TagHelperCompletionService))]
-[assembly: TypeForwardedTo(typeof(DefaultTagHelperCompletionService))]
+[assembly: TypeForwardedTo(typeof(LanguageServerTagHelperCompletionService))]
 [assembly: TypeForwardedTo(typeof(AttributeCompletionContext))]
 [assembly: TypeForwardedTo(typeof(AttributeCompletionResult))]
 [assembly: TypeForwardedTo(typeof(ElementCompletionContext))]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Working around strong naming restriction.
             var tagHelperFactsService = new DefaultTagHelperFactsService();
-            var tagHelperCompletionService = new DefaultTagHelperCompletionService(tagHelperFactsService);
+            var tagHelperCompletionService = new LanguageServerTagHelperCompletionService(tagHelperFactsService);
             var completionProviders = new RazorCompletionItemProvider[]
             {
                 new DirectiveCompletionItemProvider(),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.Editor.Razor;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using DefaultRazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.DefaultTagHelperCompletionService;
+using DefaultRazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.LanguageServerTagHelperCompletionService;
 using RazorTagHelperCompletionService = Microsoft.VisualStudio.Editor.Razor.TagHelperCompletionService;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/LanguageServerTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/LanguageServerTagHelperCompletionServiceTest.cs
@@ -1,0 +1,1419 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    public class LanguageServerTagHelperCompletionServiceTest
+    {
+        [Fact]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1452432")]
+        public void GetAttributeCompletions_OnlyIndexerNamePrefix()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("form"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .TypeName("System.Collections.Generic.IDictionary<System.String, System.String>")
+                        .PropertyName("RouteValues").AsDictionary("asp-route-", typeof(string).FullName))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last(),
+                }
+            });
+
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                Array.Empty<string>(),
+                attributes: new Dictionary<string, string>(),
+                currentTagName: "form");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_BoundDictionaryAttribute_ReturnsPrefixIndexerAndFullSetter()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("form"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("asp-all-route-data")
+                        .TypeName("System.Collections.Generic.IDictionary<System.String, System.String>")
+                        .PropertyName("RouteValues").AsDictionary("asp-route-", typeof(string).FullName))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["asp-all-route-data"] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last(),
+                },
+                ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last(),
+                }
+            });
+
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                Array.Empty<string>(),
+                attributes: new Dictionary<string, string>(),
+                currentTagName: "form");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_RequiredBoundDictionaryAttribute_ReturnsPrefixIndexerAndFullSetter()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("form")
+                        .RequireAttributeDescriptor(builder =>
+                        {
+                            builder.Name = "asp-route-";
+                            builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                        }))
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("form")
+                        .RequireAttributeDescriptor(builder => builder.Name = "asp-all-route-data"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("asp-all-route-data")
+                        .TypeName("System.Collections.Generic.IDictionary<System.String, System.String>")
+                        .PropertyName("RouteValues").AsDictionary("asp-route-", typeof(string).FullName))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["asp-all-route-data"] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last(),
+                },
+                ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last(),
+                }
+            });
+
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                Array.Empty<string>(),
+                attributes: new Dictionary<string, string>(),
+                currentTagName: "form");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_DoesNotReturnCompletionsForAlreadySuppliedAttributes()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("div")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("repeat")))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("visible")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Visible"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("StyleTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("class")
+                        .TypeName(typeof(string).FullName)
+                        .PropertyName("Class"))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
+                ["visible"] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last()
+                }
+            });
+
+            var existingCompletions = new[] { "onclick" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                attributes: new Dictionary<string, string>()
+                {
+                    ["class"] = "something",
+                    ["repeat"] = "4"
+                },
+                currentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_ReturnsCompletionForAlreadySuppliedAttribute_IfCurrentAttributeMatches()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("div")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("repeat")))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("visible")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Visible"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("StyleTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("class")
+                        .TypeName(typeof(string).FullName)
+                        .PropertyName("Class"))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
+                ["visible"] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last()
+                }
+            });
+
+            var existingCompletions = new[] { "onclick" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                attributes: new Dictionary<string, string>()
+                {
+                    ["class"] = "something",
+                    ["repeat"] = "4",
+                    ["visible"] = "false",
+                },
+                currentTagName: "div",
+                currentAttributeName: "visible");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_DoesNotReturnAlreadySuppliedAttribute_IfCurrentAttributeDoesNotMatch()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("div")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("repeat")))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("visible")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Visible"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("StyleTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("class")
+                        .TypeName(typeof(string).FullName)
+                        .PropertyName("Class"))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["onclick"] = new HashSet<BoundAttributeDescriptor>()
+            });
+
+            var existingCompletions = new[] { "onclick" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                attributes: new Dictionary<string, string>()
+                {
+                    ["class"] = "something",
+                    ["repeat"] = "4",
+                    ["visible"] = "false",
+                },
+                currentTagName: "div",
+                currentAttributeName: "repeat");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_PossibleDescriptorsReturnUnboundRequiredAttributesWithExistingCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("div")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("repeat")))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("StyleTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("*")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("class")))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["class"] = new HashSet<BoundAttributeDescriptor>(),
+                ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
+                ["repeat"] = new HashSet<BoundAttributeDescriptor>()
+            });
+
+            var existingCompletions = new[] { "onclick", "class" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_PossibleDescriptorsReturnBoundRequiredAttributesWithExistingCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("div")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("repeat")))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("repeat")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Repeat"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("visible")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Visible"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("StyleTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("*")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("class")))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("class")
+                        .TypeName(typeof(string).FullName)
+                        .PropertyName("Class"))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["class"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[1].BoundAttributes),
+                ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
+                ["repeat"] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.First()
+                }
+            });
+
+            var existingCompletions = new[] { "onclick" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_AppliedDescriptorsReturnAllBoundAttributesWithExistingCompletionsForSchemaTags()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("repeat")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Repeat"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("visible")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Visible"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("StyleTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("*")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("class")))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("class")
+                        .TypeName(typeof(string).FullName)
+                        .PropertyName("Class"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("StyleTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("visible")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Visible"))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
+                ["class"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[1].BoundAttributes),
+                ["repeat"] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.First()
+                },
+                ["visible"] = new HashSet<BoundAttributeDescriptor>()
+                {
+                    documentDescriptors[0].BoundAttributes.Last(),
+                    documentDescriptors[2].BoundAttributes.First(),
+                }
+            });
+
+            var existingCompletions = new[] { "class", "onclick" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_AppliedTagOutputHintDescriptorsReturnBoundAttributesWithExistingCompletionsForNonSchemaTags()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("CustomTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("custom"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("repeat")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Repeat"))
+                    .TagOutputHint("div")
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["class"] = new HashSet<BoundAttributeDescriptor>(),
+                ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            });
+
+            var existingCompletions = new[] { "class" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "custom");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_AppliedDescriptorsReturnBoundAttributesCompletionsForNonSchemaTags()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("CustomTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("custom"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("repeat")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Repeat"))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            });
+
+            var existingCompletions = new[] { "class" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "custom");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_AppliedDescriptorsReturnBoundAttributesWithExistingCompletionsForSchemaTags()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .BoundAttributeDescriptor(attribute => attribute
+                        .Name("repeat")
+                        .TypeName(typeof(bool).FullName)
+                        .PropertyName("Repeat"))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["class"] = new HashSet<BoundAttributeDescriptor>(),
+                ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            });
+
+            var existingCompletions = new[] { "class" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_NoDescriptorsReturnsExistingCompletions()
+        {
+            // Arrange
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "class" };
+            var completionContext = BuildAttributeCompletionContext(
+                Enumerable.Empty<TagHelperDescriptor>(),
+                existingCompletions,
+                currentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_NoDescriptorsForUnprefixedTagReturnsExistingCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("div")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("special")))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "class" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "div",
+                tagHelperPrefix: "th:");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetAttributeCompletions_NoDescriptorsForTagReturnsExistingCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("MyTableTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule
+                        .RequireTagName("table")
+                        .RequireAttributeDescriptor(attribute => attribute.Name("special")))
+                    .Build(),
+            };
+            var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+            {
+                ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "class" };
+            var completionContext = BuildAttributeCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                currentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetAttributeCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_IgnoresDirectiveAttributes()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("BindAttribute", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("input"))
+                    .BoundAttributeDescriptor(builder =>
+                    {
+                        builder.Name = "@bind";
+                        builder.AddMetadata(ComponentMetadata.Common.DirectiveAttribute, bool.TrueString);
+                    })
+                    .TagOutputHint("table")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["table"] = new HashSet<TagHelperDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "table" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "body",
+                containingParentTagName: null);
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_FiltersFullyQualifiedElementsIfShortNameExists()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("Test"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("TestAssembly.Test"))
+                    .AddMetadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch)
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("Test2TagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("Test2Assembly.Test"))
+                    .AddMetadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch)
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["Test"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0] },
+                ["Test2Assembly.Test"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[2] },
+            });
+
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                Array.Empty<string>(),
+                containingTagName: "body",
+                containingParentTagName: null);
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_TagOutputHintDoesNotFallThroughToSchemaCheck()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("MyTableTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("my-table"))
+                    .TagOutputHint("table")
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("MyTrTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("my-tr"))
+                    .TagOutputHint("tr")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["my-table"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["table"] = new HashSet<TagHelperDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "table" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "body",
+                containingParentTagName: null);
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_CatchAllsOnlyApplyToCompletionsStartingWithPrefix()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["th:li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1], documentDescriptors[0] },
+                ["li"] = new HashSet<TagHelperDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "ul",
+                tagHelperPrefix: "th:");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_TagHelperPrefixIsPrependedToTagHelperCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["th:superli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["th:li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+                ["li"] = new HashSet<TagHelperDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "ul",
+                tagHelperPrefix: "th:");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_IsCaseSensitive()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("MyliTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myli"))
+                    .SetCaseSensitive()
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("MYLITagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("MYLI"))
+                    .SetCaseSensitive()
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["myli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["MYLI"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+                ["li"] = new HashSet<TagHelperDescriptor> { },
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "ul",
+                tagHelperPrefix: null);
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_HTMLSchemaTagName_IsCaseSensitive()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("LITagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("LI"))
+                    .SetCaseSensitive()
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .SetCaseSensitive()
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["LI"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "ul",
+                tagHelperPrefix: null);
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_CatchAllsApplyToOnlyTagHelperCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["superli"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0], documentDescriptors[1] },
+                ["li"] = new HashSet<TagHelperDescriptor>(),
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "ul");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_CatchAllsApplyToNonTagHelperCompletionsIfStartsWithTagHelperPrefix()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["th:superli"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0], documentDescriptors[1] },
+                ["th:li"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[1] },
+            });
+
+            var existingCompletions = new[] { "th:li" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "ul",
+                tagHelperPrefix: "th:");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_AllowsMultiTargetingTagHelpers()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("BoldTagHelper1", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("b"))
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("bold"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("BoldTagHelper2", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["strong"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
+                ["b"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["bold"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            });
+
+            var existingCompletions = new[] { "strong", "b", "bold" };
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: "ul");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_CombinesDescriptorsOnExistingCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("LiTagHelper1", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("LiTagHelper2", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "ul");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_NewCompletionsForSchemaTagsNotInExistingCompletionsAreIgnored()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .TagOutputHint("strong")
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+                ["superli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "ul");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_OutputHintIsCrossReferencedWithExistingCompletions()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .TagOutputHint("li")
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .TagOutputHint("strong")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "ul");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_EnsuresDescriptorsHaveSatisfiedParent()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("LiTagHelper1", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("LiTagHelper2", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li").RequireParentTag("ol"))
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            });
+
+            var existingCompletions = new[] { "li" };
+            var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "ul");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_NoContainingParentTag_DoesNotGetCompletionForRuleWithParentTag()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("Tag1", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("outer-child-tag"))
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("child-tag").RequireParentTag("parent-tag"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("Tag2", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("parent-tag"))
+                    .AllowChildTag("child-tag")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["outer-child-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["parent-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            });
+
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions: Enumerable.Empty<string>(),
+                containingTagName: null,
+                containingParentTagName: null);
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_WithContainingParentTag_GetsCompletionForRuleWithParentTag()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("Tag1", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("outer-child-tag"))
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("child-tag").RequireParentTag("parent-tag"))
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("Tag2", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("parent-tag"))
+                    .AllowChildTag("child-tag")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["child-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            });
+
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions: Enumerable.Empty<string>(),
+                containingTagName: "child-tag",
+                containingParentTagName: "parent-tag");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_AllowedChildrenAreIgnoredWhenAtRoot()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .AllowChildTag("b")
+                    .AllowChildTag("bold")
+                    .AllowChildTag("div")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>());
+
+            var existingCompletions = Enumerable.Empty<string>();
+            var completionContext = BuildElementCompletionContext(
+                documentDescriptors,
+                existingCompletions,
+                containingTagName: null,
+                containingParentTagName: null);
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_DoesNotReturnExistingCompletionsWhenAllowedChildren()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .AllowChildTag("b")
+                    .AllowChildTag("bold")
+                    .AllowChildTag("div")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["b"] = new HashSet<TagHelperDescriptor>(),
+                ["bold"] = new HashSet<TagHelperDescriptor>(),
+                ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            });
+
+            var existingCompletions = new[] { "p", "em" };
+            var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "thing", containingParentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_NoneTagHelpers()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .AllowChildTag("b")
+                    .AllowChildTag("bold")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["b"] = new HashSet<TagHelperDescriptor>(),
+                ["bold"] = new HashSet<TagHelperDescriptor>(),
+            });
+
+            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_SomeTagHelpers()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .AllowChildTag("b")
+                    .AllowChildTag("bold")
+                    .AllowChildTag("div")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["b"] = new HashSet<TagHelperDescriptor>(),
+                ["bold"] = new HashSet<TagHelperDescriptor>(),
+                ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            });
+
+            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        [Fact]
+        public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_AllTagHelpers()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                TagHelperDescriptorBuilder.Create("BoldParentCatchAll", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
+                    .AllowChildTag("strong")
+                    .AllowChildTag("div")
+                    .AllowChildTag("b")
+                    .Build(),
+                TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
+                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
+                    .AllowChildTag("b")
+                    .AllowChildTag("bold")
+                    .Build(),
+            };
+            var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+            {
+                ["strong"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["b"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["bold"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+                ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
+            });
+
+            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+            var service = CreateTagHelperCompletionFactsService();
+
+            // Act
+            var completions = service.GetElementCompletions(completionContext);
+
+            // Assert
+            AssertCompletionsAreEquivalent(expectedCompletions, completions);
+        }
+
+        private static LanguageServerTagHelperCompletionService CreateTagHelperCompletionFactsService()
+        {
+            var tagHelperFactsService = new DefaultTagHelperFactsService();
+            var completionFactService = new LanguageServerTagHelperCompletionService(tagHelperFactsService);
+
+            return completionFactService;
+        }
+
+        private static void AssertCompletionsAreEquivalent(ElementCompletionResult expected, ElementCompletionResult actual)
+        {
+            Assert.Equal(expected.Completions.Count, actual.Completions.Count);
+
+            foreach (var expectedCompletion in expected.Completions)
+            {
+                var actualValue = actual.Completions[expectedCompletion.Key];
+                Assert.NotNull(actualValue);
+                Assert.Equal(expectedCompletion.Value, actualValue, TagHelperDescriptorComparer.Default);
+            }
+        }
+
+        private static void AssertCompletionsAreEquivalent(AttributeCompletionResult expected, AttributeCompletionResult actual)
+        {
+            Assert.Equal(expected.Completions.Count, actual.Completions.Count);
+
+            foreach (var expectedCompletion in expected.Completions)
+            {
+                var actualValue = actual.Completions[expectedCompletion.Key];
+                Assert.NotNull(actualValue);
+                Assert.Equal(expectedCompletion.Value, actualValue, BoundAttributeDescriptorComparer.Default);
+            }
+        }
+
+        private static ElementCompletionContext BuildElementCompletionContext(
+            IEnumerable<TagHelperDescriptor> descriptors,
+            IEnumerable<string> existingCompletions,
+            string containingTagName,
+            string containingParentTagName = "body",
+            bool containingParentIsTagHelper = false,
+            string tagHelperPrefix = "")
+        {
+            var documentContext = TagHelperDocumentContext.Create(tagHelperPrefix, descriptors);
+            var completionContext = new ElementCompletionContext(
+                documentContext,
+                existingCompletions,
+                containingTagName,
+                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                containingParentTagName: containingParentTagName,
+                containingParentIsTagHelper: containingParentIsTagHelper,
+                inHTMLSchema: (tag) => tag == "strong" || tag == "b" || tag == "bold" || tag == "li" || tag == "div");
+
+            return completionContext;
+        }
+
+        private static AttributeCompletionContext BuildAttributeCompletionContext(
+            IEnumerable<TagHelperDescriptor> descriptors,
+            IEnumerable<string> existingCompletions,
+            string currentTagName,
+            string currentAttributeName = null,
+            IEnumerable<KeyValuePair<string, string>> attributes = null,
+            string tagHelperPrefix = "")
+        {
+            attributes ??= Enumerable.Empty<KeyValuePair<string, string>>();
+            var documentContext = TagHelperDocumentContext.Create(tagHelperPrefix, descriptors);
+            var completionContext = new AttributeCompletionContext(
+                documentContext,
+                existingCompletions,
+                currentTagName,
+                currentAttributeName,
+                attributes,
+                currentParentTagName: "body",
+                currentParentIsTagHelper: false,
+                inHTMLSchema: (tag) => tag == "strong" || tag == "b" || tag == "bold" || tag == "li" || tag == "div");
+
+            return completionContext;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/LegacyTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/LegacyTagHelperCompletionServiceTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
-    public class DefaultTagHelperCompletionServiceTest
+    public class LegacyTagHelperCompletionServiceTest
     {
         [Fact]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1452432")]
@@ -1264,7 +1264,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 ["bold"] = new HashSet<TagHelperDescriptor>(),
             });
 
-            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "div", containingParentTagName: "");
             var service = CreateTagHelperCompletionFactsService();
 
             // Act
@@ -1294,7 +1294,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
             });
 
-            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "div", containingParentTagName: "");
             var service = CreateTagHelperCompletionFactsService();
 
             // Act
@@ -1330,7 +1330,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
             });
 
-            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+            var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "div", containingParentTagName: "");
             var service = CreateTagHelperCompletionFactsService();
 
             // Act
@@ -1340,10 +1340,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
             AssertCompletionsAreEquivalent(expectedCompletions, completions);
         }
 
-        private static DefaultTagHelperCompletionService CreateTagHelperCompletionFactsService()
+        private static LegacyTagHelperCompletionService CreateTagHelperCompletionFactsService()
         {
             var tagHelperFactsService = new DefaultTagHelperFactsService();
-            var completionFactService = new DefaultTagHelperCompletionService(tagHelperFactsService);
+            var completionFactService = new LegacyTagHelperCompletionService(tagHelperFactsService);
 
             return completionFactService;
         }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/LegacyTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/LegacyTagHelperCompletionServiceTest.cs
@@ -1174,8 +1174,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var completionContext = BuildElementCompletionContext(
                 documentDescriptors,
                 existingCompletions: Enumerable.Empty<string>(),
-                containingTagName: "child-tag",
-                containingParentTagName: "parent-tag");
+                containingTagName: "parent-tag",
+                containingParentTagName: null);
             var service = CreateTagHelperCompletionFactsService();
 
             // Act
@@ -1236,7 +1236,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             });
 
             var existingCompletions = new[] { "p", "em" };
-            var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "thing", containingParentTagName: "div");
+            var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "div", containingParentTagName: "thing");
             var service = CreateTagHelperCompletionFactsService();
 
             // Act


### PR DESCRIPTION
- We've been updating the usage of our TagHelper completion APIs to properly pass current HTML tag & parent HTML tags. The problem is the legacy editor still passes the old information and therefore we ended up breaking t his experience in two commits:
    - https://github.com/dotnet/razor-tooling/commit/658e2db05d0daa9326356ee1edc85cd3d1b970c4
    - https://github.com/dotnet/razor-tooling/commit/43167a25c1ada2977630f82ab016cbf8c8eaecd9
- Instead of making the existing TagHelperCompletion work for both new and old-world I decided to fork the legacy / language server implementations so the old world would get fixed while the new world continued to reap the benefits. To do this we now have a Legacy and LanguageServer fork of the compeltion service. The legacy version has the problematic versions of the above two commits reverted.

Fixes #6223