### PR TITLE
Split completion resolve / providing into separate endpoints.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
-using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
@@ -23,15 +22,12 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
-    internal class RazorCompletionEndpoint : ICompletionHandler, ICompletionResolveHandler
+    internal class RazorCompletionEndpoint : ICompletionHandler
     {
         private readonly ILogger _logger;
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
         private readonly DocumentResolver _documentResolver;
         private readonly RazorCompletionFactsService _completionFactsService;
-        private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
-        private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
-        private readonly ClientNotifierServiceBase _languageServer;
         private readonly CompletionListCache _completionListCache;
         private static readonly Command s_retriggerCompletionCommand = new()
         {
@@ -41,30 +37,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         private PlatformAgnosticCompletionCapability? _capability;
         private IReadOnlyList<ExtendedCompletionItemKinds>? _supportedItemKinds;
 
-        // Guid is magically generated and doesn't mean anything. O# magic.
-        public Guid Id => new("011c77cc-f90e-4f2e-b32c-dafc6587ccd6");
-
         public RazorCompletionEndpoint(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher!!,
             DocumentResolver documentResolver!!,
             RazorCompletionFactsService completionFactsService!!,
-            LSPTagHelperTooltipFactory lspTagHelperTooltipFactory!!,
-            VSLSPTagHelperTooltipFactory vsLspTagHelperTooltipFactory!!,
-            ClientNotifierServiceBase languageServer!!,
+            CompletionListCache completionListCache,
             ILoggerFactory loggerFactory!!)
         {
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
             _documentResolver = documentResolver;
             _completionFactsService = completionFactsService;
-            _lspTagHelperTooltipFactory = lspTagHelperTooltipFactory;
-            _vsLspTagHelperTooltipFactory = vsLspTagHelperTooltipFactory;
-            _languageServer = languageServer;
             _logger = loggerFactory.CreateLogger<RazorCompletionEndpoint>();
-            _completionListCache = new CompletionListCache();
-        }
-
-        public void SetCapability(CompletionCapability capability, ClientCapabilities clientCapabilities)
-        {
+            _completionListCache = completionListCache;
         }
 
         public CompletionRegistrationOptions GetRegistrationOptions(CompletionCapability capability, ClientCapabilities clientCapabilities)
@@ -139,109 +123,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = CreateLSPCompletionList(razorCompletionItems);
 
             return completionList;
-        }
-
-        public Task<CompletionItem> Handle(CompletionItem completionItem, CancellationToken cancellationToken)
-        {
-            if (!completionItem.TryGetCompletionListResultId(out var resultId))
-            {
-                // Couldn't resolve.
-                return Task.FromResult(completionItem);
-            }
-
-            if (!_completionListCache.TryGet(resultId.Value, out var cachedCompletionItems))
-            {
-                return Task.FromResult(completionItem);
-            }
-
-            var labelQuery = completionItem.Label;
-            var associatedRazorCompletion = cachedCompletionItems.FirstOrDefault(completion => string.Equals(labelQuery, completion.DisplayText, StringComparison.Ordinal));
-            if (associatedRazorCompletion is null)
-            {
-                _logger.LogError("Could not find an associated razor completion item. This should never happen since we were able to look up the cached completion list.");
-                Debug.Fail("Could not find an associated razor completion item. This should never happen since we were able to look up the cached completion list.");
-                return Task.FromResult(completionItem);
-            }
-
-            // If the client is VS, also fill in the Description property.
-            var useDescriptionProperty = _languageServer.ClientSettings.Capabilities is PlatformAgnosticClientCapabilities clientCapabilities &&
-                clientCapabilities.SupportsVisualStudioExtensions;
-
-            MarkupContent? tagHelperMarkupTooltip = null;
-            VSClassifiedTextElement? tagHelperClassifiedTextTooltip = null;
-
-            switch (associatedRazorCompletion.Kind)
-            {
-                case RazorCompletionItemKind.Directive:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem = completionItem with { Documentation = descriptionInfo.Description };
-                        }
-
-                        break;
-                    }
-                case RazorCompletionItemKind.MarkupTransition:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem = completionItem with { Documentation = descriptionInfo.Description };
-                        }
-
-                        break;
-                    }
-                case RazorCompletionItemKind.DirectiveAttribute:
-                case RazorCompletionItemKind.DirectiveAttributeParameter:
-                case RazorCompletionItemKind.TagHelperAttribute:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
-                        }
-
-                        break;
-                    }
-                case RazorCompletionItemKind.TagHelperElement:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
-                        }
-
-                        break;
-                    }
-            }
-
-            if (tagHelperMarkupTooltip != null)
-            {
-                var documentation = new StringOrMarkupContent(tagHelperMarkupTooltip);
-                completionItem = completionItem with { Documentation = documentation };
-            }
-
-            // We might strip out the commitcharacters for speed, bring them back
-            var container = associatedRazorCompletion.CommitCharacters != null ? new Container<string>(associatedRazorCompletion.CommitCharacters) : null;
-            completionItem = completionItem with { CommitCharacters = container };
-            var vsCompletionItem = completionItem.ToVSCompletionItem(_capability?.VSCompletionList);
-
-            if (tagHelperClassifiedTextTooltip != null)
-            {
-                vsCompletionItem.Description = tagHelperClassifiedTextTooltip;
-                return Task.FromResult<CompletionItem>(vsCompletionItem);
-            }
-
-            return Task.FromResult<CompletionItem>(vsCompletionItem);
         }
 
         // Internal for testing

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class RazorCompletionResolveEndpoint : ICompletionResolveHandler
+    {
+        private readonly ILogger _logger;
+        private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
+        private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
+        private readonly CompletionListCache _completionListCache;
+        private PlatformAgnosticCompletionCapability? _completionCapability;
+        private PlatformAgnosticClientCapabilities? _clientCapabilities;
+
+        // Guid is magically generated and doesn't mean anything. O# magic.
+        public Guid Id => new("011c77cc-f90e-4f2e-b32c-dafc6587ccd6");
+
+        public RazorCompletionResolveEndpoint(
+            LSPTagHelperTooltipFactory lspTagHelperTooltipFactory!!,
+            VSLSPTagHelperTooltipFactory vsLspTagHelperTooltipFactory!!,
+            CompletionListCache completionListCache,
+            ILoggerFactory loggerFactory!!)
+        {
+            _lspTagHelperTooltipFactory = lspTagHelperTooltipFactory;
+            _vsLspTagHelperTooltipFactory = vsLspTagHelperTooltipFactory;
+            _logger = loggerFactory.CreateLogger<RazorCompletionEndpoint>();
+            _completionListCache = completionListCache;
+        }
+
+        public void SetCapability(CompletionCapability capability, ClientCapabilities clientCapabilities)
+        {
+            _completionCapability = (PlatformAgnosticCompletionCapability)capability;
+            _clientCapabilities = (PlatformAgnosticClientCapabilities)clientCapabilities;
+        }
+
+        public Task<CompletionItem> Handle(CompletionItem completionItem, CancellationToken cancellationToken)
+        {
+            if (!completionItem.TryGetCompletionListResultId(out var resultId))
+            {
+                // Couldn't resolve.
+                return Task.FromResult(completionItem);
+            }
+
+            if (!_completionListCache.TryGet(resultId.Value, out var cachedCompletionItems))
+            {
+                return Task.FromResult(completionItem);
+            }
+
+            var labelQuery = completionItem.Label;
+            var associatedRazorCompletion = cachedCompletionItems.FirstOrDefault(completion => string.Equals(labelQuery, completion.DisplayText, StringComparison.Ordinal));
+            if (associatedRazorCompletion is null)
+            {
+                _logger.LogError("Could not find an associated razor completion item. This should never happen since we were able to look up the cached completion list.");
+                Debug.Fail("Could not find an associated razor completion item. This should never happen since we were able to look up the cached completion list.");
+                return Task.FromResult(completionItem);
+            }
+
+            // If the client is VS, also fill in the Description property.
+            var useDescriptionProperty = _clientCapabilities?.SupportsVisualStudioExtensions ?? false;
+
+            MarkupContent? tagHelperMarkupTooltip = null;
+            VSClassifiedTextElement? tagHelperClassifiedTextTooltip = null;
+
+            switch (associatedRazorCompletion.Kind)
+            {
+                case RazorCompletionItemKind.Directive:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
+                        if (descriptionInfo is not null)
+                        {
+                            completionItem = completionItem with { Documentation = descriptionInfo.Description };
+                        }
+
+                        break;
+                    }
+                case RazorCompletionItemKind.MarkupTransition:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
+                        if (descriptionInfo is not null)
+                        {
+                            completionItem = completionItem with { Documentation = descriptionInfo.Description };
+                        }
+
+                        break;
+                    }
+                case RazorCompletionItemKind.DirectiveAttribute:
+                case RazorCompletionItemKind.DirectiveAttributeParameter:
+                case RazorCompletionItemKind.TagHelperAttribute:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
+                        if (useDescriptionProperty)
+                        {
+                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                        }
+                        else
+                        {
+                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
+                        }
+
+                        break;
+                    }
+                case RazorCompletionItemKind.TagHelperElement:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
+                        if (useDescriptionProperty)
+                        {
+                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                        }
+                        else
+                        {
+                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperMarkupTooltip);
+                        }
+
+                        break;
+                    }
+            }
+
+            if (tagHelperMarkupTooltip != null)
+            {
+                var documentation = new StringOrMarkupContent(tagHelperMarkupTooltip);
+                completionItem = completionItem with { Documentation = documentation };
+            }
+
+            // We might strip out the commitcharacters for speed, bring them back
+            var container = associatedRazorCompletion.CommitCharacters != null ? new Container<string>(associatedRazorCompletion.CommitCharacters) : null;
+            completionItem = completionItem with { CommitCharacters = container };
+            var vsCompletionItem = completionItem.ToVSCompletionItem(_completionCapability?.VSCompletionList);
+
+            if (tagHelperClassifiedTextTooltip != null)
+            {
+                vsCompletionItem.Description = tagHelperClassifiedTextTooltip;
+                return Task.FromResult<CompletionItem>(vsCompletionItem);
+            }
+
+            return Task.FromResult<CompletionItem>(vsCompletionItem);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -118,6 +118,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     })
                     .WithHandler<RazorDocumentSynchronizationEndpoint>()
                     .WithHandler<RazorCompletionEndpoint>()
