### PR TITLE
Change IntegrationTest target directory

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,7 +226,7 @@ stages:
           condition: always()
           continueOnError: true
           inputs:
-            pathtoPublish: artifacts/log/$(_BuildConfig)/Screenshots/
+            pathtoPublish: artifacts/bin/Microsoft.VisualStudio.Razor.IntegrationTests/$(_BuildConfig)/net472/xUnitResults/Screenshots/
             artifactName: $(Agent.Os)_$(Agent.JobName) IntegrationTestsData $(_BuildConfig)
             artifactType: Container
             parallel: true


### PR DESCRIPTION
### Summary of the changes

- When we moved IntegrationTests to use `dotnet test` (to enable hang-dump collection) it changed the destination of the Screenshots folder. Updating it.