### PR TITLE
Return Integration Test data from Release failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
 
         - powershell: ./eng/scripts/InstallProcDump.ps1
           displayName: Install ProcDump
-        - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1 $(ProcDumpPath)procdump.exe artifacts/log/$(_BuildConfig) (Get-Date).AddMinutes(25) dotnet, msbuild
+        - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1 $(ProcDumpPath)procdump.exe artifacts/log/$(_BuildConfig) (Get-Date).AddMinutes(25) dotnet, msbuild, devenv, vbcscompiler, xunit.console, xunit.console.x86
           displayName: Start background dump collection
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
           - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,7 +141,7 @@ stages:
         - _DotNetPublishToBlobFeed : false
         - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json
         - _BuildArgs: ''
-        - XUNIT_LOGS: '$(Build.SourcesDirectory)\artifacts\log\Debug'
+        - XUNIT_LOGS: '$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)'
 
         # Variables for internal Official builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -220,6 +220,15 @@ stages:
           name: Run_Tests
           displayName: Run Unit and Integration tests
           condition: succeeded()
+        - task: PublishBuildArtifacts@1
+          displayName: Update Integration Tests Data
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/log/$(_BuildConfig)/Screenshots/
+            artifactName: $(Agent.Os)_$(Agent.JobName) IntegrationTestsData $(_BuildConfig)
+            artifactType: Container
+            parallel: true
         # Run VSCode functional tests
         # - powershell: |
         #     . ../../../../activate.ps1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
 
         - powershell: ./eng/scripts/InstallProcDump.ps1
           displayName: Install ProcDump
-        - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1 $(ProcDumpPath)procdump.exe artifacts/log/$(_BuildConfig) (Get-Date).AddMinutes(25) dotnet, msbuild, devenv, vbcscompiler, xunit.console, xunit.console.x86
+        - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1 $(ProcDumpPath)procdump.exe artifacts/log/$(_BuildConfig) (Get-Date).AddMinutes(25) devenv, xunit.console, xunit.console.x86
           displayName: Start background dump collection
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
           - task: PowerShell@2

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -78,14 +78,6 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             // Close the file we opened, just in case, so the test can start with a clean slate
             await TestServices.Editor.CloseDocumentWindowAsync(HangMitigatingCancellationToken);
 
-            // Add custom logs on failure if they haven't already been.
-            if (!s_customLoggersAdded)
-            {
-                DataCollectionService.RegisterCustomLogger(RazorOutputPaneLogger, RazorOutputLogId, "log");
-
-                s_customLoggersAdded = true;
-            }
-
             async void RazorOutputPaneLogger(string filePath)
             {
                 var paneContent = await TestServices.Output.GetRazorOutputPaneContentAsync(CancellationToken.None);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -44,15 +44,24 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
 </div>
 ";
 
+        private const string RazorComponentElementClassification = "RazorComponentElement";
         private const string RazorOutputLogId = "RazorOutputLog";
 
         protected override string LanguageName => LanguageNames.Razor;
 
-        private static bool CustomLoggersAdded = false;
+        private static bool s_customLoggersAdded = false;
 
         public override async Task InitializeAsync()
         {
             await base.InitializeAsync();
+
+            // Add custom logs on failure if they haven't already been.
+            if (!s_customLoggersAdded)
+            {
+                DataCollectionService.RegisterCustomLogger(RazorOutputPaneLogger, RazorOutputLogId, "log");
+
+                s_customLoggersAdded = true;
+            }
 
             await TestServices.SolutionExplorer.CreateSolutionAsync("BlazorSolution", HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddProjectAsync("BlazorProject", WellKnownProjectTemplates.BlazorProject, groupId: WellKnownProjectTemplates.GroupIdentifiers.Server, templateId: null, LanguageName, HangMitigatingCancellationToken);
@@ -64,17 +73,17 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             // We open the Index.razor file, and wait for the SurveyPrompt component to be classified, as that
             // way we know the LSP server is up and running and responding
             await TestServices.SolutionExplorer.OpenFileAsync(BlazorProjectName, IndexRazorFile, HangMitigatingCancellationToken);
-            await TestServices.Editor.WaitForClassificationAsync(HangMitigatingCancellationToken, expectedClassification: "RazorComponentElement");
+            await TestServices.Editor.WaitForClassificationAsync(HangMitigatingCancellationToken, expectedClassification: RazorComponentElementClassification);
 
             // Close the file we opened, just in case, so the test can start with a clean slate
             await TestServices.Editor.CloseDocumentWindowAsync(HangMitigatingCancellationToken);
 
             // Add custom logs on failure if they haven't already been.
-            if (!CustomLoggersAdded)
+            if (!s_customLoggersAdded)
             {
                 DataCollectionService.RegisterCustomLogger(RazorOutputPaneLogger, RazorOutputLogId, "log");
 
-                CustomLoggersAdded = true;
+                s_customLoggersAdded = true;
             }
 
             async void RazorOutputPaneLogger(string filePath)


### PR DESCRIPTION
### Summary of the changes

- Firstly let's set the Log creator code a bit higher up the stack.
- Secondly lets make sure to collect the data out of the "Screenshots" directory in the case of Release build Integration Test failure.

Fixes: https://github.com/dotnet/razor-tooling/issues/6252