+                    .WithHandler<RazorCompletionResolveEndpoint>()
                     .WithHandler<RazorHoverEndpoint>()
                     .WithHandler<RazorLanguageEndpoint>()
                     .WithHandler<RazorDiagnosticsEndpoint>()
@@ -202,6 +203,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<VSLSPTagHelperTooltipFactory, DefaultVSLSPTagHelperTooltipFactory>();
 
                         // Completion
+                        services.AddSingleton<CompletionListCache>();
                         services.AddSingleton<TagHelperCompletionService, LanguageServerTagHelperCompletionService>();
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
                         services.AddSingleton<RazorCompletionItemProvider, DirectiveCompletionItemProvider>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
-using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -47,18 +46,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 new TagHelperCompletionProvider(tagHelperCompletionService, new DefaultHtmlFactsService(), tagHelperFactsService)
             };
             CompletionFactsService = new DefaultRazorCompletionFactsService(completionProviders);
-            LSPTagHelperTooltipFactory = Mock.Of<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
-            VSLSPTagHelperTooltipFactory = Mock.Of<VSLSPTagHelperTooltipFactory>(MockBehavior.Strict);
             EmptyDocumentResolver = Mock.Of<DocumentResolver>(MockBehavior.Strict);
+            CompletionListCache = new CompletionListCache();
         }
 
         private RazorCompletionFactsService CompletionFactsService { get; }
 
