### PR TITLE
Add "inferred" remapping support to allow for more diagnostics.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -550,7 +550,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
         }
 
-        private bool TryMapFromProjectedDocumentRangeInferred(RazorCodeDocument codeDocument, Range projectedRange, out Range? originalRange)
+        private bool TryMapFromProjectedDocumentRangeInferred(RazorCodeDocument codeDocument, Range projectedRange, [NotNullWhen(returnValue: true)] out Range? originalRange)
         {
             // Inferred mapping behavior is a superset of inclusive mapping behavior so if the range is "inclusive" lets use that mapping.
             if (TryMapFromProjectedDocumentRangeInclusive(codeDocument, projectedRange, out originalRange))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -474,7 +474,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return true;
         }
 
-        private bool TryMapFromProjectedDocumentRangeInclusive(RazorCodeDocument codeDocument, Range projectedRange, out Range? originalRange)
+        private bool TryMapFromProjectedDocumentRangeInclusive(RazorCodeDocument codeDocument, Range projectedRange, [NotNullWhen(returnValue: true)] out Range? originalRange)
         {
             originalRange = default;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -206,6 +206,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             {
                 return TryMapFromProjectedDocumentRangeInclusive(codeDocument, projectedRange, out originalRange);
             }
+            else if (mappingBehavior == MappingBehavior.Inferred)
+            {
+                return TryMapFromProjectedDocumentRangeInferred(codeDocument, projectedRange, out originalRange);
+            }
             else
             {
                 throw new InvalidOperationException(RazorLS.Resources.Unknown_mapping_behavior);
@@ -544,6 +548,85 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     new Position(endLocation.LineIndex, endLocation.CharacterIndex));
                 return convertedRange;
             }
+        }
+
+        private bool TryMapFromProjectedDocumentRangeInferred(RazorCodeDocument codeDocument, Range projectedRange, out Range? originalRange)
+        {
+            // Inferred mapping behavior is a superset of inclusive mapping behavior so if the range is "inclusive" lets use that mapping.
+            if (TryMapFromProjectedDocumentRangeInclusive(codeDocument, projectedRange, out originalRange))
+            {
+                return true;
+            }
+
+            // Doesn't map so lets try and infer some mappings
+
+            originalRange = default;
+            var csharpDoc = codeDocument.GetCSharpDocument();
+            var csharpSourceText = codeDocument.GetCSharpSourceText();
+            var projectedRangeAsSpan = projectedRange.AsTextSpan(csharpSourceText);
+            SourceMapping? mappingBeforeProjectedRange = null;
+            SourceMapping? mappingAfterProjectedRange = null;
+
+            for (var i = csharpDoc.SourceMappings.Count - 1; i >= 0; i--)
+            {
+                var sourceMapping = csharpDoc.SourceMappings[i];
+                var sourceMappingEnd = sourceMapping.GeneratedSpan.AbsoluteIndex + sourceMapping.GeneratedSpan.Length;
+                if (projectedRangeAsSpan.Start >= sourceMappingEnd)
+                {
+                    // This is the source mapping that's before us!
+                    mappingBeforeProjectedRange = sourceMapping;
+
+                    if (i + 1 < csharpDoc.SourceMappings.Count)
+                    {
+                        // We're not at the end of the document there's another source mapping after us
+                        mappingAfterProjectedRange = csharpDoc.SourceMappings[i + 1];
+                    }
+
+                    break;
+                }
+            }
+
+            if (mappingBeforeProjectedRange == null)
+            {
+                // Could not find a mapping before
+                return false;
+            }
+
+            var sourceDocument = codeDocument.Source;
+            var originalSpanBeforeProjectedRange = mappingBeforeProjectedRange.OriginalSpan;
+            var originalEndBeforeProjectedRange = originalSpanBeforeProjectedRange.AbsoluteIndex + originalSpanBeforeProjectedRange.Length;
+            var originalEndPositionBeforeProjectedRange = sourceDocument.Lines.GetLocation(originalEndBeforeProjectedRange);
+            var inferredStartPosition = new Position(originalEndPositionBeforeProjectedRange.LineIndex, originalEndPositionBeforeProjectedRange.CharacterIndex);
+
+            if (mappingAfterProjectedRange != null)
+            {
+                // There's a mapping after the "projected range" lets use its start position as our inferred end position.
+
+                var originalSpanAfterProjectedRange = mappingAfterProjectedRange.OriginalSpan;
+                var originalStartPositionAfterProjectedRange = sourceDocument.Lines.GetLocation(originalSpanAfterProjectedRange.AbsoluteIndex);
+                var inferredEndPosition = new Position(originalStartPositionAfterProjectedRange.LineIndex, originalStartPositionAfterProjectedRange.CharacterIndex);
+
+                originalRange = new Range()
+                {
+                    Start = inferredStartPosition,
+                    End = inferredEndPosition,
+                };
+                return true;
+            }
+
+            // There was no projection after the "projected range". Therefore, lets fallback to the end-document location.
+
+            Debug.Assert(sourceDocument.Length > 0, "Source document length should be greater than 0 here because there's a mapping before us");
+
+            var endOfDocumentLocation = sourceDocument.Lines.GetLocation(sourceDocument.Length);
+            var endOfDocumentPosition = new Position(endOfDocumentLocation.LineIndex, endOfDocumentLocation.CharacterIndex);
+
+            originalRange = new Range()
+            {
+                Start = inferredStartPosition,
+                End = endOfDocumentPosition,
+            };
+            return true;
         }
 
         private static bool s_haveAsserted = false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -545,7 +545,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             if (!_documentMappingService.TryMapFromProjectedDocumentRange(
                 codeDocument,
                 diagnostic.Range,
-                MappingBehavior.Inclusive,
+                MappingBehavior.Inferred,
                 out originalRange))
             {
                 // Couldn't remap the range correctly.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
@@ -18,6 +18,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         ///     - Overlaps 1 generated range = Will reduce the provided range down to the generated range.
         ///     - Intersects 1 generated range = Will use the generated range mappings
         /// </summary>
-        Inclusive
+        Inclusive,
+
+        /// <summary>
+        /// Inferred mapping behavior will attempt to map overlapping, intersecting or inbetween generated ranges with a provided projection range.
+        ///
+        /// Behavior: Everything `Inclusive` does +
+        ///     - No mappings in document = No mapping
+        ///     - Inbetween two mappings = Maps inbetween the two generated ranges
+        ///     - Inbetween one mapping and end of document = Maps end of mapping to the end of document
+        ///     - Inbetween beginning of document and one mapping = No mapping
+        ///         o Usually errors flow forward in the document space (not backwards) which is why we don't map this scenario.
+        /// </summary>
+        Inferred
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MappingBehavior.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal enum MappingBehavior

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorDocumentMappingServiceTest.cs
@@ -335,6 +335,132 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         }
 
         [Fact]
