### PR TITLE
Don't require CPS on VSMac.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLSPEditorFeatureDetector.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     internal class VisualStudioMacLSPEditorFeatureDetector : LSPEditorFeatureDetector
     {
         private const string RazorLSPEditorFeatureFlag = "Razor.LSP.Editor";
-        private const string DotNetCoreCSharpProjectCapability = "CSharp&CPS";
+        private const string DotNetCoreCSharpProjectCapability = "DotNetCoreRazor | AspNetCore";
         private const string LegacyRazorEditorProjectCapability = "LegacyRazorEditor";
 
         private readonly AggregateProjectCapabilityResolver _projectCapabilityResolver;


### PR DESCRIPTION
- This was preventing the LSP editor from turning itself on because there's no CPS in VS4Mac land.