-        private LSPTagHelperTooltipFactory LSPTagHelperTooltipFactory { get; }
-
-        private VSLSPTagHelperTooltipFactory VSLSPTagHelperTooltipFactory { get; }
-
         private DocumentResolver EmptyDocumentResolver { get; }
+
+        private CompletionListCache CompletionListCache { get; }
 
         [Fact]
         public void IsApplicableTriggerContext_Deletion_ReturnsFalse()
@@ -335,216 +331,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Null(converted.Command);
         }
 
-        [Fact]
-        public async Task Handle_Resolve_DirectiveCompletion_ReturnsCompletionItemWithDocumentation()
-        {
-            // Arrange
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
-            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.Directive);
-            razorCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription("Test directive"));
-            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
-            var completionItem = completionList.Items.Single();
-
-            // Act
-            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.NotNull(newCompletionItem.Documentation);
-        }
-
-        [Fact]
-        public async Task Handle_Resolve_MarkupTransitionCompletion_ReturnsCompletionItemWithDocumentation()
-        {
-            // Arrange
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
-            var razorCompletionItem = new RazorCompletionItem("@...", "@", RazorCompletionItemKind.MarkupTransition);
-            razorCompletionItem.SetMarkupTransitionCompletionDescription(new MarkupTransitionCompletionDescription("Test description"));
-            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
-            var completionItem = completionList.Items.Single();
-
-            // Act
-            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.NotNull(newCompletionItem.Documentation);
-        }
-
-        [Fact]
-        public async Task Handle_Resolve_DirectiveAttributeCompletion_ReturnsCompletionItemWithDocumentation()
-        {
-            // Arrange
-            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
-            var markdown = new MarkupContent
-            {
-                Kind = MarkupKind.Markdown,
-                Value = "Some Markdown"
-            };
-            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
-                .Returns(true);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, lspDescriptionFactory.Object, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
-            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttribute);
-            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
-            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
-            var completionItem = completionList.Items.Single();
-
-            // Act
-            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.NotNull(newCompletionItem.Documentation);
-        }
-
-        [Fact]
-        public async Task Handle_Resolve_DirectiveAttributeParameterCompletion_ReturnsCompletionItemWithDocumentation()
-        {
-            // Arrange
-            var descriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
-            var markdown = new MarkupContent
-            {
-                Kind = MarkupKind.Markdown,
-                Value = "Some Markdown"
-            };
-            descriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
-                .Returns(true);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, descriptionFactory.Object, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
-            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttributeParameter);
-            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
-            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
-            var completionItem = completionList.Items.Single();
-
-            // Act
-            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.NotNull(newCompletionItem.Documentation);
-        }
-
-        [Fact]
-        public async Task Handle_Resolve_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
-        {
-            // Arrange
-            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
-            var markdown = new MarkupContent
-            {
-                Kind = MarkupKind.Markdown,
-                Value = "Some Markdown"
-            };
-            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), out markdown))
-                .Returns(true);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, lspDescriptionFactory.Object, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
-            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
-            razorCompletionItem.SetTagHelperElementDescriptionInfo(new AggregateBoundElementDescription(Array.Empty<BoundElementDescriptionInfo>()));
-            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
-            var completionItem = completionList.Items.Single();
-
-            // Act
-            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.NotNull(newCompletionItem.Documentation);
-        }
-
-        [Fact]
-        public async Task Handle_Resolve_TagHelperElementCompletion_NullCommitCharacters()
-        {
-            // Arrange
-            var vsLSPDescriptionFactory = new Mock<VSLSPTagHelperTooltipFactory>(MockBehavior.Strict);
-            var markdown = new VSClassifiedTextElement(new VSClassifiedTextRun("type", "text"));
-            vsLSPDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), out markdown))
-                .Returns(true);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams()
-            {
-                Capabilities = new PlatformAgnosticClientCapabilities
-                {
-                    SupportsVisualStudioExtensions = true,
-                }
-            });
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, vsLSPDescriptionFactory.Object, languageServer.Object, LoggerFactory);
-            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
-            razorCompletionItem.SetTagHelperElementDescriptionInfo(new AggregateBoundElementDescription(Array.Empty<BoundElementDescriptionInfo>()));
-            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
-            var completionItem = completionList.Items.Single();
-
-            // For performance we sometimes return null commit characters, so we need to be sure they resolve safely;
-            completionItem = completionItem with { CommitCharacters = null };
-
-            // Act
-            var newCompletionItem = (VSCompletionItem)await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.NotNull(newCompletionItem.Description);
-        }
-
-        [Fact]
-        public async Task Handle_Resolve_TagHelperAttribute_ReturnsCompletionItemWithDocumentation()
-        {
-            // Arrange
-            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
-            var markdown = new MarkupContent
-            {
-                Kind = MarkupKind.Markdown,
-                Value = "Some Markdown"
-            };
-            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
-                .Returns(true);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, lspDescriptionFactory.Object, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
-            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperAttribute);
-            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
-            var completionList = completionEndpoint.CreateLSPCompletionList(new[] { razorCompletionItem });
-            var completionItem = completionList.Items.Single();
-
-            // Act
-            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.NotNull(newCompletionItem.Documentation);
-        }
-
-        [Fact]
-        public async Task Handle_Resolve_NonTagHelperCompletion_Noops()
-        {
-            // Arrange
-            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
-            var markdown = new MarkupContent
-            {
-                Kind = MarkupKind.Markdown,
-                Value = "Some Markdown"
-            };
-            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), out markdown))
-                .Returns(true);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
-            var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, EmptyDocumentResolver, CompletionFactsService, lspDescriptionFactory.Object, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
-            var completionItem = new CompletionItem();
-
-            // Act
-            var newCompletionItem = await completionEndpoint.Handle(completionItem, default);
-
-            // Assert
-            Assert.Null(newCompletionItem.Documentation);
-        }
-
         // This is more of an integration test to validate that all the pieces work together
         [Fact]
         public async Task Handle_Unsupported_NoCompletionItems()
