### PR TITLE
Add VS "like" commit characters to Razor's completion item.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -34,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                         // In practice this happens in the `<button |` scenario where the "space" results in completions
                         // where this directive attribute transition character ("@...") gets provided and then typing
                         // `@` should re-trigger OR typing `/` should re-trigger.
-                        commitCharacters: new[] { "@", "/", ">" });
+                        commitCharacters: new[] { "@", "/", ">" }.Select(c => new RazorCommitCharacter(c)).ToArray());
                     s_transitionCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription(RazorLS.Resources.Blazor_directive_attributes));
                 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -35,7 +34,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                         // In practice this happens in the `<button |` scenario where the "space" results in completions
                         // where this directive attribute transition character ("@...") gets provided and then typing
                         // `@` should re-trigger OR typing `/` should re-trigger.
-                        commitCharacters: new[] { "@", "/", ">" }.Select(c => new RazorCommitCharacter(c)).ToArray());
+                        commitCharacters: RazorCommitCharacter.FromArray(new[] { "@", "/", ">" }));
                     s_transitionCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription(RazorLS.Resources.Blazor_directive_attributes));
                 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -139,7 +139,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 CompletionTriggerKind.TriggerCharacter => CompletionReason.Typing,
                 _ => CompletionReason.Typing,
             };
-            var completionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext, reason);
+            var completionOptions = new RazorCompletionOptions(SnippetsSupported: true);
+            var completionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext, reason, completionOptions);
 
             var razorCompletionItems = _completionFactsService.GetCompletionItems(completionContext, location);
 
@@ -229,6 +230,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 tagHelperCompletionItemKind = (CompletionItemKind)ExtendedCompletionItemKinds.TagHelper;
             }
 
+            var razorCommitCharacters = razorCompletionItem.CommitCharacters?.Select(c => c.Character)?.ToArray() ?? Array.Empty<string>();
             switch (razorCompletionItem.Kind)
             {
                 case RazorCompletionItemKind.Directive:
@@ -242,9 +244,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Kind = CompletionItemKind.Struct,
                         };
 
-                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        if (razorCommitCharacters.Length > 0)
                         {
-                            directiveCompletionItem = directiveCompletionItem with { CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters) };
+                            directiveCompletionItem = directiveCompletionItem with { CommitCharacters = razorCommitCharacters };
                         }
 
                         if (razorCompletionItem == DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem)
@@ -270,9 +272,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Kind = tagHelperCompletionItemKind,
                         };
 
-                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        if (razorCommitCharacters.Length > 0)
                         {
-                            directiveAttributeCompletionItem = directiveAttributeCompletionItem with { CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters) };
+                            directiveAttributeCompletionItem = directiveAttributeCompletionItem with { CommitCharacters = razorCommitCharacters };
                         }
 
                         completionItem = directiveAttributeCompletionItem;
@@ -303,9 +305,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Kind = tagHelperCompletionItemKind,
                         };
 
-                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        if (razorCommitCharacters.Length > 0)
                         {
-                            markupTransitionCompletionItem = markupTransitionCompletionItem with { CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters) };
+                            markupTransitionCompletionItem = markupTransitionCompletionItem with { CommitCharacters = razorCommitCharacters };
                         }
 
                         completionItem = markupTransitionCompletionItem;
@@ -322,9 +324,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Kind = tagHelperCompletionItemKind,
                         };
 
-                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        if (razorCommitCharacters.Length > 0)
                         {
-                            tagHelperElementCompletionItem = tagHelperElementCompletionItem with { CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters) };
+                            tagHelperElementCompletionItem = tagHelperElementCompletionItem with { CommitCharacters = razorCommitCharacters };
                         }
 
                         completionItem = tagHelperElementCompletionItem;
@@ -343,9 +345,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             Kind = tagHelperCompletionItemKind,
                         };
 
-                        if (razorCompletionItem.CommitCharacters != null && razorCompletionItem.CommitCharacters.Count > 0)
+                        if (razorCommitCharacters.Length > 0)
                         {
-                            tagHelperAttributeCompletionItem = tagHelperAttributeCompletionItem with { CommitCharacters = new Container<string>(razorCompletionItem.CommitCharacters) };
+                            tagHelperAttributeCompletionItem = tagHelperAttributeCompletionItem with { CommitCharacters = razorCommitCharacters };
                         }
 
                         completionItem = tagHelperAttributeCompletionItem;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             }
 
             // We might strip out the commitcharacters for speed, bring them back
-            var container = associatedRazorCompletion.CommitCharacters != null ? new Container<string>(associatedRazorCompletion.CommitCharacters) : null;
+            var container = associatedRazorCompletion.CommitCharacters != null ? new Container<string>(associatedRazorCompletion.CommitCharacters.Select(c => c.Character).ToArray()) : null;
             completionItem = completionItem with { CommitCharacters = container };
             var vsCompletionItem = completionItem.ToVSCompletionItem(_completionCapability?.VSCompletionList);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
