### PR TITLE
Fix document opening in dev tools

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.RazorExtension.SyntaxVisualizer
             try
             {
                 File.WriteAllText(tempFileName, generatedCode);
-                VsShellUtilities.OpenAsMiscellaneousFile(ServiceProvider.GlobalProvider, tempFileName, Path.GetFileName(tempFileName) + " [generated]", VSConstants.VsEditorFactoryGuid.TextEditor_guid, string.Empty, VSConstants.LOGVIEWID.TextView_guid);
+                VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, tempFileName);
             }
             catch
             {
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.RazorExtension.SyntaxVisualizer
             var fileName = Path.GetFileName(originalFilePath);
             var tempPath = Path.Combine(s_baseTempPath, Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(tempPath);
-            var tempFileName = Path.Combine(tempPath, fileName + ".g.html");
+            var tempFileName = Path.Combine(tempPath, fileName + extension);
             return tempFileName;
         }
 


### PR DESCRIPTION
I broke this when making sure temp files were cleaned up, hence its all Ryan's fault.

~Tagging is still broken, must be one of my changes for RPS, but I don't know why, and I don't want to regress RPS accidentally so will have to work it out.~ It was just a bad MEF cache