### PR TITLE
Move drop handling workaround into VS win specific dll.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -35,8 +35,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public const string VirtualHtmlFileNameSuffix = "__virtual.html";
 
-        public const string VSProjectItemsIdentifier = "CF_VSSTGPROJECTITEMS";
-
         public static readonly Guid RazorActiveUIContextGuid = new("3c5ded8f-72c7-4b1f-af2d-099ceeb935b8");
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorDisableDropHandlerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorDisableDropHandlerProvider.cs
@@ -9,14 +9,17 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.DragDrop;
 using Microsoft.VisualStudio.Utilities;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor
+namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
+    // The intention of this class is to disable dropping random files into the Razor language service content type without throwing. Ultimately
+    // this class serves as a workaround to a limitation in the core editor APIs where without it you get an error dialog. This class allows us
+    // to silently "do nothing" when a drop occurs on one of our documents.
     [Export(typeof(IDropHandlerProvider))]
     [ContentType(RazorConstants.RazorLSPContentTypeName)]
-    [DropFormat(RazorLSPConstants.VSProjectItemsIdentifier)]
-    [Name(nameof(RazorDropHandlerProvider))]
+    [DropFormat(RazorVisualStudioWindowsConstants.VSProjectItemsIdentifier)]
+    [Name(nameof(RazorDisableDropHandlerProvider))]
     [Order(Before = "LanguageServiceTextDropHandler")]
-    internal sealed class RazorDropHandlerProvider : IDropHandlerProvider
+    internal sealed class RazorDisableDropHandlerProvider : IDropHandlerProvider
     {
         public IDropHandler GetAssociatedDropHandler(IWpfTextView wpfTextView) => new DisabledDropHandler();
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorVisualStudioWindowsConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorVisualStudioWindowsConstants.cs
@@ -10,5 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         public const string RazorLanguageServiceString = "4513FA64-5B72-4B58-9D4C-1D3C81996C2C";
 
         public static readonly Guid RazorLanguageServiceGuid = new(RazorLanguageServiceString);
+
+        public const string VSProjectItemsIdentifier = "CF_VSSTGPROJECTITEMS";
     }
 }


### PR DESCRIPTION
- For details as to why this is VS windows specific see the comment on `RazorDisableDropHandlerProvider`:
```C#
    // The intention of this class is to disable dropping random files into the Razor language service content type without throwing. Ultimately
    // this class serves as a workaround to a limitation in the core editor APIs where without it you get an error dialog. This class allows us
    // to silently "do nothing" when a drop occurs on one of our documents.
```
- Migrated the project item constant from the LSP constants into the VS windows specific constants file.
- Updated the name of our drop handler to indicate that it's disabling drop support specifically (for a workaround).
- There's no counterpart to this in the VS4Mac land because ultimately this drop support is only there as a workaround to prevent showing a dialog in unexpected scenarios.

Part of #6038