### PR TITLE
Fix Razor MS.Extensions.Options load failure.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
@@ -69,6 +69,13 @@ using Microsoft.VisualStudio.Shell;
     OldVersionUpperBound = "2.0.0.0",
     NewVersion = "6.0.0.0")]
 [assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.Extensions.Options",
+    GenerateCodeBase = true,
+    PublicKeyToken = "adb9793829ddae60",
+    OldVersionLowerBound = "2.0.0.0",
+    OldVersionUpperBound = "2.0.0.0",
+    NewVersion = "6.0.0.0")]
+[assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.Extensions.Configuration.Abstractions",
     GenerateCodeBase = true,
     PublicKeyToken = "adb9793829ddae60",


### PR DESCRIPTION
- In our last VS insertion I had to do manual ngen updates to ensure our binaries were ngening. I made a woopsie and added an ngen binding redirect to solve an ngen load ambiguity. This was a mistake because I also needed to add that binding redirect to our extension so at runtime the right assembly resolved. Our integration tests didn't catch this failure because WebTools also offers the same assembly so instead of barfing our world would use theirs if it couldn't find the right version and things would just work; however, once ngen'd that world expects that the correct assembly exists at the expected location.
- Fix is to add a binding redirect for MS.Extensions.Options at runtime

Fixes #6310 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1528365