@@ -18,11 +17,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
     internal class TagHelperCompletionProvider : RazorCompletionItemProvider
     {
         // Internal for testing
-        internal static readonly IReadOnlyList<RazorCommitCharacter> MinimizedAttributeCommitCharacters = new[] { "=", " " }.Select(c => new RazorCommitCharacter(c)).ToArray();
-        internal static readonly IReadOnlyList<RazorCommitCharacter> AttributeCommitCharacters = new[] { "=" }.Select(c => new RazorCommitCharacter(c)).ToArray();
-        internal static readonly IReadOnlyList<RazorCommitCharacter> AttributeSnippetCommitCharacters = new[] { "=" }.Select(c => new RazorCommitCharacter(c, Insert: false)).ToArray();
+        internal static readonly IReadOnlyList<RazorCommitCharacter> MinimizedAttributeCommitCharacters = RazorCommitCharacter.FromArray(new[] { "=", " " });
+        internal static readonly IReadOnlyList<RazorCommitCharacter> AttributeCommitCharacters = RazorCommitCharacter.FromArray(new[] { "=" });
+        internal static readonly IReadOnlyList<RazorCommitCharacter> AttributeSnippetCommitCharacters = RazorCommitCharacter.FromArray(new[] { "=" }, insert: false);
 
-        private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters = new[] { " ", ">" }.Select(c => new RazorCommitCharacter(c)).ToArray();
+        private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters = RazorCommitCharacter.FromArray(new[] { " ", ">" });
         private static readonly IReadOnlyList<RazorCommitCharacter> s_noCommitCharacters = Array.Empty<RazorCommitCharacter>();
         private readonly HtmlFactsService _htmlFactsService;
         private readonly TagHelperCompletionService _tagHelperCompletionService;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -163,12 +163,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 }
 
                 var (attributeDescriptionInfos, commitCharacters) = completion.Value;
