### PR TITLE
Capture hang dumps for Integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,6 +217,7 @@ stages:
             -prepareMachine
             -test
             -integrationTest
+            /p:BuildProjectReferences=false
           name: Run_Tests
           displayName: Run Unit and Integration tests
           condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,6 +242,14 @@ stages:
           workingDirectory: $(Build.SourcesDirectory)/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension
           failOnStderr: true
           condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'))
+        - task: PublishTestResults@2
+          displayName: Publish Integration Test Results
+          condition: always()
+          continueOnError: true
+          inputs:
+            testResultsFormat: 'VSTest'
+            testResultsFiles: '*.trx'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
         - task: PublishBuildArtifacts@1
           displayName: Upload Test Results
           condition: always()

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -27,9 +27,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisensePackageVersion)" />
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version="$(NuGetSolutionRestoreManagerInteropVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkPackageVersion)" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.console" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -4,6 +4,10 @@
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio.Razor.IntegrationTests</RootNamespace>
+
+    <!-- Must use "dotnet test" to get blame-hang options -->
+    <TestRunnerName>MSTest</TestRunnerName>
+    <TestRunnerAdditionalArguments>"--blame-hang-dump-type:full" "--blame-hang-timeout:4m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +27,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisensePackageVersion)" />
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version="$(NuGetSolutionRestoreManagerInteropVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkPackageVersion)" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -7,7 +7,7 @@
 
     <!-- Must use "dotnet test" to get blame-hang options -->
     <TestRunnerName>MSTest</TestRunnerName>
-    <TestRunnerAdditionalArguments>"--blame-hang-dump-type:full" "--blame-hang-timeout:4m"</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments>"--blame-hang-dump-type:full" "--blame-hang-timeout:20m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnTypeFormattingTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnTypeFormattingTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Xunit;

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/xunit.runner.json
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/xunit.runner.json
@@ -1,4 +1,6 @@
 ﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "methodDisplay": "method",
+  "longRunningTestSeconds": 120,
   "shadowCopy": false
 }


### PR DESCRIPTION
### Summary of the changes

- We can leverage the existing `-hang-dump` infra in dotnet test to capture dumps when we go past a certain timeframe. 4 minutes is where the HangMitigatingCancellationToken should fail, so lets use that.

Fixes: https://github.com/dotnet/razor-tooling/issues/6249

CC @sharwell