@@ -554,10 +340,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var codeDocument = CreateCodeDocument("@");
             codeDocument.SetUnsupported();
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
             var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, documentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
+                Dispatcher, documentResolver, CompletionFactsService, CompletionListCache, LoggerFactory);
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -580,10 +364,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentPath = "C:/path/to/document.cshtml";
             var codeDocument = CreateCodeDocument("@");
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
             var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, documentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
+                Dispatcher, documentResolver, CompletionFactsService, CompletionListCache, LoggerFactory);
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -615,10 +397,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var codeDocument = CreateCodeDocument("@in");
             codeDocument.SetTagHelperContext(tagHelperContext);
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
             var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, documentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
+                Dispatcher, documentResolver, CompletionFactsService, CompletionListCache, LoggerFactory);
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -649,10 +429,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var codeDocument = CreateCodeDocument("@inje");
             codeDocument.SetTagHelperContext(tagHelperContext);
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
             var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, documentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
+                Dispatcher, documentResolver, CompletionFactsService, CompletionListCache, LoggerFactory);
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -683,10 +461,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var codeDocument = CreateCodeDocument("@inje");
             codeDocument.SetTagHelperContext(tagHelperContext);
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
             var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, documentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
+                Dispatcher, documentResolver, CompletionFactsService, CompletionListCache, LoggerFactory);
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -718,10 +494,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var codeDocument = CreateCodeDocument("<");
             codeDocument.SetTagHelperContext(tagHelperContext);
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
             var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, documentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
