### PR TITLE
Sign VSIX components

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,6 +203,7 @@ stages:
             -restore
             -build
             -pack
+            -sign
             /p:BuildVsix=true
             /p:BuildProjectReferences=false
             $(_BuildArgs)

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -32,6 +32,7 @@ steps:
       -configuration ${{ parameters.configuration }}
       -msbuildEngine dotnet
       -prepareMachine
+      -sign
       /p:BuildVsix=true
       /p:BuildProjectReferences=false
     name: BuildVSIX

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -22,7 +22,6 @@ steps:
       -restore
       -build
       -pack
-      -sign
       -publish
     name: Build
     displayName: Build
@@ -32,7 +31,6 @@ steps:
       -configuration ${{ parameters.configuration }}
       -msbuildEngine dotnet
       -prepareMachine
-      -sign
       /p:BuildVsix=true
       /p:BuildProjectReferences=false
     name: BuildVSIX


### PR DESCRIPTION
- We weren't signing VSIX components leading to failures at VS insertion time. Passing the `-sign` parameter should be enough to get us back into a working state.

Fixes #6234