### PR TITLE
Properly capture all VS client capabilities.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/ClientCapabilitiesExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/ClientCapabilitiesExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharpClientCapabilities = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.ClientCapabilities;
@@ -11,8 +13,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
     {
         public static VSInternalClientCapabilities ToVSClientCapabilities(this OmniSharpClientCapabilities omniSharpClientCapabilities, LspSerializer serializer)
         {
-            var serializedOmniSharpClientCapabilities = serializer.SerializeObject(omniSharpClientCapabilities);
-            var vsClientCapabilities = serializer.DeserializeObject<VSInternalClientCapabilities>(serializedOmniSharpClientCapabilities);
+            var jsonCapturingCapabilities = omniSharpClientCapabilities as ICaptureJson;
+            if (jsonCapturingCapabilities is null)
+            {
+                throw new InvalidOperationException("Client capability deserializers not registered, failed to convert to " + nameof(ICaptureJson));
+            }
+
+            var vsClientCapabilities = jsonCapturingCapabilities.Json.ToObject<VSInternalClientCapabilities>(serializer.JsonSerializer);
+            if (vsClientCapabilities is null)
+            {
+                throw new InvalidOperationException("Failed to convert client capabilities");
+            }
+
             return vsClientCapabilities;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/PlatformAgnosticClientCapabilities.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/PlatformAgnosticClientCapabilities.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
@@ -12,11 +13,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     /// <summary>
     /// These client capabilities represent the superset of client capabilities from VS and VSCode.
     /// </summary>
-    internal class PlatformAgnosticClientCapabilities : ClientCapabilities
+    internal class PlatformAgnosticClientCapabilities : ClientCapabilities, ICaptureJson
     {
         public static readonly PlatformExtensionConverter<ClientCapabilities, PlatformAgnosticClientCapabilities> JsonConverter = new PlatformExtensionConverter<ClientCapabilities, PlatformAgnosticClientCapabilities>();
 
         [JsonProperty("_vs_supportsVisualStudioExtensions")]
         public bool SupportsVisualStudioExtensions { get; set; } = false;
+
+        public JToken Json { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/ICaptureJson.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/ICaptureJson.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization
+{
+    /// <summary>
+    /// Used by an interface to capture the <see cref="JToken"/> representation of a request so no data loss occurs. This should be used sparringly
+    /// because converting to a <see cref="JToken"/> and then an actual type is not as efficient.
+    /// </summary>
+    internal interface ICaptureJson
+    {
+        public JToken Json { get; set; }
+    }
+}
+

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/PlatformExtensionConverter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/PlatformExtensionConverter.cs
@@ -3,12 +3,23 @@
 
 using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization
 {
     internal class PlatformExtensionConverter<TBase, TExtension> : JsonConverter
         where TExtension : TBase
     {
+        private readonly bool _captureJson;
+
+        public PlatformExtensionConverter()
+        {
+            if (typeof(ICaptureJson).IsAssignableFrom(typeof(TExtension)))
+            {
+                _captureJson = true;
+            }
+        }
+
         /// <inheritdoc/>
         public override bool CanWrite => false;
 
@@ -21,7 +32,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization
         /// <inheritdoc/>
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
-            return serializer.Deserialize<TExtension>(reader);
+            if (_captureJson)
+            {
+                var jtoken = JToken.ReadFrom(reader);
+                var extension = jtoken.ToObject<TExtension>(serializer);
+
+                if (extension != null)
+                {
+                    var captureJson = (ICaptureJson)extension;
+                    captureJson.Json = jtoken;
+                }
+
+                return extension;
+            }
+            else
+            {
+                return serializer.Deserialize<TExtension>(reader);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Extensions/ClientCapabilitiesExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Extensions/ClientCapabilitiesExtensionsTest.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using Xunit;
 using OmniSharpClientCapabilities = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.ClientCapabilities;
-using OmniSharpCompletionCapability = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.CompletionCapability;
-using OmniSharpCompletionSupport = OmniSharp.Extensions.LanguageServer.Protocol.Supports<OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.CompletionCapability?>;
-using OmniSharpTextDocumentClientCapability = OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.TextDocumentClientCapabilities;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
@@ -19,36 +17,298 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
         public void ToVSClientCapabilities_WorksAsExpected()
         {
             // Arrange
-            var experimentalCapability = new Dictionary<string, JToken>()
-            {
-                ["test"] = "Hello World"
-            };
-            var omniSharpCapabilities = new OmniSharpClientCapabilities()
-            {
-                Experimental = experimentalCapability,
-                TextDocument = new OmniSharpTextDocumentClientCapability()
+            var clientCapabilitiesJson = """
                 {
-                    Completion = new OmniSharpCompletionSupport(
-                        new OmniSharpCompletionCapability()
-                        {
-                            ContextSupport = true,
-                        }),
+                  "_vs_supportsVisualStudioExtensions": true,
+                  "_vs_supportedSnippetVersion": 1,
+                  "_vs_supportsIconExtensions": true,
+                  "_vs_supportsDiagnosticRequests": true,
+                  "workspace": {
+                    "applyEdit": true,
+                    "workspaceEdit": {
+                      "documentChanges": true,
+                      "resourceOperations": []
+                    },
+                    "didChangeConfiguration": {},
+                    "didChangeWatchedFiles": {},
+                    "symbol": {},
+                    "executeCommand": {
+                      "_vs_supportedCommands": [
+                        "_ms_setClipboard",
+                        "_ms_openUrl"
+                      ]
+                    },
+                    "semanticTokens": {
+                      "RefreshSupport": true
+                    }
+                  },
+                  "textDocument": {
+                    "_vs_onAutoInsert": {},
+                    "synchronization": {
+                      "didSave": true
+                    },
+                    "completion": {
+                      "_vs_completionList": {
+                        "_vs_data": true,
+                        "_vs_commitCharacters": true
+                      },
+                      "completionItem": {},
+                      "completionItemKind": {
+                        "valueSet": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          7,
+                          8,
+                          9,
+                          10,
+                          11,
+                          12,
+                          13,
+                          14,
+                          15,
+                          16,
+                          17,
+                          18,
+                          19,
+                          20,
+                          21,
+                          22,
+                          23,
+                          24,
+                          25,
+                          118115,
+                          118116,
+                          118117,
+                          118118,
+                          118119,
+                          118120,
+                          118121,
+                          118122,
+                          118123,
+                          118124,
+                          118125,
+                          118126
+                        ]
+                      },
+                      "completionList": {
+                        "itemDefaults": [
+                          "commitCharacters",
+                          "editRange",
+                          "insertTextFormat"
+                        ]
+                      }
+                    },
+                    "hover": {
+                      "contentFormat": [
+                        "plaintext"
+                      ]
+                    },
+                    "signatureHelp": {
+                      "signatureInformation": {
+                        "documentationFormat": [
+                          "plaintext"
+                        ],
+                        "parameterInformation": {
+                          "labelOffsetSupport": true
+                        }
+                      },
+                      "contextSupport": true
+                    },
+                    "definition": {},
+                    "typeDefinition": {},
+                    "implementation": {},
+                    "references": {},
+                    "documentHighlight": {},
+                    "documentSymbol": {},
+                    "codeAction": {
+                      "codeActionLiteralSupport": {
+                        "_vs_codeActionGroup": {
+                          "_vs_valueSet": [
+                            "quickfix",
+                            "refactor",
+                            "refactor.extract",
+                            "refactor.inline",
+                            "refactor.rewrite",
+                            "source",
+                            "source.organizeImports"
+                          ]
+                        },
+                        "codeActionKind": {
+                          "valueSet": [
+                            "quickfix",
+                            "refactor",
+                            "refactor.extract",
+                            "refactor.inline",
+                            "refactor.rewrite",
+                            "source",
+                            "source.organizeImports"
+                          ]
+                        }
+                      },
+                      "resolveSupport": {
+                        "properties": [
+                          "additionalTextEdits",
+                          "command",
+                          "commitCharacters",
+                          "description",
+                          "detail",
+                          "documentation",
+                          "insertText",
+                          "insertTextFormat",
+                          "label"
+                        ]
+                      },
+                      "dataSupport": true
+                    },
+                    "codeLens": {},
+                    "documentLink": {},
+                    "formatting": {},
+                    "rangeFormatting": {},
+                    "onTypeFormatting": {},
+                    "rename": {},
+                    "publishDiagnostics": {
+                      "tagSupport": {
+                        "valueSet": [
+                          1,
+                          2,
+                          -1,
+                          -2
+                        ]
+                      }
+                    },
+                    "foldingRange": {
+                      "_vs_refreshSupport": true
+                    },
+                    "linkedEditingRange": {},
+                    "semanticTokens": {
+                      "requests": {
+                        "range": true,
+                        "full": {
+                          "range": true
+                        }
+                      },
+                      "tokenTypes": [
+                        "namespace",
+                        "type",
+                        "class",
+                        "enum",
+                        "interface",
+                        "struct",
+                        "typeParameter",
+                        "parameter",
+                        "variable",
+                        "property",
+                        "enumMember",
+                        "event",
+                        "function",
+                        "method",
+                        "macro",
+                        "keyword",
+                        "modifier",
+                        "comment",
+                        "string",
+                        "number",
+                        "regexp",
+                        "operator",
+                        "cppMacro",
+                        "cppEnumerator",
+                        "cppGlobalVariable",
+                        "cppLocalVariable",
+                        "cppParameter",
+                        "cppType",
+                        "cppRefType",
+                        "cppValueType",
+                        "cppFunction",
+                        "cppMemberFunction",
+                        "cppMemberField",
+                        "cppStaticMemberFunction",
+                        "cppStaticMemberField",
+                        "cppProperty",
+                        "cppEvent",
+                        "cppClassTemplate",
+                        "cppGenericType",
+                        "cppFunctionTemplate",
+                        "cppNamespace",
+                        "cppLabel",
+                        "cppUserDefinedLiteralRaw",
+                        "cppUserDefinedLiteralNumber",
+                        "cppUserDefinedLiteralString",
+                        "cppOperator",
+                        "cppMemberOperator",
+                        "cppNewDelete"
+                      ],
+                      "tokenModifiers": [
+                        "declaration",
+                        "definition",
+                        "readonly",
+                        "static",
+                        "deprecated",
+                        "abstract",
+                        "async",
+                        "modification",
+                        "documentation",
+                        "defaultLibrary"
+                      ],
+                      "formats": [
+                        "relative"
+                      ]
+                    }
+                  }
                 }
-            };
+                """;
             var serializer = new LspSerializer();
+            serializer.RegisterRazorConverters();
             serializer.RegisterVSInternalExtensionConverters();
+            var omniSharpCapabilities = serializer.DeserializeObject<OmniSharpClientCapabilities>(clientCapabilitiesJson);
 
             // Act
             var vsCapabilities = omniSharpCapabilities.ToVSClientCapabilities(serializer);
 
             // Assert
-            Assert.NotNull(vsCapabilities.Experimental);
-            var actualExperimental = JObject.FromObject(vsCapabilities.Experimental!);
-            var expectedExperimental = JObject.FromObject(experimentalCapability);
+            var expectedCapabilitiesObj = serializer.DeserializeObject<VSInternalClientCapabilities>(clientCapabilitiesJson);
+            var expectedCapabilities = JObject.FromObject(expectedCapabilitiesObj);
+            var actualCapabilities = JObject.FromObject(vsCapabilities);
 
-            Assert.Equal(expectedExperimental, actualExperimental);
-            Assert.NotNull(vsCapabilities.TextDocument);
-            Assert.True(vsCapabilities.TextDocument?.Completion?.ContextSupport);
+            AssertJTokensEqual(expectedCapabilities, actualCapabilities);
+        }
+
+        private static void AssertJTokensEqual(JToken expected, JObject actualClientCapabilities)
+        {
+            if (expected == null)
+            {
+                return;
+            }
+
+            if (expected.HasValues)
+            {
+                foreach (var token in expected)
+                {
+                    AssertJTokensEqual(token, actualClientCapabilities);
+                }
+
+                return;
+            }
+
+            // Token
+            if (expected.Path.Contains("["))
+            {
+                // We're going to skip validating arrays
+                return;
+            }
+
+            var pathParts = expected.Path.Split('.');
+            JToken actual = actualClientCapabilities;
+            for (var i = 0; i < pathParts.Length; i++)
+            {
+                actual = actual[pathParts[i]]!;
+            }
+
+            Assert.Equal(expected, actual);
         }
     }
 }


### PR DESCRIPTION
- Prior to this I hadn't realized that we were only capturing VS items that were specifically "overloaded" in our "Platform agnostic XYZ" types. This meant that when we were trying to inspect other items on the client capability collection we'd fail to understand them because O# would see the initialize request, deserialize into their own ClientCapabilities at which point all data representing VS' would be lost. To overcome this I created a new `ICaptureJson` type that informs our platform extension converters to maintain the JToken representation of objects.
- Updated our test to be pretty exhaustive to ensure we're capturing all information.

Part of #6328