+                Dispatcher, documentResolver, CompletionFactsService, CompletionListCache, LoggerFactory);
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),
@@ -756,10 +530,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var codeDocument = CreateCodeDocument("<test  ");
             codeDocument.SetTagHelperContext(tagHelperContext);
             var documentResolver = CreateDocumentResolver(documentPath, codeDocument);
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
             var completionEndpoint = new RazorCompletionEndpoint(
-                Dispatcher, documentResolver, CompletionFactsService, LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, languageServer.Object, LoggerFactory);
+                Dispatcher, documentResolver, CompletionFactsService, CompletionListCache, LoggerFactory);
             var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier(new Uri(documentPath)),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
+    {
+        public RazorCompletionResolveEndpointTest()
+        {
+            LSPTagHelperTooltipFactory = Mock.Of<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            VSLSPTagHelperTooltipFactory = Mock.Of<VSLSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            CompletionListCache = new CompletionListCache();
+            CompletionCapability = new PlatformAgnosticCompletionCapability();
+            DefaultClientCapability = new PlatformAgnosticClientCapabilities();
+            VSClientCapability = new PlatformAgnosticClientCapabilities()
+            {
+                SupportsVisualStudioExtensions = true,
+            };
+        }
+
+        private LSPTagHelperTooltipFactory LSPTagHelperTooltipFactory { get; }
+
+        private VSLSPTagHelperTooltipFactory VSLSPTagHelperTooltipFactory { get; }
+
+        private CompletionListCache CompletionListCache { get; }
+
+        private CompletionCapability CompletionCapability { get; }
+
+        private PlatformAgnosticClientCapabilities DefaultClientCapability { get; }
+
+        private PlatformAgnosticClientCapabilities VSClientCapability { get; }
+
+        [Fact]
+        public async Task Handle_Resolve_DirectiveCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
+            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
+            var endpoint = new RazorCompletionResolveEndpoint(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, DefaultClientCapability);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.Directive);
+            razorCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription("Test directive"));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_MarkupTransitionCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
+            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
+            var endpoint = new RazorCompletionResolveEndpoint(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, DefaultClientCapability);
+            var razorCompletionItem = new RazorCompletionItem("@...", "@", RazorCompletionItemKind.MarkupTransition);
+            razorCompletionItem.SetMarkupTransitionCompletionDescription(new MarkupTransitionCompletionDescription("Test description"));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_DirectiveAttributeCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            var markdown = new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = "Some Markdown"
+            };
+            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
+                .Returns(true);
+            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
+            languageServer.Setup(ls => ls.ClientSettings).Returns(new InitializeParams());
+            var endpoint = new RazorCompletionResolveEndpoint(lspDescriptionFactory.Object, VSLSPTagHelperTooltipFactory, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, DefaultClientCapability);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_DirectiveAttributeParameterCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var descriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            var markdown = new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = "Some Markdown"
+            };
+            descriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
+                .Returns(true);
+            var endpoint = new RazorCompletionResolveEndpoint(descriptionFactory.Object, VSLSPTagHelperTooltipFactory, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, DefaultClientCapability);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttributeParameter);
+            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            var markdown = new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = "Some Markdown"
+            };
+            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), out markdown))
+                .Returns(true);
+            var endpoint = new RazorCompletionResolveEndpoint(lspDescriptionFactory.Object, VSLSPTagHelperTooltipFactory, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, DefaultClientCapability);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
+            razorCompletionItem.SetTagHelperElementDescriptionInfo(new AggregateBoundElementDescription(Array.Empty<BoundElementDescriptionInfo>()));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_TagHelperElementCompletion_NullCommitCharacters()
+        {
+            // Arrange
+            var vsLSPDescriptionFactory = new Mock<VSLSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            var markdown = new VSClassifiedTextElement(new VSClassifiedTextRun("type", "text"));
+            vsLSPDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), out markdown))
+                .Returns(true);
+            var endpoint = new RazorCompletionResolveEndpoint(LSPTagHelperTooltipFactory, vsLSPDescriptionFactory.Object, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, VSClientCapability);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
+            razorCompletionItem.SetTagHelperElementDescriptionInfo(new AggregateBoundElementDescription(Array.Empty<BoundElementDescriptionInfo>()));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // For performance we sometimes return null commit characters, so we need to be sure they resolve safely;
+            completionItem = completionItem with { CommitCharacters = null };
+
+            // Act
+            var newCompletionItem = (VSCompletionItem)await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Description);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_TagHelperAttribute_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            var markdown = new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = "Some Markdown"
+            };
+            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), out markdown))
+                .Returns(true);
+            var endpoint = new RazorCompletionResolveEndpoint(lspDescriptionFactory.Object, VSLSPTagHelperTooltipFactory, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, DefaultClientCapability);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single();
+
+            // Act
+            var newCompletionItem = await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.NotNull(newCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task Handle_Resolve_NonTagHelperCompletion_Noops()
+        {
+            // Arrange
+            var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict);
+            var markdown = new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = "Some Markdown"
+            };
+            lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), out markdown))
+                .Returns(true);
+            var endpoint = new RazorCompletionResolveEndpoint(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory, CompletionListCache, LoggerFactory);
+            endpoint.SetCapability(CompletionCapability, DefaultClientCapability);
+            var completionItem = new CompletionItem();
+
+            // Act
+            var newCompletionItem = await endpoint.Handle(completionItem, default);
+
+            // Assert
+            Assert.Null(newCompletionItem.Documentation);
+        }
+
+        private CompletionList CreateLSPCompletionList(IReadOnlyList<RazorCompletionItem> razorCompletionItems)
+        {
+            var completionList = RazorCompletionEndpoint.CreateLSPCompletionList(razorCompletionItems, CompletionListCache, supportedItemKinds: null, completionCapability: null);
+            return completionList;
+        }
+    }
+}


### PR DESCRIPTION
- When playing with the completion stack I felt that resolve / providing was becoming a bit unweidly and concerns were bleeding across the domain. Therefore I went ahead and split the resolve / provide endpoints apart so the logic is kept separately. This is similar to how we have code actions today as well.
- Also split tests and updated accordingly.
- Ended up needing to promote our completion list cache into a service so both endpoints could interact with the same completion list cache without relying on member state.