### PR TITLE
Format explicit C# statements

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
@@ -18,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
     {
         public static IReadOnlyList<FormattingSpan> GetFormattingSpans(this RazorSyntaxTree syntaxTree!!)
         {
-            var visitor = new FormattingVisitor(syntaxTree.Source);
+            var visitor = new FormattingVisitor();
             visitor.Visit(syntaxTree.Root);
 
             return visitor.FormattingSpans;
@@ -26,7 +25,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 
         public static IReadOnlyList<RazorDirectiveSyntax> GetCodeBlockDirectives(this RazorSyntaxTree syntaxTree!!)
         {
-
             // We want all nodes of type RazorDirectiveSyntax which will contain code.
             // Since code block directives occur at the top-level, we don't need to dive deeper into unrelated nodes.
             var codeBlockDirectives = syntaxTree.Root

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
@@ -116,6 +116,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         private static async Task<Dictionary<int, int>> GetCSharpIndentationCoreAsync(FormattingContext context, List<int> projectedDocumentLocations, CancellationToken cancellationToken)
         {
+            // No point calling the C# formatting if we won't be interested in any of its work anyway
+            if (projectedDocumentLocations.Count == 0)
+            {
+                return new Dictionary<int, int>();
+            }
+
             var (indentationMap, syntaxTree) = InitializeIndentationData(context, projectedDocumentLocations, cancellationToken);
 
             var root = await syntaxTree.GetRootAsync(cancellationToken);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -299,7 +299,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 IsInHtmlTag() ||
                 IsInDirectiveWithNoKind() ||
                 IsInSingleLineDirective() ||
-                IsImplicitOrExplicitExpression() ||
+                IsImplicitExpression() ||
                 IsInSectionDirectiveCloseBrace() ||
                 (!allowImplicitStatements && IsImplicitStatementStart()))
             {
@@ -382,14 +382,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     n => n is RazorDirectiveSyntax directive && directive.DirectiveDescriptor.Kind == DirectiveKind.SingleLine);
             }
 
-            bool IsImplicitOrExplicitExpression()
+            bool IsImplicitExpression()
             {
                 // E.g, (| is position)
                 //
                 // `@|foo` - true
-                // `@(|foo)` - true
                 //
-                return owner.AncestorsAndSelf().Any(n => n is CSharpImplicitExpressionSyntax || n is CSharpExplicitExpressionSyntax);
+                return owner.AncestorsAndSelf().Any(n => n is CSharpImplicitExpressionSyntax);
             }
 
             bool IsInSectionDirectiveCloseBrace()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -6,10 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
@@ -51,7 +52,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public override void VisitCSharpCodeBlock(CSharpCodeBlockSyntax node)
         {
             if (node.Parent is CSharpStatementBodySyntax ||
-                node.Parent is CSharpExplicitExpressionBodySyntax ||
                 node.Parent is CSharpImplicitExpressionBodySyntax ||
                 node.Parent is RazorDirectiveBodySyntax ||
                 (_currentBlockKind == FormattingBlockKind.Directive &&

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     {
         private const string HtmlTagName = "html";
 
-        private readonly RazorSourceDocument _source;
         private readonly List<FormattingSpan> _spans;
         private FormattingBlockKind _currentBlockKind;
         private SyntaxNode? _currentBlock;
@@ -27,9 +26,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private int _currentComponentIndentationLevel = 0;
         private bool _isInClassBody = false;
 
-        public FormattingVisitor(RazorSourceDocument source!!)
+        public FormattingVisitor()
         {
-            _source = source;
             _spans = new List<FormattingSpan>();
             _currentBlockKind = FormattingBlockKind.Markup;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -1007,6 +1007,19 @@ input: @"
     @(DateTime
 .Now
 .ToString())
+
+                @(   Html.DisplayNameFor (@<text>
+        <p >
+        <h2 ></h2>
+        </p>
+        </text>)
+        .ToString())
+
+@{
+var x = @<p>Hi there!</p>
+}
+@x()
+@(@x())
 </div>
 
 @functions {
@@ -1036,6 +1049,19 @@ expected: @"@using System.Text;
     @(DateTime
         .Now
         .ToString())
+
+    @(Html.DisplayNameFor(@<text>
+        <p>
+            <h2></h2>
+        </p>
+    </text>)
+        .ToString())
+
+    @{
+        var x = @<p>Hi there!</p>
+    }
+    @x()
+    @(@x())
 </div>
 
 @functions {

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/TestFiles/Expected/FormatDocument.cshtml
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/TestFiles/Expected/FormatDocument.cshtml
@@ -16,6 +16,6 @@
 </div>
 <div>
     @(Html.DropDownList("list")
-    .ToString()
-    )
+        .ToString()
+        )
 </div>


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6110

This is one of those weird situations where the fix is too easy and makes me question everything, though it's possible formatting explicit C# statements used to not work well, and other fixes have meant that things are fine now.

Essentially what was happening was HTML formatting was removing all of the indentation, and then since C# formatting skipped them, you ended up with everything in a neat line like in the screenshot in the issue.