### PR TITLE
Remove VS4Mac shipped dependencies from manifest.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -27,12 +27,17 @@
     <Import assembly="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
     <Import assembly="Microsoft.Extensions.Configuration.dll" />
     <Import assembly="Microsoft.Extensions.Configuration.Abstractions.dll" />
-    <Import assembly="Microsoft.Extensions.Logging.dll" />
-    <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
-    <Import assembly="System.IO.Pipelines.dll" />
-    <Import assembly="System.Reactive.dll" />
-    <Import assembly="System.Runtime.CompilerServices.Unsafe.dll" />
-    <Import assembly="System.Threading.Channels.dll" />
+
+    <!--
+        Purposefully not including these actual dependencies because VS4Mac ships them for us on our behalf. This differs from VisualStudio windows.
+
+        <Import assembly="Microsoft.Extensions.Logging.dll" />
+        <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
+        <Import assembly="System.IO.Pipelines.dll" />
+        <Import assembly="System.Reactive.dll" />
+        <Import assembly="System.Runtime.CompilerServices.Unsafe.dll" />
+        <Import assembly="System.Threading.Channels.dll" />
+    -->
   </Runtime>
   <Dependencies>
     <Addin id="::MonoDevelop.Core" version="17.0" />

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
@@ -27,12 +27,17 @@
     <Import assembly="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
     <Import assembly="Microsoft.Extensions.Configuration.dll" />
     <Import assembly="Microsoft.Extensions.Configuration.Abstractions.dll" />
-    <Import assembly="Microsoft.Extensions.Logging.dll" />
-    <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
-    <Import assembly="System.IO.Pipelines.dll" />
-    <Import assembly="System.Reactive.dll" />
-    <Import assembly="System.Runtime.CompilerServices.Unsafe.dll" />
-    <Import assembly="System.Threading.Channels.dll" />
+
+    <!--
+        Purposefully not including these actual dependencies because VS4Mac ships them for us on our behalf. This differs from VisualStudio windows.
+
+        <Import assembly="Microsoft.Extensions.Logging.dll" />
+        <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
+        <Import assembly="System.IO.Pipelines.dll" />
+        <Import assembly="System.Reactive.dll" />
+        <Import assembly="System.Runtime.CompilerServices.Unsafe.dll" />
+        <Import assembly="System.Threading.Channels.dll" />
+    -->
   </Runtime>
   <Dependencies>
     <Addin id="::MonoDevelop.Core" version="17.0" />


### PR DESCRIPTION
- This removes the following assemblies from the manifest:
    - Microsoft.Extensions.Logging.dll
    - Microsoft.Extensions.Logging.Abstractions.dll
    - System.IO.Pipelines.dll
    - System.Reactive.dll
    - System.Runtime.CompilerServices.Unsafe.dll
    - System.Threading.Channels.dll
- These seemed to cause errors at runtime.

Part of #6038