### PR TITLE
Allow solutions with `+` in name to operate correctly in C#

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/RazorBreakpointSpanEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/RazorBreakpointSpanEndpoint.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/DocumentUriExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/DocumentUriExtensions.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using Microsoft.CodeAnalysis.Razor;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
@@ -14,11 +13,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
         public static string GetAbsoluteOrUNCPath(this DocumentUri documentUri!!)
         {
             return documentUri.ToUri().GetAbsoluteOrUNCPath();
-        }
-
-        public static string GetAbsolutePath(this DocumentUri documentUri!!)
-        {
-            return documentUri.ToUri().AbsolutePath;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             Range range,
             CancellationToken cancellationToken)
         {
-            var documentPath = textDocumentIdentifier.Uri.GetAbsolutePath();
+            var documentPath = textDocumentIdentifier.Uri.GetAbsoluteOrUNCPath();
             if (documentPath is null)
             {
                 return null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Razor
             }
 
             // Absolute paths are usually encoded.
-            return uri.AbsolutePath.Contains("%")? WebUtility.UrlDecode(uri.AbsolutePath) : uri.AbsolutePath;
+            return uri.AbsolutePath.Contains("%") ? WebUtility.UrlDecode(uri.AbsolutePath) : uri.AbsolutePath;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Extensions/UriExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Extensions/UriExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Extensions
             }
 
             // Absolute paths are usually encoded.
-            return WebUtility.UrlDecode(uri.AbsolutePath);
+            return uri.AbsolutePath.Contains("%") ? WebUtility.UrlDecode(uri.AbsolutePath) : uri.AbsolutePath;
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -442,7 +442,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         private CSharpVirtualDocumentSnapshot? GetCSharpDocumentSnapshsot(Uri uri)
         {
             var normalizedString = uri.GetAbsoluteOrUNCPath();
-            var normalizedUri = new Uri(WebUtility.UrlDecode(normalizedString));
+            var normalizedUri = new Uri(normalizedString);
 
             if (!_documentManager.TryGetDocument(normalizedUri, out var documentSnapshot))
             {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor
     public class UriExtensionsTest
     {
         [OSSkipConditionFact(new[] { "OSX", "Linux" })]
-        public void GetAbsoluteOrUNCPath_ReturnsAbsolutePath()
+        public void GetAbsoluteOrUNCPath_AbsolutePath_ReturnsAbsolutePath()
         {
             // Arrange
             var uri = new Uri("c:\\Some\\path\\to\\file.cshtml");
@@ -22,6 +22,32 @@ namespace Microsoft.CodeAnalysis.Razor
 
             // Assert
             Assert.Equal(uri.AbsolutePath, path);
+        }
+
+        [OSSkipConditionFact(new[] { "OSX", "Linux" })]
+        public void GetAbsoluteOrUNCPath_AbsolutePath_HandlesPlusPaths()
+        {
+            // Arrange
+            var uri = new Uri("c:\\Some\\path\\to\\file+2.cshtml");
+
+            // Act
+            var path = uri.GetAbsoluteOrUNCPath();
+
+            // Assert
+            Assert.Equal(uri.AbsolutePath, path);
+        }
+
+        [OSSkipConditionFact(new[] { "OSX", "Linux" })]
+        public void GetAbsoluteOrUNCPath_AbsolutePath_HandlesSpacePaths()
+        {
+            // Arrange
+            var uri = new Uri("c:\\Some\\path\\to\\file path.cshtml");
+
+            // Act
+            var path = uri.GetAbsoluteOrUNCPath();
+
+            // Assert
+            Assert.Equal("c:/Some/path/to/file path.cshtml", path);
         }
 
         [Fact]
@@ -35,6 +61,32 @@ namespace Microsoft.CodeAnalysis.Razor
 
             // Assert
             Assert.Equal(uri.LocalPath, path);
+        }
+
+        [Fact]
+        public void GetAbsoluteOrUNCPath_UNCPath_HandlesPlusPaths()
+        {
+            // Arrange
+            var uri = new Uri("//Some/path/to/file+2.cshtml");
+
+            // Act
+            var path = uri.GetAbsoluteOrUNCPath();
+
+            // Assert
+            Assert.Equal(uri.LocalPath, path);
+        }
+
+        [Fact]
+        public void GetAbsoluteOrUNCPath_UNCPath_HandlesSpacePaths()
+        {
+            // Arrange
+            var uri = new Uri("//Some/path/to/file path.cshtml");
+
+            // Act
+            var path = uri.GetAbsoluteOrUNCPath();
+
+            // Assert
+            Assert.Equal(@"\\some\path\to\file path.cshtml", path);
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\OSSkipConditionFactAttribute.cs" LinkBase="Shared" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.LanguageServer.ContainedLanguage\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.Editor.Razor.Test\Microsoft.VisualStudio.Editor.Razor.Test.csproj" />

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/UriExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/UriExtensionsTest.cs
@@ -3,9 +3,10 @@
 
 using System;
 using Microsoft.AspNetCore.Razor;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Extensions;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Razor
+namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 {
     public class UriExtensionsTest
     {


### PR DESCRIPTION
### Summary of the changes
- Gist of the issue is that we would sometimes double decode paths. For example, a solution with the name `file+path` would be double decoded into `file path`. This is similar to the issue Ryan fixed last year in this PR: https://github.com/dotnet/razor-tooling/pull/4136. There are two `UriExtensions` classes and only one was fixed up in the linked PR. This PR fixes the other extensions class.
- Double decoding was also occurring separately in our C# semantic tokens logic which prevented C# semantic tokens from lighting up.
- There is an edge case I found where a solution that contains both a space _and_ `+` in its name seems to fail to get any language server functionality whatsoever. This seems to be a more complicated problem but is also likely a pretty rare occurrence. Due to this, I think we can wait for more user feedback before addressing.
- Added tests.

Fixes:
https://github.com/dotnet/razor-tooling/issues/5828