+        public void TryMapFromProjectedDocumentRange_Inferred_DirectlyMaps_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService(LoggerFactory);
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "<p>@DateTime.Now</p>",
+                "__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 6),
+                End = new Position(0, 18),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 4),
+                End = new Position(0, 16)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inferred,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inferred_BeginningOfDocAndProjection_ReturnsFalse()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService(LoggerFactory);
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "@<unclosed></unclosed><p>@DateTime.Now</p>",
+                "(__builder) => { };__o = DateTime.Now;",
+                new[] { new SourceMapping(new SourceSpan(26, 12), new SourceSpan(25, 12)) });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 0),
+                End = new Position(0, 19),
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inferred,
+                out var originalRange);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inferred_InbetweenProjections_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService(LoggerFactory);
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "@{ var abc = @<unclosed></unclosed> }",
+                " var abc =  (__builder) => { } ",
+                new[] {
+                    new SourceMapping(new SourceSpan(2, 11), new SourceSpan(0, 11)),
+                    new SourceMapping(new SourceSpan(35, 1), new SourceSpan(30, 1)),
+                });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 12),
+                End = new Position(0, 29),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 13),
+                End = new Position(0, 35)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inferred,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
+        public void TryMapFromProjectedDocumentRange_Inferred_InbetweenProjectionAndEndOfDoc_ReturnsTrue()
+        {
+            // Arrange
+            var service = new DefaultRazorDocumentMappingService(LoggerFactory);
+            var codeDoc = CreateCodeDocumentWithCSharpProjection(
+                "@{ var abc = @<unclosed></unclosed>",
+                " var abc =  (__builder) => { }",
+                new[] { new SourceMapping(new SourceSpan(2, 11), new SourceSpan(0, 11)), });
+            var projectedRange = new Range()
+            {
+                Start = new Position(0, 12),
+                End = new Position(0, 29),
+            };
+            var expectedOriginalRange = new Range()
+            {
+                Start = new Position(0, 13),
+                End = new Position(0, 35)
+            };
+
+            // Act
+            var result = service.TryMapFromProjectedDocumentRange(
+                codeDoc,
+                projectedRange,
+                MappingBehavior.Inferred,
+                out var originalRange);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedOriginalRange, originalRange);
+        }
+
+        [Fact]
         public void TryMapToProjectedDocumentPosition_NotMatchingAnyMapping()
         {
             // Arrange


### PR DESCRIPTION
- In this changeset I went ahead and experimented with a new diagnostic translation approach that I call "inferred". The general idea is that when we encounter diagnostics that aren't in mappable regions / we can't derive where they came from to then attempt to give customers a general idea on where diagnostics are coming from. This means we'll highlight larger diagnostic regions in the document to help guide customers towards problem areas instead of hiding diagnostics entirely. When playing around with this tech I found that we more often than not could show higher quality + significantly more diagnostics to customers without being too noisy.
    - One thing to keep in mind, in an "ideal" world we'd know where all diagnostics came from, aka a SyntaxNode generated X generated Code which resulted in Y generated errors; however, in practice that doesn't seem to actually happen.
- So what is "inferred" diagnostic mapping behavior? Effectively it's adding the ability to map "inbetween" known mapping areas. Because languages typically operate on a forward progressing parser model (i.e. errors get propagated downward, not up) we can apply a few heuristics based on some possible states of diagnostics:
    1. Diagnostic maps directly to a known sub-language region = return as is (this is strict mapping behavior)
    1. Diagnostic intersects with a known sub-language region = scope the diagnostic to the sub-language region to draw attention (inclusive mapping behavior)
    1. Diagnostic does not map to any known sub-language region (inferred mapping behavior):
        1. Diagnostic is inbetween beginning of document and a known sub-language region = Associate diagnostic with the document without a location given diagnostics are typically propagated forward and we'd be highlighting too large an area
        1. Diagnostic is inbetween two known sub-language regions = Associate diagnostic with the region between the two known sub-language region because something inbetween those regions is most likely the cause.
        1. Diagnostic is inbetween end of document and a known sub-language region = Associate diagnostic with end of closest sub-language region all the way till end of document
- Added tests for the above scenarios

**Left side new (`MappingBehavior.Inferred`), Right side old (`MappingBehavior.Inclusive`)**:

![devenv_HY8clnTtsy](https://user-images.githubusercontent.com/2008729/163880142-3fc1cf97-b690-42b0-84e2-2791c3ba8c37.gif)


Fixes #6136