### PR TITLE
Fix folding display

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
         /// </summary>
         private void FixRangeStart(Range mappedRange, RazorCodeDocument codeDocument)
         {
-            Debug.Assert(mappedRange.Start.Line > mappedRange.End.Line);
+            Debug.Assert(mappedRange.Start.Line < mappedRange.End.Line);
 
             var sourceText = codeDocument.GetSourceText();
             var startLine = mappedRange.Start.Line;


### PR DESCRIPTION
When a folding range is collapsed, it uses the offset character to
determine where to put the "...". We want to make sure some text is
showing to indicate what actually is being folded. Modify the range so
that it's at the end of the start line always (ignoring whitespace).
