### PR TITLE
Add "IsSnippet" understanding to Razor completion item.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -231,6 +231,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             }
 
             var razorCommitCharacters = razorCompletionItem.CommitCharacters?.Select(c => c.Character)?.ToArray() ?? Array.Empty<string>();
+            var insertTextFormat = razorCompletionItem.IsSnippet ? InsertTextFormat.Snippet : InsertTextFormat.PlainText;
+
             switch (razorCompletionItem.Kind)
             {
                 case RazorCompletionItemKind.Directive:
@@ -241,6 +243,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.DisplayText,
                             SortText = razorCompletionItem.SortText,
+                            InsertTextFormat = insertTextFormat,
                             Kind = CompletionItemKind.Struct,
                         };
 
@@ -269,6 +272,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.InsertText,
                             SortText = razorCompletionItem.SortText,
+                            InsertTextFormat = insertTextFormat,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -288,6 +292,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.InsertText,
                             SortText = razorCompletionItem.SortText,
+                            InsertTextFormat = insertTextFormat,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -302,6 +307,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                             InsertText = razorCompletionItem.InsertText,
                             FilterText = razorCompletionItem.DisplayText,
                             SortText = razorCompletionItem.SortText,
+                            InsertTextFormat = insertTextFormat,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -319,8 +325,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                         {
                             Label = razorCompletionItem.DisplayText,
                             InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.InsertText,
+                            FilterText = razorCompletionItem.DisplayText,
                             SortText = razorCompletionItem.SortText,
+                            InsertTextFormat = insertTextFormat,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -334,14 +341,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     }
                 case RazorCompletionItemKind.TagHelperAttribute:
                     {
-                        var isSnippet = IsInsertTextSnippet(razorCompletionItem, out var snippetInsertText);
                         var tagHelperAttributeCompletionItem = new CompletionItem()
                         {
                             Label = razorCompletionItem.DisplayText,
-                            InsertText = snippetInsertText,
-                            FilterText = razorCompletionItem.InsertText,
+                            InsertText = razorCompletionItem.InsertText,
+                            FilterText = razorCompletionItem.DisplayText,
                             SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = isSnippet ? InsertTextFormat.Snippet : InsertTextFormat.PlainText,
+                            InsertTextFormat = insertTextFormat,
                             Kind = tagHelperCompletionItemKind,
                         };
 
@@ -357,22 +363,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             completionItem = null;
             return false;
-
-            static bool IsInsertTextSnippet(RazorCompletionItem razorCompletionItem, out string insertText)
-            {
-                var attributeCompletionTypes = razorCompletionItem.GetAttributeCompletionTypes();
-                // If the attribute is a boolean than just its name is a legal response. Therefor don't do the snippet
-                if (attributeCompletionTypes.Any(type => string.Equals(type, typeof(bool).ToString(), StringComparison.Ordinal)))
-                {
-                    insertText = razorCompletionItem.InsertText;
-                    return false;
-                }
-                else
-                {
-                    insertText = $"{razorCompletionItem.InsertText}=\"$0\"";
-                    return true;
-                }
-            }
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -24,12 +24,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         /// <param name="sortText">A string that is used to alphabetically sort the completion item. If omitted defaults to <paramref name="displayText"/>.</param>
         /// <param name="commitCharacters">Characters that can be used to commit the completion item.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="displayText"/> or <paramref name="insertText"/> are <c>null</c>.</exception>
+        /// <param name="isSnippet">Indicates whether the completion item's <see cref="InsertText"/> is an LSP snippet or not.</param>
         public RazorCompletionItem(
             string displayText,
             string insertText,
             RazorCompletionItemKind kind,
             string sortText = null,
-            IReadOnlyList<RazorCommitCharacter> commitCharacters = null)
+            IReadOnlyList<RazorCommitCharacter> commitCharacters = null,
+            bool isSnippet = false)
         {
             if (displayText is null)
             {
@@ -46,11 +48,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Kind = kind;
             CommitCharacters = commitCharacters;
             SortText = sortText ?? displayText;
+            IsSnippet = isSnippet;
         }
 
         public string DisplayText { get; }
 
         public string InsertText { get; }
+
+        public bool IsSnippet { get; }
 
         /// <summary>
         /// A string that is used to alphabetically sort the completion item.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void TryConvert_TagHelperAttribute_ForHtml_ReturnsTrue()
         {
             // Arrange
-            var completionItem = new RazorCompletionItem("format", "format", RazorCompletionItemKind.TagHelperAttribute);
+            var completionItem = new RazorCompletionItem("format", "format=\"$0\"", RazorCompletionItemKind.TagHelperAttribute, isSnippet: true);
             var attributeCompletionDescription = new AggregateBoundAttributeDescription(new BoundAttributeDescriptionInfo[] { });
             completionItem.SetAttributeCompletionDescription(attributeCompletionDescription);
 
@@ -303,8 +303,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.DisplayText, converted.Label);
             Assert.Equal("format=\"$0\"", converted.InsertText);
             Assert.Equal(InsertTextFormat.Snippet, converted.InsertTextFormat);
-            Assert.Equal(completionItem.InsertText, converted.FilterText);
-            Assert.Equal(completionItem.InsertText, converted.SortText);
+            Assert.Equal(completionItem.DisplayText, converted.FilterText);
+            Assert.Equal(completionItem.DisplayText, converted.SortText);
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);
@@ -314,7 +314,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void TryConvert_TagHelperAttribute_ReturnsTrue()
         {
             // Arrange
-            var completionItem = new RazorCompletionItem("format", "format", RazorCompletionItemKind.TagHelperAttribute);
+            var completionItem = new RazorCompletionItem("format", "format=\"$0\"", RazorCompletionItemKind.TagHelperAttribute, isSnippet: true);
 
             // Act
             var result = RazorCompletionEndpoint.TryConvert(completionItem, _supportedCompletionItemKinds, out var converted);
@@ -324,8 +324,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Equal(completionItem.DisplayText, converted.Label);
             Assert.Equal("format=\"$0\"", converted.InsertText);
             Assert.Equal(InsertTextFormat.Snippet, converted.InsertTextFormat);
-            Assert.Equal(completionItem.InsertText, converted.FilterText);
-            Assert.Equal(completionItem.InsertText, converted.SortText);
+            Assert.Equal(completionItem.DisplayText, converted.FilterText);
+            Assert.Equal(completionItem.DisplayText, converted.SortText);
             Assert.Null(converted.Detail);
             Assert.Null(converted.Documentation);
             Assert.Null(converted.Command);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -213,6 +213,38 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        public void GetCompletionAt_AtAttributeEdge_IntAttribute_Snippets_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", isRazorFile: false, DefaultTagHelpers);
+            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
+            var options = new RazorCompletionOptions(SnippetsSupported: true);
+            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), Options: options);
+
+            // Act
+            var completions = service.GetCompletionItems(context, sourceSpan);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("bool-val", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                    Assert.False(completion.IsSnippet);
+                },
+                completion =>
+                {
+                    Assert.Equal("int-val=\"$0\"", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.AttributeSnippetCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                    Assert.True(completion.IsSnippet);
+                });
+        }
+
+        [Fact]
         public void GetCompletionAt_KnownHtmlElement_ReturnsCompletions_DefaultPriority()
         {
             // Arrange


### PR DESCRIPTION
- We now provide the ability to indicate of a Razor completion items `InsertText` is a snippet.
- With this changeset we can remove some of our pre-existing hack logic on trying to detect minimized or unminimized attributes and instead utilize our new `IsSnippet` tech.
- In updating the RazorCompletionEndpoint to respect the new insert text format that we pass through our system I also found some mishaps in FilterText that I corrected as well. These were exposed by tests.
- Updated existing tests to respect when snippets come from completion items.
- Added new tests to validate snippets

Fixes #6341