### PR TITLE
Add deployment project to include dlls that are not available on public preview integration test machines

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,7 +77,7 @@
     <MicrosoftVisualStudioShellPackagesVersion>17.0.31723.112</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.0.487</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.2.0-3.22164.11</RoslynPackageVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.1.11</VisualStudioLanguageServerProtocolVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.2.8</VisualStudioLanguageServerProtocolVersion>
     <MicrosoftNetCompilersToolsetVersion>4.2.0-1.final</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">

--- a/src/Razor/Razor.sln
+++ b/src/Razor/Razor.sln
@@ -95,6 +95,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Razor.IntegrationTests", "test\Microsoft.VisualStudio.Razor.IntegrationTests\Microsoft.VisualStudio.Razor.IntegrationTests.csproj", "{8CEC0991-259F-4313-B3EF-E398F2B40E61}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RazorDeployment", "src\RazorDeployment\RazorDeployment.csproj", "{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -415,6 +417,14 @@ Global
 		{8CEC0991-259F-4313-B3EF-E398F2B40E61}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8CEC0991-259F-4313-B3EF-E398F2B40E61}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{8CEC0991-259F-4313-B3EF-E398F2B40E61}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -459,6 +469,7 @@ Global
 		{39233703-B752-43AC-AD86-E9D3E61B4AD9} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{17C4A6DF-3AA5-43FE-8A0E-53DF14340446} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 		{8CEC0991-259F-4313-B3EF-E398F2B40E61} = {92463391-81BE-462B-AC3C-78C6C760741F}
+		{87D808DC-5C9D-4D72-A9B7-C828A8DC09FA} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/src/Razor/src/RazorDeployment/AssemblyCodeBases.cs
+++ b/src/Razor/src/RazorDeployment/AssemblyCodeBases.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Shell;
+
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]

--- a/src/Razor/src/RazorDeployment/RazorDeployment.csproj
+++ b/src/Razor/src/RazorDeployment/RazorDeployment.csproj
@@ -1,0 +1,66 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!--
+      This project deploys extra dependencies that may not be included in the host VS.
+      Used by integration tests to deploy dependencies not available on public preview. 
+    -->
+    
+    <TargetFramework>net472</TargetFramework>
+
+    <!-- Use the RoslynDev Experimental instance so we can mingle with local builds of Roslyn -->
+    <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+
+    <!-- Required to run the project localy -->
+    <StartArguments>/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log</StartArguments>
+
+    <IsShipping>false</IsShipping>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsPackable>false</IsPackable>
+
+    <!-- Don't automatically include dependencies -->
+    <IncludePackageReferencesInVSIXContainer>false</IncludePackageReferencesInVSIXContainer>
+
+    <CreateVsixContainer>true</CreateVsixContainer>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <DeployExtension>true</DeployExtension>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AvailableItemName Include="VSIXSourceItem" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- To include the ProvideCodeBase attribute type. -->
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference the LSP protocol dlls so that we can include them in the code base and output them with the VSIX. -->
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="$(MicrosoftVisualStudioLanguageServerProtocolPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" Version="$(MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="$(MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.VisualStudio.RazorExtension\Microsoft.VisualStudio.RazorExtension.csproj">
+      <Name>RazorExtension</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <IncludeOutputGroupsInVSIX>VSIXContainerProjectOutputGroup</IncludeOutputGroupsInVSIX>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll" />
+  </ItemGroup>
+</Project>

--- a/src/Razor/src/RazorDeployment/source.extension.vsixmanifest
+++ b/src/Razor/src/RazorDeployment/source.extension.vsixmanifest
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="RazorDeployment" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>RazorDeployment</DisplayName>
+    <Description xml:space="preserve">Language services for ASP.NET Core Razor</Description>
+
+    <!-- This is needed to mark this extension as cloud compliant. -->
+    <AllowClientRole>true</AllowClientRole>
+  </Metadata>
+  <Installation AllUsers="true" Experimental="true">
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency DisplayName="Razor Language Services"
+                Version="[|RazorExtension;GetVsixVersion|,)"
+                d:Source="Project"
+                Id="Microsoft.VisualStudio.RazorExtension"
+                d:ProjectName="RazorExtension"
+                Location="|RazorExtension;VSIXContainerProjectOutputGroup|"/>
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[17.0,)" DisplayName="Roslyn Language Services" />
+  </Prerequisites>
+  
+</PackageManifest>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <Nullable>enable</Nullable>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.RazorExtension\Microsoft.VisualStudio.RazorExtension.csproj" />
+    <ProjectReference Include="..\..\src\RazorDeployment\RazorDeployment.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
   </ItemGroup>


### PR DESCRIPTION
It took off years of my life to figure out what all these undocumented magic incantations do.  But I think this works - I verified running integration tests via test explorer pass with the codebases and do not without them.

Essentially this creates a new deployment project that is not inserted which adds codebases to the LSP protocol dlls.  This project is deployed in integration tests.  This deployment project just wraps the existing one similar to what roslyn does.

@ryanbrandenburg the reason why your change was having issues was that for some reason it was not deploying binding redirects for all of the rest of the razor dlls (which are versioned with 42.42.42.42 in f5).  This should sidestep that problem since it just includes the existing extension project.  I also found out with this method I just need codebases and everything works nicely.

TODO - see if integration tests pass in CI.  