### PR TITLE
Restrict FQN C# code action from appearing in single line directives.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
@@ -156,26 +156,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             {
                 if (codeAction.Name.Equals(RazorPredefinedCodeFixProviderNames.FullyQualify, StringComparison.Ordinal))
                 {
-                    var node = FindImplicitOrExplicitExpressionNode(context);
                     string action;
 
-                    // The formatting pass of our Default code action resolver rejects
-                    // implicit/explicit expressions. So if we're in an implicit expression,
-                    // we run the remapping resolver responsible for simply remapping
-                    // (without formatting) the resolved code action. We do not support
-                    // explicit expressions due to issues with the remapping methodology
-                    // risking document corruption.
-                    if (node is null)
+                    if (!TryGetOwner(context, out var owner))
                     {
-                        action = LanguageServerConstants.CodeActions.Default;
+                        // Failed to locate a valid owner for the light bulb
+                        continue;
                     }
-                    else if (node is CSharpImplicitExpressionSyntax)
+                    else if (IsSingleLineDirectiveNode(owner))
+                    {
+                        // Don't support single line directives
+                        continue;
+                    }
+                    else if (IsExplicitExpressionNode(owner))
+                    {
+                        // Don't support explicit expressions
+                        continue;
+                    }
+                    else if (IsImplicitExpressionNode(owner))
                     {
                         action = LanguageServerConstants.CodeActions.UnformattedRemap;
                     }
                     else
                     {
-                        continue;
+                        // All other scenarios we support default formatted code action behavior
+                        action = LanguageServerConstants.CodeActions.Default;
                     }
 
                     typeAccessibilityCodeActions.Add(codeAction.WrapResolvableCSharpCodeAction(context, action));
@@ -197,28 +202,52 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             return typeAccessibilityCodeActions;
 
-            static SyntaxNode FindImplicitOrExplicitExpressionNode(RazorCodeActionContext context)
+            static bool TryGetOwner(RazorCodeActionContext context, out SyntaxNode owner)
             {
                 var change = new SourceChange(context.Location.AbsoluteIndex, length: 0, newText: string.Empty);
                 var syntaxTree = context.CodeDocument.GetSyntaxTree();
                 if (syntaxTree?.Root is null)
                 {
-                    return null;
+                    owner = null;
+                    return false;
                 }
 
-                var owner = syntaxTree.Root.LocateOwner(change);
+                owner = syntaxTree.Root.LocateOwner(change);
                 if (owner is null)
                 {
                     Debug.Fail("Owner should never be null.");
-                    return null;
+                    return false;
                 }
 
+                return true;
+            }
+
+            static bool IsImplicitExpressionNode(SyntaxNode owner)
+            {
                 // E.g, (| is position)
                 //
                 // `@|foo` - true
+                //
+                return owner.AncestorsAndSelf().Any(n => n is CSharpImplicitExpressionSyntax);
+            }
+
+            static bool IsExplicitExpressionNode(SyntaxNode owner)
+            {
+                // E.g, (| is position)
+                //
                 // `@(|foo)` - true
                 //
-                return owner.AncestorsAndSelf().FirstOrDefault(n => n is CSharpImplicitExpressionSyntax || n is CSharpExplicitExpressionSyntax);
+                return owner.AncestorsAndSelf().Any(n => n is CSharpExplicitExpressionBodySyntax);
+            }
+
+            static bool IsSingleLineDirectiveNode(SyntaxNode owner)
+            {
+                // E.g, (| is position)
+                //
+                // `@inject |SomeType SomeName` - true
+                //
+                return owner.AncestorsAndSelf().Any(
+                    n => n is RazorDirectiveSyntax directive && directive.DirectiveDescriptor.Kind == DirectiveKind.SingleLine);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
@@ -18,6 +18,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Razor;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
@@ -202,7 +203,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             return typeAccessibilityCodeActions;
 
-            static bool TryGetOwner(RazorCodeActionContext context, out SyntaxNode owner)
+            static bool TryGetOwner(RazorCodeActionContext context, [NotNullWhen(true)] out SyntaxNode owner)
             {
                 var change = new SourceChange(context.Location.AbsoluteIndex, length: 0, newText: string.Empty);
                 var syntaxTree = context.CodeDocument.GetSyntaxTree();


### PR DESCRIPTION
- Found that we'd provide the FQN directive for single line directives and then upon formatting we'd bail because we can't accurately format single line directives. At first I tried digging into why we couldn't format them and turns out the C# formatter returns some really odd edits to us in terms of proper formatting. Once we build in the tech for fully formatting single line directives in the Razor context (ignore what C# tells us) this should enable us to build a good experience around this. For now disabling FQN cleans up what we provide to users.
- Added a test to validate

Fixes #6015