### PR TITLE
Fix VS deadlock on shutdown.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
@@ -73,6 +73,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public void SubjectBuffersDisconnected(ITextView textView, ConnectionReason reason, IReadOnlyCollection<ITextBuffer> subjectBuffers)
         {
+            _ = SubjectBuffersDisconnectedAsync(textView, subjectBuffers);
+        }
+
+        public async Task SubjectBuffersDisconnectedAsync(ITextView textView, IReadOnlyCollection<ITextBuffer> subjectBuffers)
+        {
             try
             {
                 if (textView is null)
@@ -85,10 +90,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     throw new ArgumentNullException(nameof(subjectBuffers));
                 }
 
-                _joinableTaskContext.Factory.Run(async () => {
-                    _joinableTaskContext.AssertUIThread();
-                    await _documentManager.OnTextViewClosedAsync(textView, subjectBuffers);
-                });
+                _joinableTaskContext.AssertUIThread();
+
+                await _documentManager.OnTextViewClosedAsync(textView, subjectBuffers);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- This is a contained fix to address a deadlock plagueing RPS tests on VS shutdown (it'd hang). See the associated issue for context.
- This is a partial revert of https://github.com/dotnet/razor-tooling/commit/cb467896550c867281e87a75c35b9313006ec77b


Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1529381