### PR TITLE
Use VS Protocol types for VS capability extensions.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/Microsoft.AspNetCore.Razor.LanguageServer.Protocol.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/Microsoft.AspNetCore.Razor.LanguageServer.Protocol.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Need this reference to avoid 'The C# language is not supported' error during formatting. -->
-    <PackageReference Include="OmniSharp.Extensions.LanguageProtocol" Version="$(OmniSharpExtensionsLanguageProtocolPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="$(MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
@@ -58,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             _onAutoInsertTriggerCharacters = _onAutoInsertProviders.Select(provider => provider.TriggerCharacter).ToList();
         }
 
-        public RegistrationExtensionResult GetRegistration()
+        public RegistrationExtensionResult GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
             const string AssociatedServerCapability = "_vs_onAutoInsertProvider";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/ClientCapabilitiesExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/ClientCapabilitiesExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using OmniSharpClientCapabilities = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.ClientCapabilities;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
+{
+    internal static class ClientCapabilitiesExtensions
+    {
+        public static VSInternalClientCapabilities ToVSClientCapabilities(this OmniSharpClientCapabilities omniSharpClientCapabilities, LspSerializer serializer)
+        {
+            var serializedOmniSharpClientCapabilities = serializer.SerializeObject(omniSharpClientCapabilities);
+            var vsClientCapabilities = serializer.DeserializeObject<VSInternalClientCapabilities>(serializedOmniSharpClientCapabilities);
+            return vsClientCapabilities;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRegistrationExtension.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRegistrationExtension.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal interface IRegistrationExtension
     {
-        RegistrationExtensionResult GetRegistration();
+        RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
@@ -19,7 +19,9 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using InsertTextFormat = OmniSharp.Extensions.LanguageServer.Protocol.Models.InsertTextFormat;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
@@ -84,7 +86,7 @@ internal class InlineCompletionEndpoint : IInlineCompletionHandler
         _logger = loggerFactory.CreateLogger<InlineCompletionEndpoint>();
     }
 
-    public RegistrationExtensionResult GetRegistration()
+    public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
     {
         const string AssociatedServerCapability = "_vs_inlineCompletionOptions";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
 using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Folding;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hover;
@@ -72,6 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             var serializer = new LspSerializer();
             serializer.RegisterRazorConverters();
+            serializer.RegisterVSInternalExtensionConverters();
 
             ILanguageServer server = null;
             var logLevel = RazorLSPOptions.GetLogLevelForTrace(trace);
@@ -98,10 +100,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         var handlersManager = s.GetRequiredService<IHandlersManager>();
                         var jsonRpcHandlers = handlersManager.Descriptors.Select(d => d.Handler);
                         var registrationExtensions = jsonRpcHandlers.OfType<IRegistrationExtension>().Distinct();
+                        var vsCapabilities = s.ClientSettings.Capabilities.ToVSClientCapabilities(serializer);
                         foreach (var registrationExtension in registrationExtensions)
                         {
-                            var optionsResult = registrationExtension.GetRegistration();
-                            response.Capabilities.ExtensionData[optionsResult.ServerCapability] = JObject.FromObject(optionsResult.Options);
+                            var optionsResult = registrationExtension.GetRegistration(vsCapabilities);
+                            if (optionsResult != null)
+                            {
+                                response.Capabilities.ExtensionData[optionsResult.ServerCapability] = JObject.FromObject(optionsResult.Options);
+                            }
                         }
 
                         RazorLanguageServerCapability.AddTo(response.Capabilities);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/LspSerializerExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/LspSerializerExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
@@ -35,12 +36,36 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization
             AddConverter(serializer, OmniSharpVSCompletionContext.JsonConverter);
             AddConverter(serializer, OmniSharpVSDiagnostic.JsonConverter);
             AddConverter(serializer, OmniSharpVSCodeActionContext.JsonConverter);
+        }
 
-            static void AddConverter(LspSerializer serializer, JsonConverter converter)
+        public static void RegisterVSInternalExtensionConverters(this LspSerializer serializer)
+        {
+            if (serializer is null)
             {
-                serializer.Settings.Converters.Add(converter);
-                serializer.JsonSerializer.Converters.Add(converter);
+                throw new ArgumentNullException(nameof(serializer));
             }
+
+            // In all of the below we add our converters to both the serializer settings and the actual
+            // JsonSerializer. The reasoning behind this choice is that OmniSharp framework is not consistent
+            // in using one over the other so we want to protect ourselves.
+
+            // We create a temporary serializer because the VS API's only have extension methods for adding converters to the top-level serializer type; therefore,
+            // we effectively create a bag that the VS APIs can add to and then extract the added converters to add to the LSP serializer.
+            var tempSerializer = new JsonSerializer();
+            tempSerializer.Converters.Clear();
+            tempSerializer.AddVSInternalExtensionConverters();
+
+            var converters = tempSerializer.Converters;
+            for (var i = 0; i < converters.Count; i++)
+            {
+                AddConverter(serializer, converters[i]);
+            }
+        }
+
+        private static void AddConverter(LspSerializer serializer, JsonConverter converter)
+        {
+            serializer.Settings.Converters.Add(converter);
+            serializer.JsonSerializer.Converters.Add(converter);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Extensions/ClientCapabilitiesExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Extensions/ClientCapabilitiesExtensionsTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using Xunit;
+using OmniSharpClientCapabilities = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.ClientCapabilities;
+using OmniSharpCompletionCapability = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.CompletionCapability;
+using OmniSharpCompletionSupport = OmniSharp.Extensions.LanguageServer.Protocol.Supports<OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.CompletionCapability?>;
+using OmniSharpTextDocumentClientCapability = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.TextDocumentClientCapabilities;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
+{
+    public class ClientCapabilitiesExtensionsTest
+    {
+        [Fact]
+        public void ToVSClientCapabilities_WorksAsExpected()
+        {
+            // Arrange
+            var experimentalCapability = new Dictionary<string, JToken>()
+            {
+                ["test"] = "Hello World"
+            };
+            var omniSharpCapabilities = new OmniSharpClientCapabilities()
+            {
+                Experimental = experimentalCapability,
+                TextDocument = new OmniSharpTextDocumentClientCapability()
+                {
+                    Completion = new OmniSharpCompletionSupport(
+                        new OmniSharpCompletionCapability()
+                        {
+                            ContextSupport = true,
+                        }),
+                }
+            };
+            var serializer = new LspSerializer();
+            serializer.RegisterVSInternalExtensionConverters();
+
+            // Act
+            var vsCapabilities = omniSharpCapabilities.ToVSClientCapabilities(serializer);
+
+            // Assert
+            Assert.NotNull(vsCapabilities.Experimental);
+            var actualExperimental = JObject.FromObject(vsCapabilities.Experimental!);
+            var expectedExperimental = JObject.FromObject(experimentalCapability);
+
+            Assert.Equal(expectedExperimental, actualExperimental);
+            Assert.NotNull(vsCapabilities.TextDocument);
+            Assert.True(vsCapabilities.TextDocument?.Completion?.ContextSupport);
+        }
+    }
+}


### PR DESCRIPTION
- Today we have the `IRegistrationExtension` concept which is used to extend Razor's server capabilities to communicate with VS on what "extra" capabilities are enabled. Examples of this are OnAutoInsert and VS' InlineCompletion for snippets. As we're moving more towards consuming VS' protocol types directly it naturally makes sense to flow VS' client capabilities into these extensions so they can make decisions utilizing VS' types which are a superset of proper LSP.
- Changed the `Microsoft.AspnetCore.Razor.LanguageServer.Protocol` package to utilize VS' protocol types and not O#'s. This is a big move because it means all of our "shared" implementation types wont leak O# into the client but then also requires the server to have moved to VS protocol types.
- Added VS internal serializers to the LSP serializer collection. In the end this was harder than I initially thought because the LSP platform APIs don't have a way to add to a list of converters, they only have a way to add to a serializer; unfortunately O# has two sets of converters it looks at so I had to do some hacks to work around this.
- Now that we're passing VS' capabilities into registration extensions I changed the way we consumed the result of a `GetRegistration` call and if it happens to be `null` we now no-op to not add junk to our server capability collection.
- Added tests to validate that we convert capabilities correctly.

Fixes #6332