### PR TITLE
Remove leftover semantic tokens isFinalized references

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensResponse.cs
@@ -11,24 +11,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
     /// </summary>
     internal class ProvideSemanticTokensResponse
     {
-        public ProvideSemanticTokensResponse(int[]? tokens, bool isFinalized, long? hostDocumentSyncVersion)
+        public ProvideSemanticTokensResponse(int[]? tokens, long? hostDocumentSyncVersion)
         {
             Tokens = tokens;
-            IsFinalized = isFinalized;
             HostDocumentSyncVersion = hostDocumentSyncVersion;
         }
 
         public int[]? Tokens { get; }
 
-        public bool IsFinalized { get; }
-
         public long? HostDocumentSyncVersion { get; }
 
         public override bool Equals(object obj)
         {
-            if (obj is not ProvideSemanticTokensResponse other ||
-                other.IsFinalized != IsFinalized ||
-                other.HostDocumentSyncVersion != HostDocumentSyncVersion)
+            if (obj is not ProvideSemanticTokensResponse other || other.HostDocumentSyncVersion != HostDocumentSyncVersion)
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -435,8 +435,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 // If we're unable to synchronize we won't produce useful results, but we have to indicate
                 // it's due to out of sync by providing the old version
-                return new ProvideSemanticTokensResponse(
-                    tokens: null, isFinalized: false, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
+                return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
             }
 
             var csharpTextDocument = semanticTokensParams.TextDocument with { Uri = csharpDoc.Uri };
@@ -461,12 +460,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             if (result is null)
             {
                 // Weren't able to re-invoke C# semantic tokens but we have to indicate it's due to out of sync by providing the old version
-                return new ProvideSemanticTokensResponse(
-                    tokens: null, isFinalized: false, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
+                return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
             }
 
-            var response = new ProvideSemanticTokensResponse(
-                result.Data, result.IsFinalized, semanticTokensParams.RequiredHostDocumentVersion);
+            var response = new ProvideSemanticTokensResponse(result.Data, semanticTokensParams.RequiredHostDocumentVersion);
 
             return response;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -41,8 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 End = new OSharp.Position { Line = 3, Character = 0 }
             };
 
-            var csharpTokens = new ProvideSemanticTokensResponse(
-                tokens: Array.Empty<int>(), isFinalized: false, hostDocumentSyncVersion: 1);
+            var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: 1);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 1);
         }
 
@@ -95,8 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 End = new OSharp.Position { Line = 2, Character = 0 }
             };
 
-            var csharpTokens = new ProvideSemanticTokensResponse(
-                tokens: Array.Empty<int>(), isFinalized: true, hostDocumentSyncVersion: null);
+            var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: null);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 1);
         }
 
@@ -782,7 +780,7 @@ things *@
 
             if (csharpTokens is null)
             {
-                csharpTokens = new ProvideSemanticTokensResponse(tokens: null, isFinalized: true, documentVersion);
+                csharpTokens = new ProvideSemanticTokensResponse(tokens: null, documentVersion);
             }
 
             var (documentSnapshots, textDocumentIdentifiers) = CreateDocumentSnapshot(documentTexts, isRazorArray, DefaultTagHelpers);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokenTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokenTestBase.cs
@@ -117,7 +117,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             var codeDocument = CreateCodeDocument(documentText, isRazorFile, DefaultTagHelpers);
             var csharpRange = GetMappedCSharpRange(codeDocument, razorRange);
             var csharpTokens = Array.Empty<int>();
-            var isFinalized = true;
 
             if (csharpRange is not null)
             {
@@ -135,11 +134,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                     CreateVSSemanticTokensRangeParams(csharpRange.AsVSRange(), documentUri), CancellationToken.None);
 
                 csharpTokens = result?.Data;
-                isFinalized = result?.IsFinalized ?? false;
             }
 
-            var csharpResponse = new ProvideSemanticTokensResponse(
-                tokens: csharpTokens, isFinalized, hostDocumentSyncVersion);
+            var csharpResponse = new ProvideSemanticTokensResponse(tokens: csharpTokens, hostDocumentSyncVersion);
             return csharpResponse;
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -470,8 +470,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 },
                 requiredHostDocumentVersion: 0,
                 range: new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range());
-            var expectedResults = new ProvideSemanticTokensResponse(
-                expectedcSharpResults.Data, expectedcSharpResults.IsFinalized, documentVersion);
+            var expectedResults = new ProvideSemanticTokensResponse(expectedcSharpResults.Data, documentVersion);
 
             // Act
             var result = await target.ProvideSemanticTokensRangeAsync(request, CancellationToken.None);


### PR DESCRIPTION
### Summary of the changes
- Should have been removed as part of https://github.com/dotnet/razor-tooling/pull/6298, but found some leftover references while working in the repo. Since both Razor + Roslyn have implemented semanticTokens/refresh, isFinalized is no longer necessary since C# will notify us automatically when their semantic model is finalized.