### PR TITLE
Disable integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,7 @@ stages:
             -prepareMachine
             -test
             # -integrationTest
-            /p:BuildProjectReferences=false
+            # /p:BuildProjectReferences=false
           name: Run_Tests
           displayName: Run Unit and Integration tests
           condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,19 +216,20 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             -test
+            # -integrationTest
             /p:BuildProjectReferences=false
           name: Run_Tests
           displayName: Run Unit and Integration tests
           condition: succeeded()
-        - task: PublishBuildArtifacts@1
-          displayName: Update Integration Tests Data
-          condition: always()
-          continueOnError: true
-          inputs:
-            pathtoPublish: artifacts/log/$(_BuildConfig)/Screenshots/
-            artifactName: $(Agent.Os)_$(Agent.JobName) IntegrationTestsData $(_BuildConfig)
-            artifactType: Container
-            parallel: true
+        # - task: PublishBuildArtifacts@1
+        #   displayName: Update Integration Tests Data
+        #   condition: always()
+        #   continueOnError: true
+        #   inputs:
+        #     pathtoPublish: artifacts/log/$(_BuildConfig)/Screenshots/
+        #     artifactName: $(Agent.Os)_$(Agent.JobName) IntegrationTestsData $(_BuildConfig)
+        #     artifactType: Container
+        #     parallel: true
         # Run VSCode functional tests
         # - powershell: |
         #     . ../../../../activate.ps1
@@ -250,14 +251,14 @@ stages:
           workingDirectory: $(Build.SourcesDirectory)/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension
           failOnStderr: true
           condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'))
-        - task: PublishTestResults@2
-          displayName: Publish Integration Test Results
-          condition: always()
-          continueOnError: true
-          inputs:
-            testResultsFormat: 'VSTest'
-            testResultsFiles: '*.trx'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        # - task: PublishTestResults@2
+        #   displayName: Publish Integration Test Results
+        #   condition: always()
+        #   continueOnError: true
+        #   inputs:
+        #     testResultsFormat: 'VSTest'
+        #     testResultsFiles: '*.trx'
+        #     searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
         - task: PublishBuildArtifacts@1
           displayName: Upload Test Results
           condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,7 +216,6 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             -test
-            -integrationTest
             /p:BuildProjectReferences=false
           name: Run_Tests
           displayName: Run Unit and Integration tests


### PR DESCRIPTION
https://github.com/dotnet/razor-tooling/pull/6298 upgrades the version of Roslyn and other packages. Unfortunately the integration tests run against the latest preview, so the changes from the upgraded packages aren't in the integration machines yet. We should temporarily disable the integration tests until the next preview image is released. @ryanbrandenburg is also planning on investigating what a longer-term solution looks like.