### PR TITLE
Set Roslyn's global line formatting options

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -76,7 +76,7 @@
     <Tooling_MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.21103.2</Tooling_MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.2.32330.158</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.3.37-preview</MicrosoftVisualStudioPackagesVersion>
-    <RoslynPackageVersion>4.3.0-1.22222.8</RoslynPackageVersion>
+    <RoslynPackageVersion>4.3.0-2.22259.8</RoslynPackageVersion>
     <VisualStudioLanguageServerProtocolVersion>17.3.15</VisualStudioLanguageServerProtocolVersion>
     <MicrosoftNetCompilersToolsetVersion>4.2.0-1.final</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultEditorSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultEditorSettingsManager.cs
@@ -28,6 +28,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             _settings = EditorSettings.Default;
 
+            // update Roslyn's global options (null in tests):
+            if (globalOptions != null)
+            {
+                globalOptions.TabSize = _settings.IndentSize;
+                globalOptions.UseTabs = _settings.IndentWithTabs;
+            }
+
             foreach (var changeTrigger in editorSettingsChangeTriggers)
             {
                 changeTrigger.Initialize(this);

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultEditorSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultEditorSettingsManagerTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Razor.Editor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Editor.Razor


### PR DESCRIPTION
When editor settings (use tabs, tab size) change store the updated values to Roslyn's global options.

This will allow us to remove `IRazorDocumentOptionsService` in future.
Requires https://github.com/dotnet/roslyn/pull/61054
