### PR TITLE
Vsix deploy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,6 +199,7 @@ stages:
           condition: succeeded()
         - script: eng\cibuild.cmd
             -configuration $(_BuildConfig)
+            -msbuildEngine vs
             -prepareMachine
             -restore
             -build

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -17,7 +17,7 @@ steps:
 
   - script: eng\cibuild.cmd
       -configuration ${{ parameters.configuration }}
-      -msbuildEngine dotnet
+      -msbuildEngine vs
       -prepareMachine
       -restore
       -build
@@ -29,7 +29,7 @@ steps:
 
   - script: eng\cibuild.cmd
       -configuration ${{ parameters.configuration }}
-      -msbuildEngine dotnet
+      -msbuildEngine vs
       -prepareMachine
       /p:BuildVsix=true
       /p:BuildProjectReferences=false
@@ -39,7 +39,7 @@ steps:
 
   - script: eng\cibuild.cmd
       -configuration ${{ parameters.configuration }}
-      -msbuildEngine dotnet
+      -msbuildEngine vs
       -prepareMachine
       -integrationTest
       /p:BuildProjectReferences=false

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -93,6 +93,8 @@ Welcome to your new app.
             // We open the Index.razor file, and wait for 3 RazorComponentElement's to be classified, as that
             // way we know the LSP server is up, running, and has processed both local and library-sourced Components
             await TestServices.SolutionExplorer.AddFileAsync(BlazorProjectName, ModifiedIndexRazorFile, IndexPageContent, open: true, HangMitigatingCancellationToken);
+
+            EnsureExtensionInstalled();
             try
             {
                 await TestServices.Editor.WaitForClassificationAsync(HangMitigatingCancellationToken, expectedClassification: RazorComponentElementClassification, count: 3);
@@ -189,6 +191,19 @@ Welcome to your new app.
                     // Wait a bit
                     Thread.Sleep(100);
                 }
+            }
+        }
+
+        private static void EnsureExtensionInstalled()
+        {
+            var assembly = Assembly.Load(new AssemblyName("Microsoft.VisualStudio.RazorExtension"));
+            var version = assembly.GetName().Version;
+
+            var localAppData = Environment.GetEnvironmentVariable("LocalAppData");
+
+            if (!version.Equals(new Version(42, 42, 42, 42)) || !assembly.Location.StartsWith(localAppData, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new NotImplementedException("Integration test not running against Experimental Extension");
             }
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
@@ -1,0 +1,5 @@
+# Razor Tooling Visual Studio Integration tests
+
+## Running
+
+If you run the integration tests from the command line using something like "dotnet test" they may fail because the Extension was now deployed. To ensure the extension was deployed you can either launch tests through Visual Studio or first run a command like `eng\cibuild.cmd -configuration Debug -msbuildEngine vs -prepareMachine /p:BuildVsix=true`


### PR DESCRIPTION
### Summary of the changes

- We want our integration tests to fail if we're not running against the experimental instance we've just built. It's surprisingly difficult to tell this, but we can at least ensure that the proper Extension has been deployed (to the LocalAppData directory).
- This WON'T protect us from using an OLD experimental instance, we only know that we're using AN experimental instance. This means we need to worry about:
  - Dev-box pollution. This mostly shouldn't be a problem since most devs run Integration tests from VS (which seems to always deploy) or not at all.
  - Test machine pollution. Basically as above but for test machines.