### PR TITLE
Re-use result IDs when calculating TagHelpers (prevent misses).

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/RemoteTagHelperDeltaProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/RemoteTagHelperDeltaProviderTest.cs
@@ -123,6 +123,30 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
         }
 
         [Fact]
+        public void GetTagHelpersDelta_NoChange_MultipleRequests()
+        {
+            // Arrange
+            var project1Delta0 = Provider.GetTagHelpersDelta(Project1FilePath, lastResultId: -1, Project1TagHelpers);
+            var project2Delta0 = Provider.GetTagHelpersDelta(Project2FilePath, lastResultId: -1, Project2TagHelpers);
+
+            // Act
+            var project2Delta = Provider.GetTagHelpersDelta(Project2FilePath, project2Delta0.ResultId, Project2TagHelpers);
+            var project1Delta1 = Provider.GetTagHelpersDelta(Project1FilePath, project1Delta0.ResultId, Project1TagHelpers);
+            var project1Delta2 = Provider.GetTagHelpersDelta(Project1FilePath, project1Delta1.ResultId, Project1TagHelpers);
+
+            // Assert
+            Assert.True(project1Delta1.Delta);
+            Assert.Empty(project1Delta1.Added);
+            Assert.Empty(project1Delta1.Removed);
+            Assert.True(project2Delta.Delta);
+            Assert.Empty(project2Delta.Added);
+            Assert.Empty(project2Delta.Removed);
+            Assert.True(project1Delta2.Delta);
+            Assert.Empty(project1Delta2.Added);
+            Assert.Empty(project1Delta2.Removed);
+        }
+
+        [Fact]
         public void GetTagHelpersDelta_EndToEnd()
         {
             // Arrange


### PR DESCRIPTION
- Prior to this what would happen is when folks would request TagHelpers we'd be incrementing a wholistic "result" value for every cached item. This means if you had 3 projects A, B and C we'd cache all 3 the very first time they were requested. The second time they were requested, we'd similarly say "we hit the cache but we'd then provide a different resultId (the wrong one) depending on the current wholistic "resultId". This means on the third time requesting TagHelpers it'd request A, B and C with resultId NEW at which point all woudl fail to hit the cache resulting in us not returning a delta result. This in turn would wreck serialization perf on devenv and on the service hub sides. This change ensure that we have a near 100% cache hit rate to prevent devenv and service hub from spending time in serialization. In trying this out I found that devenv effectively idle's (before it would burn through CPU) and ServiceHub behaves a bit better.
- Added a test to cover this scenario.

Fixes #5697 