+                var razorCommitCharacters = commitCharacters.Select(static c => new RazorCommitCharacter(c)).ToList();
 
                 var razorCompletionItem = new RazorCompletionItem(
                     completion.Key,
                     insertText,
                     RazorCompletionItemKind.DirectiveAttribute,
-                    commitCharacters: commitCharacters);
+                    commitCharacters: razorCommitCharacters);
                 var completionDescription = new AggregateBoundAttributeDescription(attributeDescriptionInfos.ToArray());
                 razorCompletionItem.SetAttributeCompletionDescription(completionDescription);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     [Export(typeof(RazorCompletionItemProvider))]
     internal class DirectiveCompletionItemProvider : RazorCompletionItemProvider
     {
-        internal static readonly IReadOnlyList<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = new string[] { " " }.Select(c => new RazorCommitCharacter(c)).ToArray();
-        internal static readonly IReadOnlyList<RazorCommitCharacter> BlockDirectiveCommitCharacters = new string[] { " ", "{" }.Select(c => new RazorCommitCharacter(c)).ToArray();
+        internal static readonly IReadOnlyList<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = RazorCommitCharacter.FromArray(new[] { " " });
+        internal static readonly IReadOnlyList<RazorCommitCharacter> BlockDirectiveCommitCharacters = RazorCommitCharacter.FromArray(new[] { " ", "{" });
 
         private static readonly IEnumerable<DirectiveDescriptor> s_defaultDirectives = new[]
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     [Export(typeof(RazorCompletionItemProvider))]
     internal class DirectiveCompletionItemProvider : RazorCompletionItemProvider
     {
-        internal static readonly IReadOnlyCollection<string> SingleLineDirectiveCommitCharacters = new string[] { " " };
-        internal static readonly IReadOnlyCollection<string> BlockDirectiveCommitCharacters = new string[] { " ", "{" };
+        internal static readonly IReadOnlyList<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = new string[] { " " }.Select(c => new RazorCommitCharacter(c)).ToArray();
+        internal static readonly IReadOnlyList<RazorCommitCharacter> BlockDirectiveCommitCharacters = new string[] { " ", "{" }.Select(c => new RazorCommitCharacter(c)).ToArray();
 
         private static readonly IEnumerable<DirectiveDescriptor> s_defaultDirectives = new[]
         {
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             return completionItems;
         }
 
-        private static IReadOnlyCollection<string> GetDirectiveCommitCharacters(DirectiveKind directiveKind)
+        private static IReadOnlyList<RazorCommitCharacter> GetDirectiveCommitCharacters(DirectiveKind directiveKind)
         {
             return directiveKind switch
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -16,10 +16,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     internal class MarkupTransitionCompletionItemProvider : RazorCompletionItemProvider
     {
-        private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters = new[]
-        {
-            new RazorCommitCharacter(">"),
-        };
+        private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters = RazorCommitCharacter.FromArray(new[] { ">" });
 
         private readonly HtmlFactsService _htmlFactsService;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -16,7 +16,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     internal class MarkupTransitionCompletionItemProvider : RazorCompletionItemProvider
     {
-        private static readonly IReadOnlyCollection<string> s_elementCommitCharacters = new HashSet<string>{ ">" };
+        private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters = new[]
+        {
+            new RazorCommitCharacter(">"),
+        };
 
         private readonly HtmlFactsService _htmlFactsService;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCommitCharacter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCommitCharacter.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal sealed record RazorCommitCharacter(string Character, bool Insert = true);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCommitCharacter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCommitCharacter.cs
@@ -1,7 +1,24 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
-    internal sealed record RazorCommitCharacter(string Character, bool Insert = true);
+    internal sealed record RazorCommitCharacter(string Character, bool Insert = true)
+    {
+        public static IReadOnlyList<RazorCommitCharacter> FromArray(IReadOnlyList<string> characters) => FromArray(characters, insert: true);
+
+        public static IReadOnlyList<RazorCommitCharacter> FromArray(IReadOnlyList<string> characters, bool insert)
+        {
+            var converted = new RazorCommitCharacter[characters.Count];
+
+            for (var i = 0; i < characters.Count; i++)
+            {
+                converted[i] = new RazorCommitCharacter(characters[i], insert);
+            }
+
+            return converted;
+        }
+    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionContext.cs
@@ -6,7 +6,10 @@ using Microsoft.AspNetCore.Razor.Language;
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     internal record RazorCompletionContext(
-            RazorSyntaxTree SyntaxTree,
-            TagHelperDocumentContext TagHelperDocumentContext,
-            CompletionReason Reason = CompletionReason.Invoked);
+        RazorSyntaxTree SyntaxTree,
+        TagHelperDocumentContext TagHelperDocumentContext,
+        CompletionReason Reason = CompletionReason.Invoked,
+        RazorCompletionOptions Options = default)
+    {
+    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             string insertText,
             RazorCompletionItemKind kind,
             string sortText = null,
-            IReadOnlyCollection<string> commitCharacters = null)
+            IReadOnlyList<RazorCommitCharacter> commitCharacters = null)
         {
             if (displayText is null)
             {
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
         public RazorCompletionItemKind Kind { get; }
 
-        public IReadOnlyCollection<string> CommitCharacters { get; }
+        public IReadOnlyCollection<RazorCommitCharacter> CommitCharacters { get; }
 
         public ItemCollection Items
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Razor.Completion
+{
+    internal record struct RazorCompletionOptions(bool SnippetsSupported);
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void TryConvert_DirectiveAttribute_ReturnsTrue()
         {
             // Arrange
-            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: new[] { "=", ":" }.Select(c => new RazorCommitCharacter(c)).ToArray());
+            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: RazorCommitCharacter.FromArray(new[] { "=", ":" }));
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, _supportedCompletionItemKinds, out var converted);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.DisplayText, converted.SortText);
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
-            Assert.Equal(converted.CommitCharacters, completionItem.CommitCharacters);
+            Assert.Equal(converted.CommitCharacters, completionItem.CommitCharacters.Select(c => c.Character));
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void TryConvert_DirectiveAttribute_ReturnsTrue()
         {
             // Arrange
-            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: new[] { "=", ":" });
+            var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: new[] { "=", ":" }.Select(c => new RazorCommitCharacter(c)).ToArray());
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, _supportedCompletionItemKinds, out var converted);
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.InsertText, converted.InsertText);
             Assert.Equal(completionItem.InsertText, converted.FilterText);
             Assert.Equal(completionItem.DisplayText, converted.SortText);
-            Assert.Equal(completionItem.CommitCharacters, converted.CommitCharacters);
+            Assert.Equal(completionItem.CommitCharacters.Select(c => c.Character), converted.CommitCharacters);
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -321,7 +321,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Contains(completions, completion =>
                 insertText == completion.InsertText &&
                 displayText == completion.DisplayText &&
-                commitCharacters.SequenceEqual(completion.CommitCharacters) &&
+                commitCharacters.SequenceEqual(completion.CommitCharacters.Select(c => c.Character)) &&
                 RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
         }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             return new RazorCompletionContext(syntaxTree, tagHelperDocumentContext, reason);
         }
 
-        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item, IReadOnlyCollection<string> commitCharacters = null)
+        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item, IReadOnlyList<RazorCommitCharacter> commitCharacters = null)
         {
             Assert.Equal(item.DisplayText, completionDisplayText);
             Assert.Equal(item.InsertText, directive.Directive);


### PR DESCRIPTION
- The new `RazorCommitCharacter` construct allows us to specify whether or not to insert the commit character on insert. Unfortunately this PR doesn't go alllll the way and remove the hacked code to inject VS commit characters onto our O# completion items yet (that's coming).
- Updated call sites to take in the new Razor commit character construct
- Added a new `RazorCompletionOptions` record struct that can indicate when snippest are supported. In all relevant scenarios they are; however, in the legacy editor they're not so we need an option to know if we should use snippet based commit characters or non-snippet based commit characters.
- Updated tests

Fixes #6339