### PR TITLE
Use raw string literals for formatting tests

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
@@ -20,102 +20,107 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task CloseCurly_IfBlock_SingleLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@{
- if(true){}$$
-}
-",
-expected: @"
-@{
-    if (true) { }
-}
-", triggerCharacter: '}');
+                input: """
+                    @{
+                     if(true){}$$
+                    }
+                    """,
+                expected: """
+                    @{
+                        if (true) { }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_IfBlock_MultiLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@{
- if(true)
-{
- }$$
-}
-",
-expected: @"
-@{
-    if (true)
-    {
-    }
-}
-", triggerCharacter: '}');
+                input: """
+                    @{
+                     if(true)
+                    {
+                     }$$
+                    }
+                    """,
+                expected: """
+                    @{
+                        if (true)
+                        {
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_MultipleStatementBlocksAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-<div>
-    @{
-      if(true) { }
-    }
-</div>
+                input: """
+                    <div>
+                        @{
+                          if(true) { }
+                        }
+                    </div>
 
-@{
- if(true)
-{
- }$$
-}
-",
-expected: @"
-<div>
-    @{
-        if(true) { }
-    }
-</div>
+                    @{
+                     if(true)
+                    {
+                     }$$
+                    }
+                    """,
+                expected: """
+                    <div>
+                        @{
+                            if(true) { }
+                        }
+                    </div>
 
-@{
-    if (true)
-    {
-    }
-}
-", triggerCharacter: '}');
+                    @{
+                        if (true)
+                        {
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task Semicolon_Variable_SingleLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@{
- var x = 'foo';$$
-}
-",
-expected: @"
-@{
-    var x = 'foo';
-}
-", triggerCharacter: ';');
+                input: """
+                    @{
+                     var x = 'foo';$$
+                    }
+                    """,
+                expected: """
+                    @{
+                        var x = 'foo';
+                    }
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
         public async Task Semicolon_Variable_MultiLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@{
- var x = @""
-foo"";$$
-}
-",
-expected: @"
-@{
-    var x = @""
-foo"";
-}
-", triggerCharacter: ';');
+                input: """
+                    @{
+                     var x = @"
+                    foo";$$
+                    }
+                    """,
+                expected: """
+                    @{
+                        var x = @"
+                    foo";
+                    }
+                    """,
+                triggerCharacter: ';');
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -27,786 +27,814 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task FormatsCodeBlockDirective()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}
-        public interface Bar {
-}
-}
-",
-expected: @"@code {
-    public class Foo { }
-    public interface Bar
-    {
-    }
-}
-");
+                input: """
+                    @code {
+                     public class Foo{}
+                            public interface Bar {
+                    }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public class Foo { }
+                        public interface Bar
+                        {
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Format_DocumentWithDiagnostics()
         {
             await RunFormattingTestAsync(
-input: @"
-@page
-@model BlazorApp58.Pages.Index2Model
-@{
-}
-
-<section class=""section"">
-    <div class=""container"">
-        <h1 class=""title"">Managed pohotos</h1>
-        <p class=""subtitle"">@Model.ReferenceNumber</p>
-    </div>
-</section>
-<section class=""section"">
-    <div class=""container"">
-        @foreach       (var item in Model.Images)
-        {
-            <div><div>
-        }
-    </div>
-</section>
-",
-expected: @"@page
-@model BlazorApp58.Pages.Index2Model
-@{
-}
-
-<section class=""section"">
-    <div class=""container"">
-        <h1 class=""title"">Managed pohotos</h1>
-        <p class=""subtitle"">@Model.ReferenceNumber</p>
-    </div>
-</section>
-<section class=""section"">
-    <div class=""container"">
-        @foreach (var item in Model.Images)
-        {
-            <div>
-                <div>
+                input: """
+                    @page
+                    @model BlazorApp58.Pages.Index2Model
+                    @{
                     }
-                </div>
-    </section>
-",
-            fileKind: FileKinds.Legacy,
-            allowDiagnostics: true);
+
+                    <section class="section">
+                        <div class="container">
+                            <h1 class="title">Managed pohotos</h1>
+                            <p class="subtitle">@Model.ReferenceNumber</p>
+                        </div>
+                    </section>
+                    <section class="section">
+                        <div class="container">
+                            @foreach       (var item in Model.Images)
+                            {
+                                <div><div>
+                            }
+                        </div>
+                    </section>
+                    """,
+                expected: """
+                    @page
+                    @model BlazorApp58.Pages.Index2Model
+                    @{
+                    }
+
+                    <section class="section">
+                        <div class="container">
+                            <h1 class="title">Managed pohotos</h1>
+                            <p class="subtitle">@Model.ReferenceNumber</p>
+                        </div>
+                    </section>
+                    <section class="section">
+                        <div class="container">
+                            @foreach (var item in Model.Images)
+                            {
+                                <div>
+                                    <div>
+                                        }
+                                    </div>
+                        </section>
+                    """,
+                fileKind: FileKinds.Legacy,
+                allowDiagnostics: true);
         }
 
         [Fact]
         public async Task Formats_MultipleBlocksInADirective()
         {
             await RunFormattingTestAsync(
-input: @"
-@{
-void Method(){
-var x = ""foo"";
-@(DateTime.Now)
-    <p></p>
-var y= ""fooo"";
-}
-}
-<div>
-        </div>
-",
-expected: @"@{
-    void Method()
-    {
-        var x = ""foo"";
-        @(DateTime.Now)
-        <p></p>
-        var y = ""fooo"";
-    }
-}
-<div>
-</div>
-");
+                input: """
+                    @{
+                    void Method(){
+                    var x = "foo";
+                    @(DateTime.Now)
+                        <p></p>
+                    var y= "fooo";
+                    }
+                    }
+                    <div>
+                            </div>
+                    """,
+                expected: """
+                    @{
+                        void Method()
+                        {
+                            var x = "foo";
+                            @(DateTime.Now)
+                            <p></p>
+                            var y = "fooo";
+                        }
+                    }
+                    <div>
+                    </div>
+                    """);
         }
 
         [Fact]
         public async Task Formats_NonCodeBlockDirectives()
         {
             await RunFormattingTestAsync(
-input: @"
-@{
-var x = ""foo"";
-}
-<div>
-        </div>
-",
-expected: @"@{
-    var x = ""foo"";
-}
-<div>
-</div>
-");
+                input: """
+                    @{
+                    var x = "foo";
+                    }
+                    <div>
+                            </div>
+                    """,
+                expected: """
+                    @{
+                        var x = "foo";
+                    }
+                    <div>
+                    </div>
+                    """);
         }
 
         [Fact]
         public async Task Formats_CodeBlockDirectiveWithMarkup_NonBraced()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-void Method() { var x = ""t""; <div></div> var y = ""t"";}
-}
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        void Method()
-        {
-            var x = ""t"";
-            <div></div>
-            var y = ""t"";
-        }
-    }
-}
-");
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() { var x = "t"; <div></div> var y = "t";}
+                    }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method()
+                            {
+                                var x = "t";
+                                <div></div>
+                                var y = "t";
+                            }
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Formats_CodeBlockDirectiveWithMarkup()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-void Method() { <div></div> }
-}
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        void Method()
-        {
-            <div></div>
-        }
-    }
-}
-");
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() { <div></div> }
+                    }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method()
+                            {
+                                <div></div>
+                            }
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Formats_CodeBlockDirectiveWithImplicitExpressions()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{
-void Method() { @DateTime.Now }
-    }
-}
-",
-expected: @"@code {
-    public class Foo
-    {
-        void Method()
-        {
-            @DateTime.Now
-        }
-    }
-}
-");
+                input: """
+                    @code {
+                     public class Foo{
+                    void Method() { @DateTime.Now }
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public class Foo
+                        {
+                            void Method()
+                            {
+                                @DateTime.Now
+                            }
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task DoesNotFormat_CodeBlockDirectiveWithExplicitExpressions()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-void Method() { @(DateTime.Now) }
-    }
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        void Method()
-        {
-            @(DateTime.Now)
-        }
-    }
-}
-",
-fileKind: FileKinds.Legacy);
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() { @(DateTime.Now) }
+                        }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method()
+                            {
+                                @(DateTime.Now)
+                            }
+                        }
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task Format_SectionDirectiveBlock1()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-void Method() {  }
-    }
-}
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
 
-@section Scripts {
-<script></script>
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        void Method() { }
-    }
-}
+                    @section Scripts {
+                    <script></script>
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
 
-@section Scripts {
-    <script></script>
-}
-",
-fileKind: FileKinds.Legacy);
+                    @section Scripts {
+                        <script></script>
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task Format_SectionDirectiveBlock2()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-void Method() {  }
-    }
-}
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
 
-@section Scripts {
-<script>
-    function f() {
-    }
-</script>
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        void Method() { }
-    }
-}
+                    @section Scripts {
+                    <script>
+                        function f() {
+                        }
+                    </script>
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
 
-@section Scripts {
-    <script>
-        function f() {
-        }
-    </script>
-}
-",
-fileKind: FileKinds.Legacy);
+                    @section Scripts {
+                        <script>
+                            function f() {
+                            }
+                        </script>
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task Format_SectionDirectiveBlock3()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-void Method() {  }
-    }
-}
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
 
-@section Scripts {
-<p>this is a para</p>
-@if(true)
-{
-<p>and so is this</p>
-}
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        void Method() { }
-    }
-}
+                    @section Scripts {
+                    <p>this is a para</p>
+                    @if(true)
+                    {
+                    <p>and so is this</p>
+                    }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
 
-@section Scripts {
-    <p>this is a para</p>
-    @if (true)
-    {
-        <p>and so is this</p>
-    }
-}
-",
-fileKind: FileKinds.Legacy);
+                    @section Scripts {
+                        <p>this is a para</p>
+                        @if (true)
+                        {
+                            <p>and so is this</p>
+                        }
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task Formats_CodeBlockDirectiveWithRazorComments()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-@* This is a Razor Comment *@
-void Method() {  }
-}
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        @* This is a Razor Comment *@
-        void Method() { }
-    }
-}
-");
+                input: """
+                    @functions {
+                     public class Foo{
+                    @* This is a Razor Comment *@
+                    void Method() {  }
+                    }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            @* This is a Razor Comment *@
+                            void Method() { }
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Formats_CodeBlockDirectiveWithRazorStatements()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{
-@* This is a Razor Comment *@
-    }
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-        @* This is a Razor Comment *@
-    }
-}
-");
+                input: """
+                    @functions {
+                     public class Foo{
+                    @* This is a Razor Comment *@
+                        }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            @* This is a Razor Comment *@
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task DoesNotFormat_CodeBlockDirective_NotInSelectedRange()
         {
             await RunFormattingTestAsync(
-input: @"
-[|<div>Foo</div>|]
-@functions {
- public class Foo{}
-        public interface Bar {
-}
-}
-",
-expected: @"
-<div>Foo</div>
-@functions {
- public class Foo{}
-        public interface Bar {
-}
-}
-");
+                input: """
+                    [|<div>Foo</div>|]
+                    @functions {
+                     public class Foo{}
+                            public interface Bar {
+                    }
+                    }
+                    """,
+                expected: """
+                    <div>Foo</div>
+                    @functions {
+                     public class Foo{}
+                            public interface Bar {
+                    }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task OnlyFormatsWithinRange()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{}
-        [|public interface Bar {
-}|]
-}
-",
-expected: @"
-@functions {
- public class Foo{}
-    public interface Bar
-    {
-    }
-}
-");
+                input: """
+                    @functions {
+                     public class Foo{}
+                            [|public interface Bar {
+                    }|]
+                    }
+                    """,
+                expected: """
+                    @functions {
+                     public class Foo{}
+                        public interface Bar
+                        {
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task MultipleCodeBlockDirectives()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
- public class Foo{}
-        public interface Bar {
-}
-}
-Hello World
-@functions {
-      public class Baz    {
-          void Method ( )
-          { }
-          }
-}
-",
-expected: @"@functions {
-    public class Foo { }
-    public interface Bar
-    {
-    }
-}
-Hello World
-@functions {
-    public class Baz
-    {
-        void Method()
-        { }
-    }
-}
-",
-fileKind: FileKinds.Legacy);
+                input: """
+                    @functions {
+                     public class Foo{}
+                            public interface Bar {
+                    }
+                    }
+                    Hello World
+                    @functions {
+                          public class Baz    {
+                              void Method ( )
+                              { }
+                              }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo { }
+                        public interface Bar
+                        {
+                        }
+                    }
+                    Hello World
+                    @functions {
+                        public class Baz
+                        {
+                            void Method()
+                            { }
+                        }
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task MultipleCodeBlockDirectives2()
         {
             await RunFormattingTestAsync(
-input: @"
-Hello World
-@code {
-public class HelloWorld
-{
-}
-}
+                input: """
+                    Hello World
+                    @code {
+                    public class HelloWorld
+                    {
+                    }
+                    }
 
-@functions{
+                    @functions{
 
- public class Bar {}
-}
-",
-expected: @"Hello World
-@code {
-    public class HelloWorld
-    {
-    }
-}
+                        public class Bar {}
+                    }
+                    """,
+                expected: """
+                    Hello World
+                    @code {
+                        public class HelloWorld
+                        {
+                        }
+                    }
 
-@functions {
+                    @functions {
 
-    public class Bar { }
-}
-");
+                        public class Bar { }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task CodeOnTheSameLineAsCodeBlockDirectiveStart()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {public class Foo{
-}
-}
-",
-expected: @"@functions {
-    public class Foo
-    {
-    }
-}
-");
+                input: """
+                    @functions {public class Foo{
+                    }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task CodeOnTheSameLineAsCodeBlockDirectiveEnd()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {
-public class Foo{
-}}
-",
-expected: @"@functions {
-    public class Foo
-    {
-    }
-}
-");
+                input: """
+                    @functions {
+                    public class Foo{
+                    }}
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task SingleLineCodeBlockDirective()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions {public class Foo{}
-}
-",
-expected: @"@functions {
-    public class Foo { }
-}
-");
+            input: """
+                @functions {public class Foo{}
+                }
+                """,
+            expected: """
+                @functions {
+                    public class Foo { }
+                }
+                """);
         }
 
         [Fact]
         public async Task IndentsCodeBlockDirectiveStart()
         {
             await RunFormattingTestAsync(
-input: @"
-Hello World
-     @functions {public class Foo{}
-}
-",
-expected: @"Hello World
-@functions {
-    public class Foo { }
-}
-");
+                input: """
+                    Hello World
+                         @functions {public class Foo{}
+                    }
+                    """,
+                expected: """
+                    Hello World
+                    @functions {
+                        public class Foo { }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task IndentsCodeBlockDirectiveEnd()
         {
             await RunFormattingTestAsync(
-input: @"
- @functions {
-public class Foo{}
-     }
-",
-expected: @"@functions {
-    public class Foo { }
-     }
-");
+                input: """
+                     @functions {
+                    public class Foo{}
+                         }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo { }
+                         }
+                    """);
         }
 
         [Fact]
         public async Task ComplexCodeBlockDirective()
         {
             await RunFormattingTestAsync(
-input: @"
-@using System.Buffers
-@functions{
-     public class Foo
-            {
-                public Foo()
-                {
-                    var arr = new string[ ] { ""One"", ""two"",""three"" };
-                    var str = @""
-This should
-not
-be indented.
-"";
-                }
-public int MyProperty { get
-{
-return 0 ;
-} set {} }
+                input: """
+                    @using System.Buffers
+                    @functions{
+                         public class Foo
+                                {
+                                    public Foo()
+                                    {
+                                        var arr = new string[ ] { "One", "two","three" };
+                                        var str = @"
+                    This should
+                    not
+                    be indented.
+                    ";
+                                    }
+                    public int MyProperty { get
+                    {
+                    return 0 ;
+                    } set {} }
 
-void Method(){
+                    void Method(){
 
-}
                     }
-}
-",
-expected: @"@using System.Buffers
-@functions {
-    public class Foo
-    {
-        public Foo()
-        {
-            var arr = new string[] { ""One"", ""two"", ""three"" };
-            var str = @""
-This should
-not
-be indented.
-"";
-        }
-        public int MyProperty
-        {
-            get
-            {
-                return 0;
-            }
-            set { }
-        }
+                                        }
+                    }
+                    """,
+                expected: """
+                    @using System.Buffers
+                    @functions {
+                        public class Foo
+                        {
+                            public Foo()
+                            {
+                                var arr = new string[] { "One", "two", "three" };
+                                var str = @"
+                    This should
+                    not
+                    be indented.
+                    ";
+                            }
+                            public int MyProperty
+                            {
+                                get
+                                {
+                                    return 0;
+                                }
+                                set { }
+                            }
 
-        void Method()
-        {
+                            void Method()
+                            {
 
-        }
-    }
-}
-");
+                            }
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Strings()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions{
-private string str1 = ""hello world"";
-private string str2 = $""hello world"";
-private string str3 = @""hello world"";
-private string str4 = $@""hello world"";
-private string str5 = @""
-    One
-        Two
-            Three
-"";
-private string str6 = $@""
-    One
-        Two
-            Three
-"";
-// This looks wrong, but matches what the C# formatter does. Try it and see!
-private string str7 = ""One"" +
-    ""Two"" +
-        ""Three"" +
-"""";
-}
-",
-expected: @"@functions {
-    private string str1 = ""hello world"";
-    private string str2 = $""hello world"";
-    private string str3 = @""hello world"";
-    private string str4 = $@""hello world"";
-    private string str5 = @""
-    One
-        Two
-            Three
-"";
-    private string str6 = $@""
-    One
-        Two
-            Three
-"";
-    // This looks wrong, but matches what the C# formatter does. Try it and see!
-    private string str7 = ""One"" +
-        ""Two"" +
-            ""Three"" +
-    """";
-}
-");
+                input: """
+                    @functions{
+                    private string str1 = "hello world";
+                    private string str2 = $"hello world";
+                    private string str3 = @"hello world";
+                    private string str4 = $@"hello world";
+                    private string str5 = @"
+                        One
+                            Two
+                                Three
+                    ";
+                    private string str6 = $@"
+                        One
+                            Two
+                                Three
+                    ";
+                    // This looks wrong, but matches what the C# formatter does. Try it and see!
+                    private string str7 = "One" +
+                        "Two" +
+                            "Three" +
+                    "";
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        private string str1 = "hello world";
+                        private string str2 = $"hello world";
+                        private string str3 = @"hello world";
+                        private string str4 = $@"hello world";
+                        private string str5 = @"
+                        One
+                            Two
+                                Three
+                    ";
+                        private string str6 = $@"
+                        One
+                            Two
+                                Three
+                    ";
+                        // This looks wrong, but matches what the C# formatter does. Try it and see!
+                        private string str7 = "One" +
+                            "Two" +
+                                "Three" +
+                        "";
+                    }
+                    """);
         }
 
         [Fact]
         public async Task CodeBlockDirective_UseTabs()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}
-        void Method(  ) {
-}
-}
-",
-expected: @"@code {
-	public class Foo { }
-	void Method()
-	{
-	}
-}
-",
-insertSpaces: false);
+                input: """
+                    @code {
+                     public class Foo{}
+                            void Method(  ) {
+                    }
+                    }
+                    """,
+                expected: """
+                    @code {
+                    	public class Foo { }
+                    	void Method()
+                    	{
+                    	}
+                    }
+                    """,
+                insertSpaces: false);
 
         }
         [Fact]
         public async Task CodeBlockDirective_UseTabsWithTabSize8_HTML()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}
-        void Method(  ) {<div></div>
-}
-}
-",
-expected: @"@code {
-	public class Foo { }
-	void Method()
-	{
-		<div></div>
-	}
-}
-",
-tabSize: 8,
-insertSpaces: false);
+                input: """
+                    @code {
+                     public class Foo{}
+                            void Method(  ) {<div></div>
+                    }
+                    }
+                    """,
+                expected: """
+                    @code {
+                    	public class Foo { }
+                    	void Method()
+                    	{
+                    		<div></div>
+                    	}
+                    }
+                    """,
+                tabSize: 8,
+                insertSpaces: false);
         }
 
         [Fact]
         public async Task CodeBlockDirective_UseTabsWithTabSize8()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}
-        void Method(  ) {
-}
-}
-",
-expected: @"@code {
-	public class Foo { }
-	void Method()
-	{
-	}
-}
-",
-tabSize: 8,
-insertSpaces: false);
+                input: """
+                    @code {
+                     public class Foo{}
+                            void Method(  ) {
+                    }
+                    }
+                    """,
+                expected: """
+                    @code {
+                    	public class Foo { }
+                    	void Method()
+                    	{
+                    	}
+                    }
+                    """,
+                tabSize: 8,
+                insertSpaces: false);
         }
 
         [Fact]
         public async Task CodeBlockDirective_WithTabSize3()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}
-        void Method(  ) {
-}
-}
-",
-expected: @"@code {
-   public class Foo { }
-   void Method()
-   {
-   }
-}
-",
-tabSize: 3);
+                input: """
+                    @code {
+                     public class Foo{}
+                            void Method(  ) {
+                    }
+                    }
+                    """,
+                expected: """
+                    @code {
+                       public class Foo { }
+                       void Method()
+                       {
+                       }
+                    }
+                    """,
+                tabSize: 3);
         }
 
         [Fact]
         public async Task CodeBlockDirective_WithTabSize8()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}
-        void Method(  ) {
-}
-}
-",
-expected: @"@code {
-        public class Foo { }
-        void Method()
-        {
-        }
-}
-",
-tabSize: 8);
+                input: """
+                    @code {
+                     public class Foo{}
+                            void Method(  ) {
+                    }
+                    }
+                    """,
+                expected: """
+                    @code {
+                            public class Foo { }
+                            void Method()
+                            {
+                            }
+                    }
+                    """,
+                tabSize: 8);
         }
 
         [Fact]
         public async Task CodeBlockDirective_WithTabSize12()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}
-        void Method(  ) {
-}
-}
-",
-expected: @"@code {
-            public class Foo { }
-            void Method()
-            {
-            }
-}
-",
-tabSize: 12);
+                input: """
+                    @code {
+                     public class Foo{}
+                            void Method(  ) {
+                    }
+                    }
+                    """,
+                expected: """
+                    @code {
+                                public class Foo { }
+                                void Method()
+                                {
+                                }
+                    }
+                    """,
+                tabSize: 12);
         }
 
         [Fact]
@@ -814,18 +842,18 @@ tabSize: 12);
         public async Task CodeBlock_SemiColon_SingleLine()
         {
             await RunFormattingTestAsync(
-input: @"
-<div></div>
-@{ Debugger.Launch()$$;}
-<div></div>
-",
-expected: @"
-<div></div>
-@{
-    Debugger.Launch();
-}
-<div></div>
-");
+                input: """
+                    <div></div>
+                    @{ Debugger.Launch()$$;}
+                    <div></div>
+                    """,
+                expected: """
+                    <div></div>
+                    @{
+                        Debugger.Launch();
+                    }
+                    <div></div>
+                    """);
         }
 
         [Fact]
@@ -833,37 +861,38 @@ expected: @"
         public async Task CodeBlock_NestedComponents()
         {
             await RunFormattingTestAsync(
-input: @"
-@code {
-    private WeatherForecast[] forecasts;
+                input: """
+                    @code {
+                        private WeatherForecast[] forecasts;
 
-    protected override async Task OnInitializedAsync()
-    {
-        <Counter>
-            @{
-                    var t = DateTime.Now;
-                    t.ToString();
-                }
-            </Counter>
-        forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
-    }
-}
-",
-expected: @"@code {
-    private WeatherForecast[] forecasts;
+                        protected override async Task OnInitializedAsync()
+                        {
+                            <Counter>
+                                @{
+                                        var t = DateTime.Now;
+                                        t.ToString();
+                                    }
+                                </Counter>
+                            forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        private WeatherForecast[] forecasts;
 
-    protected override async Task OnInitializedAsync()
-    {
-        <Counter>
-            @{
-                var t = DateTime.Now;
-                t.ToString();
-            }
-        </Counter>
-        forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
-    }
-}
-");
+                        protected override async Task OnInitializedAsync()
+                        {
+                            <Counter>
+                                @{
+                                    var t = DateTime.Now;
+                                    t.ToString();
+                                }
+                            </Counter>
+                            forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
+                        }
+                    }
+                    """);
         }
 
         [Fact]
@@ -873,55 +902,56 @@ expected: @"@code {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
             await RunFormattingTestAsync(
-input: @"
-@code {
-    public List<object> AList = new List<object>()
-    {
-        new
-        {
-            Name = ""One"",
-            Goo = new
-            {
-                First = 1,
-                Second = 2
-            },
-            Bar = new string[] {
-                ""Hello"",
-                ""There""
-            },
-            Baz = new string[]
-            {
-                ""Hello"",
-                ""There""
-            }
-        }
-    };
-}
-",
-expected: @"@code {
-    public List<object> AList = new List<object>()
-    {
-        new
-        {
-            Name = ""One"",
-            Goo = new
-            {
-                First = 1,
-                Second = 2
-            },
-            Bar = new string[] {
-                ""Hello"",
-                ""There""
-            },
-            Baz = new string[]
-            {
-                ""Hello"",
-                ""There""
-            }
-        }
-    };
-}
-");
+                input: """
+                    @code {
+                        public List<object> AList = new List<object>()
+                        {
+                            new
+                            {
+                                Name = "One",
+                                Goo = new
+                                {
+                                    First = 1,
+                                    Second = 2
+                                },
+                                Bar = new string[] {
+                                    "Hello",
+                                    "There"
+                                },
+                                Baz = new string[]
+                                {
+                                    "Hello",
+                                    "There"
+                                }
+                            }
+                        };
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public List<object> AList = new List<object>()
+                        {
+                            new
+                            {
+                                Name = "One",
+                                Goo = new
+                                {
+                                    First = 1,
+                                    Second = 2
+                                },
+                                Bar = new string[] {
+                                    "Hello",
+                                    "There"
+                                },
+                                Baz = new string[]
+                                {
+                                    "Hello",
+                                    "There"
+                                }
+                            }
+                        };
+                    }
+                    """);
         }
 
         [Fact]
@@ -931,31 +961,32 @@ expected: @"@code {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
             await RunFormattingTestAsync(
-input: @"
-@code {
-    private void M()
-    {
-        var entries = new string[]
-        {
-            ""a"",
-            ""b"",
-            ""c""
-        };
-    }
-}
-",
-expected: @"@code {
-    private void M()
-    {
-        var entries = new string[]
-        {
-            ""a"",
-            ""b"",
-            ""c""
-        };
-    }
-}
-");
+                input: """
+                    @code {
+                        private void M()
+                        {
+                            var entries = new string[]
+                            {
+                                "a",
+                                "b",
+                                "c"
+                            };
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        private void M()
+                        {
+                            var entries = new string[]
+                            {
+                                "a",
+                                "b",
+                                "c"
+                            };
+                        }
+                    }
+                    """);
         }
 
         [Fact]
@@ -965,29 +996,30 @@ expected: @"@code {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
             await RunFormattingTestAsync(
-input: @"
-@code {
-    private void M()
-    {
-        var entries = new
-        {
-            First = 1,
-            Second = 2
-        };
-    }
-}
-",
-expected: @"@code {
-    private void M()
-    {
-        var entries = new
-        {
-            First = 1,
-            Second = 2
-        };
-    }
-}
-");
+                input: """
+                    @code {
+                        private void M()
+                        {
+                            var entries = new
+                            {
+                                First = 1,
+                                Second = 2
+                            };
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        private void M()
+                        {
+                            var entries = new
+                            {
+                                First = 1,
+                                Second = 2
+                            };
+                        }
+                    }
+                    """);
         }
 
         [Fact]
@@ -997,31 +1029,32 @@ expected: @"@code {
             // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
             await RunFormattingTestAsync(
-input: @"
-@code {
-    private void M()
-    {
-        var entries = new List<string>()
-        {
-            ""a"",
-            ""b"",
-            ""c""
-        };
-    }
-}
-",
-expected: @"@code {
-    private void M()
-    {
-        var entries = new List<string>()
-        {
-            ""a"",
-            ""b"",
-            ""c""
-        };
-    }
-}
-");
+                input: """
+                    @code {
+                        private void M()
+                        {
+                            var entries = new List<string>()
+                            {
+                                "a",
+                                "b",
+                                "c"
+                            };
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        private void M()
+                        {
+                            var entries = new List<string>()
+                            {
+                                "a",
+                                "b",
+                                "c"
+                            };
+                        }
+                    }
+                    """);
         }
 
         [Fact]
@@ -1030,37 +1063,38 @@ expected: @"@code {
         {
             // The C# Formatter _does_ touch these types of initializers if they're empty. Who knew ¯\_(ツ)_/¯
             await RunFormattingTestAsync(
-input: @"
-@code {
-    public void Foo()
-    {
-        SomeMethod(new List<string>()
-            {
+                input: """
+                    @code {
+                        public void Foo()
+                        {
+                            SomeMethod(new List<string>()
+                                {
 
-            });
+                                });
 
-        SomeMethod(new Exception
-            {
+                            SomeMethod(new Exception
+                                {
 
-            });
-    }
-}
-",
-expected: @"@code {
-    public void Foo()
-    {
-        SomeMethod(new List<string>()
-        {
+                                });
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public void Foo()
+                        {
+                            SomeMethod(new List<string>()
+                            {
 
-        });
+                            });
 
-        SomeMethod(new Exception
-        {
+                            SomeMethod(new Exception
+                            {
 
-        });
-    }
-}
-");
+                            });
+                        }
+                    }
+                    """);
         }
 
         [Fact]
@@ -1068,15 +1102,16 @@ expected: @"@code {
         public async Task IfBlock_TopLevel()
         {
             await RunFormattingTestAsync(
-input: @"
-        @if (true)
-{
-}
-",
-expected: @"@if (true)
-{
-}
-");
+                input: """
+                            @if (true)
+                    {
+                    }
+                    """,
+                expected: """
+                    @if (true)
+                    {
+                    }
+                    """);
         }
 
         [Fact]
@@ -1084,23 +1119,24 @@ expected: @"@if (true)
         public async Task IfBlock_TopLevel_WithOtherCode()
         {
             await RunFormattingTestAsync(
-input: @"
-@{
-    // foo
-}
+                input: """
+                    @{
+                        // foo
+                    }
 
-        @if (true)
-{
-}
-",
-expected: @"@{
-    // foo
-}
+                            @if (true)
+                    {
+                    }
+                    """,
+                expected: """
+                    @{
+                        // foo
+                    }
 
-@if (true)
-{
-}
-");
+                    @if (true)
+                    {
+                    }
+                    """);
         }
 
         [Fact]
@@ -1108,20 +1144,20 @@ expected: @"@{
         public async Task IfBlock_Nested()
         {
             await RunFormattingTestAsync(
-input: @"
-<div>
-        @if (true)
-{
-}
-</div>
-",
-expected: @"
-<div>
-    @if (true)
-    {
-    }
-</div>
-");
+                input: """
+                    <div>
+                            @if (true)
+                    {
+                    }
+                    </div>
+                    """,
+                expected: """
+                    <div>
+                        @if (true)
+                        {
+                        }
+                    </div>
+                    """);
         }
 
         [Fact]
@@ -1129,54 +1165,57 @@ expected: @"
         public async Task GenericComponentWithCascadingTypeParameter()
         {
             await RunFormattingTestAsync(
-input: @"
-@page ""/counter""
+                input: """
+                    @page "/counter"
 
-@if(true)
-    {
-                // indented
-        }
+                    @if(true)
+                        {
+                                    // indented
+                            }
 
-<TestGeneric Items=""_items"">
-    @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-        {
-            <div></div>
-        }
-    </TestGeneric>
+                    <TestGeneric Items="_items">
+                        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                            {
+                                <div></div>
+                            }
+                        </TestGeneric>
 
-@if(true)
-    {
-                // indented
-            }
+                    @if(true)
+                        {
+                                    // indented
+                                }
 
-@code
-    {
-    private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
-}",
-expected: @"@page ""/counter""
+                    @code
+                        {
+                        private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
+                    }
+                    """,
+                expected: """
+                    @page "/counter"
 
-@if (true)
-{
-    // indented
-}
+                    @if (true)
+                    {
+                        // indented
+                    }
 
-<TestGeneric Items=""_items"">
-    @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-    {
-        <div></div>
-    }
-</TestGeneric>
+                    <TestGeneric Items="_items">
+                        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                        {
+                            <div></div>
+                        }
+                    </TestGeneric>
 
-@if (true)
-{
-    // indented
-}
+                    @if (true)
+                    {
+                        // indented
+                    }
 
-@code
-{
-    private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
-}",
-tagHelpers: GetComponentWithCascadingTypeParameter());
+                    @code
+                    {
+                        private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
+                    }
+                    """,
+                tagHelpers: GetComponentWithCascadingTypeParameter());
         }
 
         [Fact]
@@ -1184,46 +1223,49 @@ tagHelpers: GetComponentWithCascadingTypeParameter());
         public async Task GenericComponentWithCascadingTypeParameter_Nested()
         {
             await RunFormattingTestAsync(
-input: @"
-@page ""/counter""
+                input: """
+                    @page "/counter"
 
-<TestGeneric Items=""_items"">
-    @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-        {
-            <div></div>
-        }
-<TestGeneric Items=""_items"">
-    @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-        {
-            <div></div>
-        }
-    </TestGeneric>
-    </TestGeneric>
+                    <TestGeneric Items="_items">
+                        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                            {
+                                <div></div>
+                            }
+                    <TestGeneric Items="_items">
+                        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                            {
+                                <div></div>
+                            }
+                        </TestGeneric>
+                        </TestGeneric>
 
-@code
-    {
-    private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
-}",
-expected: @"@page ""/counter""
+                    @code
+                        {
+                        private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
+                    }
+                    """,
+                expected: """
+                    @page "/counter"
 
-<TestGeneric Items=""_items"">
-    @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-    {
-        <div></div>
-    }
-    <TestGeneric Items=""_items"">
-        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-        {
-            <div></div>
-        }
-    </TestGeneric>
-</TestGeneric>
+                    <TestGeneric Items="_items">
+                        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                        {
+                            <div></div>
+                        }
+                        <TestGeneric Items="_items">
+                            @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                            {
+                                <div></div>
+                            }
+                        </TestGeneric>
+                    </TestGeneric>
 
-@code
-{
-    private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
-}",
-tagHelpers: GetComponentWithCascadingTypeParameter());
+                    @code
+                    {
+                        private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
+                    }
+                    """,
+                tagHelpers: GetComponentWithCascadingTypeParameter());
         }
 
         [Fact]
@@ -1231,179 +1273,187 @@ tagHelpers: GetComponentWithCascadingTypeParameter());
         public async Task GenericComponentWithCascadingTypeParameter_MultipleParameters()
         {
             await RunFormattingTestAsync(
-input: @"
-@page ""/counter""
+                input: """
+                    @page "/counter"
 
-<TestGenericTwo Items=""_items"" ItemsTwo=""_items2"">
-    @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-        {
-            <div></div>
-        }
-    </TestGenericTwo>
+                    <TestGenericTwo Items="_items" ItemsTwo="_items2">
+                        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                            {
+                                <div></div>
+                            }
+                        </TestGenericTwo>
 
-@code
-    {
-    private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
-    private IEnumerable<long> _items2 = new long[] { 1, 2, 3, 4, 5 };
-}",
-expected: @"@page ""/counter""
+                    @code
+                        {
+                        private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
+                        private IEnumerable<long> _items2 = new long[] { 1, 2, 3, 4, 5 };
+                    }
+                    """,
+                expected: """
+                    @page "/counter"
 
-<TestGenericTwo Items=""_items"" ItemsTwo=""_items2"">
-    @foreach (var v in System.Linq.Enumerable.Range(1, 10))
-    {
-        <div></div>
-    }
-</TestGenericTwo>
+                    <TestGenericTwo Items="_items" ItemsTwo="_items2">
+                        @foreach (var v in System.Linq.Enumerable.Range(1, 10))
+                        {
+                            <div></div>
+                        }
+                    </TestGenericTwo>
 
-@code
-{
-    private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
-    private IEnumerable<long> _items2 = new long[] { 1, 2, 3, 4, 5 };
-}",
-tagHelpers: GetComponentWithTwoCascadingTypeParameter());
+                    @code
+                    {
+                        private IEnumerable<int> _items = new[] { 1, 2, 3, 4, 5 };
+                        private IEnumerable<long> _items2 = new long[] { 1, 2, 3, 4, 5 };
+                    }
+                    """,
+                tagHelpers: GetComponentWithTwoCascadingTypeParameter());
         }
 
         [Fact]
         public async Task Formats_MultilineExpressionAtStartOfBlock()
         {
             await RunFormattingTestAsync(
-input: @"
-@{
-    var x = DateTime
-        .Now
-        .ToString();
-}
-",
-expected: @"@{
-    var x = DateTime
-        .Now
-        .ToString();
-}
-");
+                input: """
+                    @{
+                        var x = DateTime
+                            .Now
+                            .ToString();
+                    }
+                    """,
+                expected: """
+                    @{
+                        var x = DateTime
+                            .Now
+                            .ToString();
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Formats_MultilineExpressionAfterWhitespaceAtStartOfBlock()
         {
             await RunFormattingTestAsync(
-input: @"
-@{
-    
-        
-
-    var x = DateTime
-        .Now
-        .ToString();
-}
-",
-expected: @"@{
+                input: """
+                    @{
 
 
 
-    var x = DateTime
-        .Now
-        .ToString();
-}
-");
+                        var x = DateTime
+                            .Now
+                            .ToString();
+                    }
+                    """,
+                expected: """
+                    @{
+
+
+
+                        var x = DateTime
+                            .Now
+                            .ToString();
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Formats_MultilineExpressionNotAtStartOfBlock()
         {
             await RunFormattingTestAsync(
-input: @"
-@{
-    //
-    var x = DateTime
-        .Now
-        .ToString();
-}
-",
-expected: @"@{
-    //
-    var x = DateTime
-        .Now
-        .ToString();
-}
-");
+                input: """
+                    @{
+                        //
+                        var x = DateTime
+                            .Now
+                            .ToString();
+                    }
+                    """,
+                expected: """
+                    @{
+                        //
+                        var x = DateTime
+                            .Now
+                            .ToString();
+                    }
+                    """);
         }
 
         [Fact]
         public async Task Formats_MultilineRazorComment()
         {
             await RunFormattingTestAsync(
-input: @"
-<div></div>
-    @*
-line 1
-  line 2
-    line 3
-            *@
-@code
-{
-    void M()
-    {
-    @*
-line 1
-  line 2
-    line 3
-                *@
-    }
-}
-",
-expected: @"
-<div></div>
-@*
-line 1
-  line 2
-    line 3
-            *@
-@code
-{
-    void M()
-    {
-        @*
-line 1
-  line 2
-    line 3
-                *@
-    }
-}
-");
+                input: """
+                    <div></div>
+                        @*
+                    line 1
+                      line 2
+                        line 3
+                                *@
+                    @code
+                    {
+                        void M()
+                        {
+                        @*
+                    line 1
+                      line 2
+                        line 3
+                                    *@
+                        }
+                    }
+                    """,
+                expected: """
+                    <div></div>
+                    @*
+                    line 1
+                      line 2
+                        line 3
+                                *@
+                    @code
+                    {
+                        void M()
+                        {
+                            @*
+                    line 1
+                      line 2
+                        line 3
+                                    *@
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6192")]
         public async Task Formats_NoEditsForNoChanges()
         {
-            var input = @"@code {
-    public void M()
-    {
-        Console.WriteLine(""Hello"");
-        Console.WriteLine(""World""); // <-- type/replace semicolon here
-    }
-}
-";
+            var input = """
+                @code {
+                    public void M()
+                    {
+                        Console.WriteLine("Hello");
+                        Console.WriteLine("World"); // <-- type/replace semicolon here
+                    }
+                }
+
+                """;
 
             await RunFormattingTestAsync(input, input, fileKind: FileKinds.Component);
         }
 
         private IReadOnlyList<TagHelperDescriptor> GetComponentWithCascadingTypeParameter()
         {
-            var input = @"
-@using System.Collections.Generic
-@using Microsoft.AspNetCore.Components
-@typeparam TItem
-@attribute [CascadingTypeParameter(nameof(TItem))]
+            var input = """
+                @using System.Collections.Generic
+                @using Microsoft.AspNetCore.Components
+                @typeparam TItem
+                @attribute [CascadingTypeParameter(nameof(TItem))]
 
-<h3>TestGeneric</h3>
+                <h3>TestGeneric</h3>
 
-@code
-{
-    [Parameter] public IEnumerable<TItem> Items { get; set; }
-    [Parameter] public RenderFragment ChildContent { get; set; }
-}
-            ";
+                @code
+                {
+                    [Parameter] public IEnumerable<TItem> Items { get; set; }
+                    [Parameter] public RenderFragment ChildContent { get; set; }
+                }
+                """;
 
             var generated = CompileToCSharp("TestGeneric.razor", input, throwOnFailure: true, fileKind: FileKinds.Component);
             var tagHelpers = generated.CodeDocument.GetTagHelperContext().TagHelpers;
@@ -1412,23 +1462,23 @@ line 1
 
         private IReadOnlyList<TagHelperDescriptor> GetComponentWithTwoCascadingTypeParameter()
         {
-            var input = @"
-@using System.Collections.Generic
-@using Microsoft.AspNetCore.Components
-@typeparam TItem
-@typeparam TItemTwo
-@attribute [CascadingTypeParameter(nameof(TItem))]
-@attribute [CascadingTypeParameter(nameof(TItemTwo))]
+            var input = """
+                @using System.Collections.Generic
+                @using Microsoft.AspNetCore.Components
+                @typeparam TItem
+                @typeparam TItemTwo
+                @attribute [CascadingTypeParameter(nameof(TItem))]
+                @attribute [CascadingTypeParameter(nameof(TItemTwo))]
 
-<h3>TestGeneric</h3>
+                <h3>TestGeneric</h3>
 
-@code
-{
-    [Parameter] public IEnumerable<TItem> Items { get; set; }
-    [Parameter] public IEnumerable<TItemTwo> ItemsTwo { get; set; }
-    [Parameter] public RenderFragment ChildContent { get; set; }
-}
-            ";
+                @code
+                {
+                    [Parameter] public IEnumerable<TItem> Items { get; set; }
+                    [Parameter] public IEnumerable<TItemTwo> ItemsTwo { get; set; }
+                    [Parameter] public RenderFragment ChildContent { get; set; }
+                }
+                """;
 
             var generated = CompileToCSharp("TestGenericTwo.razor", input, throwOnFailure: true, fileKind: FileKinds.Component);
             var tagHelpers = generated.CodeDocument.GetTagHelperContext().TagHelpers;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
@@ -21,209 +21,223 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task CloseCurly_Class_SingleLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}$$
-}
-",
-expected: @"
-@code {
-    public class Foo { }
-}
-", triggerCharacter: '}');
+                input: """
+                    @code {
+                     public class Foo{}$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public class Foo { }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_Class_SingleLine_UseTabsAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}$$
-}
-",
-expected: @"
-@code {
-	public class Foo { }
-}
-", triggerCharacter: '}', insertSpaces: false);
+                input: """
+                    @code {
+                     public class Foo{}$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                    	public class Foo { }
+                    }
+                    """,
+                triggerCharacter: '}',
+                insertSpaces: false);
         }
 
         [Fact]
         public async Task CloseCurly_Class_SingleLine_AdjustTabSizeAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public class Foo{}$$
-}
-",
-expected: @"
-@code {
-      public class Foo { }
-}
-", triggerCharacter: '}', tabSize: 6);
+                input: """
+                    @code {
+                     public class Foo{}$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                          public class Foo { }
+                    }
+                    """,
+                triggerCharacter: '}',
+                tabSize: 6);
         }
 
         [Fact]
         public async Task CloseCurly_Class_MultiLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public class Foo{
-}$$
-}
-",
-expected: @"
-@code {
-    public class Foo
-    {
-    }
-}
-", triggerCharacter: '}');
+                input: """
+                    @code {
+                     public class Foo{
+                    }$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public class Foo
+                        {
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_Method_SingleLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public void Foo{}$$
-}
-",
-expected: @"
-@code {
-    public void Foo { }
-}
-", triggerCharacter: '}');
+                input: """
+                    @code {
+                     public void Foo{}$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public void Foo { }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_Method_MultiLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public void Foo{
-}$$
-}
-",
-expected: @"
-@code {
-    public void Foo
-    {
-    }
-}
-", triggerCharacter: '}');
+                input: """
+                    @code {
+                     public void Foo{
+                    }$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public void Foo
+                        {
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_Property_SingleLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public string Foo{ get;set;}$$
-}
-",
-expected: @"
-@code {
-    public string Foo { get; set; }
-}
-", triggerCharacter: '}');
+                input: """
+                    @code {
+                     public string Foo{ get;set;}$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public string Foo { get; set; }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_Property_MultiLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public string Foo{
-get;set;}$$
-}
-",
-expected: @"
-@code {
-    public string Foo
-    {
-        get; set;
-    }
-}
-", triggerCharacter: '}');
+                input: """
+                    @code {
+                     public string Foo{
+                    get;set;}$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public string Foo
+                        {
+                            get; set;
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task CloseCurly_Property_StartOfBlockAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code { public string Foo{ get;set;}$$
-}
-",
-expected: @"
-@code {
-    public string Foo { get; set; }
-}
-", triggerCharacter: '}');
+                input: """
+                    @code { public string Foo{ get;set;}$$
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public string Foo { get; set; }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task Semicolon_ClassField_SingleLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
- public class Foo {private int _hello = 0;$$}
-}
-",
-expected: @"
-@code {
-    public class Foo { private int _hello = 0; }
-}
-", triggerCharacter: ';');
+                input: """
+                    @code {
+                     public class Foo {private int _hello = 0;$$}
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public class Foo { private int _hello = 0; }
+                    }
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
         public async Task Semicolon_ClassField_MultiLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
-    public class Foo{
-private int _hello = 0;$$ }
-}
-",
-expected: @"
-@code {
-    public class Foo{
-        private int _hello = 0; }
-}
-", triggerCharacter: ';');
+                input: """
+                    @code {
+                        public class Foo{
+                    private int _hello = 0;$$ }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public class Foo{
+                            private int _hello = 0; }
+                    }
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
         public async Task Semicolon_MethodVariableAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code {
-    public void Foo()
-    {
-                            var hello = 0;$$
-    }
-}
-",
-expected: @"
-@code {
-    public void Foo()
-    {
-        var hello = 0;
-    }
-}
-", triggerCharacter: ';');
+                input: """
+                    @code {
+                        public void Foo()
+                        {
+                                                var hello = 0;$$
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public void Foo()
+                        {
+                            var hello = 0;
+                        }
+                    }
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
@@ -231,122 +245,129 @@ expected: @"
         public async Task Semicolon_Fluent_CallAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"@implements IDisposable
+                input: """
+                    @implements IDisposable
 
-@code{
-    protected override async Task OnInitializedAsync()
-    {
-        hubConnection = new HubConnectionBuilder()
-            .WithUrl(NavigationManager.ToAbsoluteUri(""/chathub""))
-            .Build();$$
-    }
-}
-",
-expected: @"@implements IDisposable
+                    @code{
+                        protected override async Task OnInitializedAsync()
+                        {
+                            hubConnection = new HubConnectionBuilder()
+                                .WithUrl(NavigationManager.ToAbsoluteUri("/chathub"))
+                                .Build();$$
+                        }
+                    }
 
-@code{
-    protected override async Task OnInitializedAsync()
-    {
-        hubConnection = new HubConnectionBuilder()
-            .WithUrl(NavigationManager.ToAbsoluteUri(""/chathub""))
-            .Build();
-    }
-}
-", triggerCharacter: ';');
+                    """,
+                expected: """
+                    @implements IDisposable
+
+                    @code{
+                        protected override async Task OnInitializedAsync()
+                        {
+                            hubConnection = new HubConnectionBuilder()
+                                .WithUrl(NavigationManager.ToAbsoluteUri("/chathub"))
+                                .Build();
+                        }
+                    }
+
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
         public async Task ClosingBrace_MatchesCSharpIndentationAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@page ""/counter""
+                input: """
+                    @page "/counter"
 
-<h1>Counter</h1>
+                    <h1>Counter</h1>
 
-<p>Current count: @currentCount</p>
+                    <p>Current count: @currentCount</p>
 
-<button class=""btn btn-primary"" @onclick=""IncrementCount"">Click me</button>
+                    <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
-@code {
-    private int currentCount = 0;
+                    @code {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-        if (true){
-            }$$
-    }
-}
-",
-expected: @"
-@page ""/counter""
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                            if (true){
+                                }$$
+                        }
+                    }
+                    """,
+                expected: """
+                    @page "/counter"
 
-<h1>Counter</h1>
+                    <h1>Counter</h1>
 
-<p>Current count: @currentCount</p>
+                    <p>Current count: @currentCount</p>
 
-<button class=""btn btn-primary"" @onclick=""IncrementCount"">Click me</button>
+                    <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
-@code {
-    private int currentCount = 0;
+                    @code {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-        if (true)
-        {
-        }
-    }
-}
-", triggerCharacter: '}');
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                            if (true)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         public async Task ClosingBrace_DoesntMatchCSharpIndentationAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@page ""/counter""
+                input: """
+                    @page "/counter"
 
-<h1>Counter</h1>
+                    <h1>Counter</h1>
 
-<p>Current count: @currentCount</p>
+                    <p>Current count: @currentCount</p>
 
-<button class=""btn btn-primary"" @onclick=""IncrementCount"">Click me</button>
+                    <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
-@code {
-    private int currentCount = 0;
+                    @code {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-        if (true){
-                }$$
-    }
-}
-",
-expected: @"
-@page ""/counter""
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                            if (true){
+                                    }$$
+                        }
+                    }
+                    """,
+                expected: """
+                    @page "/counter"
 
-<h1>Counter</h1>
+                    <h1>Counter</h1>
 
-<p>Current count: @currentCount</p>
+                    <p>Current count: @currentCount</p>
 
-<button class=""btn btn-primary"" @onclick=""IncrementCount"">Click me</button>
+                    <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
-@code {
-    private int currentCount = 0;
+                    @code {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-        if (true)
-        {
-        }
-    }
-}
-", triggerCharacter: '}');
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                            if (true)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
@@ -354,18 +375,19 @@ expected: @"
         public async Task CodeBlock_SemiColon_SingleLine1Async()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-<div></div>
-@{ Debugger.Launch();$$}
-<div></div>
-",
-expected: @"
-<div></div>
-@{
-    Debugger.Launch();
-}
-<div></div>
-", triggerCharacter: ';');
+                input: """
+                    <div></div>
+                    @{ Debugger.Launch();$$}
+                    <div></div>
+                    """,
+                expected: """
+                    <div></div>
+                    @{
+                        Debugger.Launch();
+                    }
+                    <div></div>
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
@@ -373,18 +395,19 @@ expected: @"
         public async Task CodeBlock_SemiColon_SingleLine2Async()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-<div></div>
-@{     Debugger.Launch(   )     ;$$ }
-<div></div>
-",
-expected: @"
-<div></div>
-@{
-    Debugger.Launch(); 
-}
-<div></div>
-", triggerCharacter: ';');
+                input: """
+                    <div></div>
+                    @{     Debugger.Launch(   )     ;$$ }
+                    <div></div>
+                    """,
+                expected: """
+                    <div></div>
+                    @{
+                        Debugger.Launch(); 
+                    }
+                    <div></div>
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
@@ -392,18 +415,19 @@ expected: @"
         public async Task CodeBlock_SemiColon_SingleLine3Async()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-<div>
-    @{     Debugger.Launch(   )     ;$$ }
-</div>
-",
-expected: @"
-<div>
-    @{
-        Debugger.Launch(); 
-    }
-</div>
-", triggerCharacter: ';');
+                input: """
+                    <div>
+                        @{     Debugger.Launch(   )     ;$$ }
+                    </div>
+                    """,
+                expected: """
+                    <div>
+                        @{
+                            Debugger.Launch(); 
+                        }
+                    </div>
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
@@ -411,20 +435,21 @@ expected: @"
         public async Task CodeBlock_SemiColon_MultiLineAsync()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-<div></div>
-@{
-    var abc = 123;$$
-}
-<div></div>
-",
-expected: @"
-<div></div>
-@{
-    var abc = 123;
-}
-<div></div>
-", triggerCharacter: ';');
+                input: """
+                    <div></div>
+                    @{
+                        var abc = 123;$$
+                    }
+                    <div></div>
+                    """,
+                expected: """
+                    <div></div>
+                    @{
+                        var abc = 123;
+                    }
+                    <div></div>
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
@@ -432,40 +457,41 @@ expected: @"
         public async Task Switch_Statment_NestedHtml_NestedCodeBlock()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@switch (""asdf"")
-{
-    case ""asdf"":
-        <div>
-            @if (true)
-            {
-                <strong></strong>
-            }
-            else if (false)
-            {
-1.ToString();$$
-            }
-        </div>
-        break;
-}
-",
-expected: @"
-@switch (""asdf"")
-{
-    case ""asdf"":
-        <div>
-            @if (true)
-            {
-                <strong></strong>
-            }
-            else if (false)
-            {
-                1.ToString();
-            }
-        </div>
-        break;
-}
-", triggerCharacter: ';');
+                input: """
+                    @switch ("asdf")
+                    {
+                        case "asdf":
+                            <div>
+                                @if (true)
+                                {
+                                    <strong></strong>
+                                }
+                                else if (false)
+                                {
+                    1.ToString();$$
+                                }
+                            </div>
+                            break;
+                    }
+                    """,
+                expected: """
+                    @switch ("asdf")
+                    {
+                        case "asdf":
+                            <div>
+                                @if (true)
+                                {
+                                    <strong></strong>
+                                }
+                                else if (false)
+                                {
+                                    1.ToString();
+                                }
+                            </div>
+                            break;
+                    }
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact]
@@ -473,36 +499,37 @@ expected: @"
         public async Task NestedHtml_NestedCodeBlock()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@if (true)
-{
-    <div>
-        @if (true)
-        {
-            <strong></strong>
-        }
-        else if (false)
-        {
-1.ToString();$$
-        }
-    </div>
-}
-",
-expected: @"
-@if (true)
-{
-    <div>
-        @if (true)
-        {
-            <strong></strong>
-        }
-        else if (false)
-        {
-            1.ToString();
-        }
-    </div>
-}
-", triggerCharacter: ';');
+                input: """
+                    @if (true)
+                    {
+                        <div>
+                            @if (true)
+                            {
+                                <strong></strong>
+                            }
+                            else if (false)
+                            {
+                    1.ToString();$$
+                            }
+                        </div>
+                    }
+                    """,
+                expected: """
+                    @if (true)
+                    {
+                        <div>
+                            @if (true)
+                            {
+                                <strong></strong>
+                            }
+                            else if (false)
+                            {
+                                1.ToString();
+                            }
+                        </div>
+                    }
+                    """,
+                triggerCharacter: ';');
         }
 
         [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/36390")]
@@ -510,34 +537,35 @@ expected: @"
         public async Task NestedHtml_NestedCodeBlock_EndingBrace()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@if (true)
-{
-    <div>
-        @if (true)
-        {
-            <strong></strong>
-        }
-        else if (false)
-        {
-            }$$
-    </div>
-}
-",
-expected: @"
-@if (true)
-{
-    <div>
-        @if (true)
-        {
-            <strong></strong>
-        }
-        else if (false)
-        {
-        }
-    </div>
-}
-", triggerCharacter: '}');
+                input: """
+                    @if (true)
+                    {
+                        <div>
+                            @if (true)
+                            {
+                                <strong></strong>
+                            }
+                            else if (false)
+                            {
+                                }$$
+                        </div>
+                    }
+                    """,
+                expected: """
+                    @if (true)
+                    {
+                        <div>
+                            @if (true)
+                            {
+                                <strong></strong>
+                            }
+                            else if (false)
+                            {
+                            }
+                        </div>
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/36390")]
@@ -545,52 +573,53 @@ expected: @"
         public async Task NestedHtml_NestedCodeBlock_EndingBrace_WithCode()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@if (true)
-{
-    <div>
-        @if (true)
-        {
-            <strong></strong>
-        }
-        else if (false)
-        {
-            ""asdf"".ToString();
-            }$$
-    </div>
-}
-",
-expected: @"
-@if (true)
-{
-    <div>
-        @if (true)
-        {
-            <strong></strong>
-        }
-        else if (false)
-        {
-            ""asdf"".ToString();
-        }
-    </div>
-}
-", triggerCharacter: '}');
+                input: """
+                    @if (true)
+                    {
+                        <div>
+                            @if (true)
+                            {
+                                <strong></strong>
+                            }
+                            else if (false)
+                            {
+                                "asdf".ToString();
+                                }$$
+                        </div>
+                    }
+                    """,
+                expected: """
+                    @if (true)
+                    {
+                        <div>
+                            @if (true)
+                            {
+                                <strong></strong>
+                            }
+                            else if (false)
+                            {
+                                "asdf".ToString();
+                            }
+                        </div>
+                    }
+                    """,
+                triggerCharacter: '}');
         }
 
         [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/5698")]
         public async Task Semicolon_NoDocumentChanges()
         {
-            var input = @"
-@page ""/""
+            var input = """
+                @page "/"
 
-@code {
-    void Foo()
-    {
-        DateTime.Now;$$
-    }
-}
-";
+                @code {
+                    void Foo()
+                    {
+                        DateTime.Now;$$
+                    }
+                }
+                """;
 
             await RunOnTypeFormattingTestAsync(input, input.Replace("$$", ""), triggerCharacter: ';');
         }
@@ -600,36 +629,37 @@ expected: @"
         public async Task IfStatementInsideLambda()
         {
             await RunOnTypeFormattingTestAsync(
-input: @"
-@code
-{
-    public RenderFragment RenderFoo()
-    {
-        return (__builder) =>
-        {
-            @if (true)
-            {
+                input: """
+                    @code
+                    {
+                        public RenderFragment RenderFoo()
+                        {
+                            return (__builder) =>
+                            {
+                                @if (true)
+                                {
 
-            }$$
-        };
-    }
-}
-",
-expected: @"
-@code
-{
-    public RenderFragment RenderFoo()
-    {
-        return (__builder) =>
-        {
-            @if (true)
-            {
+                                }$$
+                            };
+                        }
+                    }
+                    """,
+                expected: """
+                    @code
+                    {
+                        public RenderFragment RenderFoo()
+                        {
+                            return (__builder) =>
+                            {
+                                @if (true)
+                                {
 
-            }
-        };
-    }
-}
-", triggerCharacter: '}');
+                                }
+                            };
+                        }
+                    }
+                    """,
+                triggerCharacter: '}');
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -254,15 +254,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var sourceDocument = text.GetRazorSourceDocument(path, path);
 
             // Yes I know "BlazorServer_31 is weird, but thats what is in the taghelpers.json file
-            const string DefaultImports = @"
-@using BlazorServer_31
-@using BlazorServer_31.Pages
-@using BlazorServer_31.Shared
-@using Microsoft.AspNetCore.Components
-@using Microsoft.AspNetCore.Components.Authorization
-@using Microsoft.AspNetCore.Components.Routing
-@using Microsoft.AspNetCore.Components.Web
-";
+            const string DefaultImports = """
+                @using BlazorServer_31
+                @using BlazorServer_31.Pages
+                @using BlazorServer_31.Shared
+                @using Microsoft.AspNetCore.Components
+                @using Microsoft.AspNetCore.Components.Authorization
+                @using Microsoft.AspNetCore.Components.Routing
+                @using Microsoft.AspNetCore.Components.Web
+                """;
 
             var importsPath = new Uri("file:///path/to/_Imports.razor").AbsolutePath;
             var importsSourceText = SourceText.From(DefaultImports);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -27,357 +27,368 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task FormatsSimpleHtmlTag()
         {
             await RunFormattingTestAsync(
-input: @"
-   <html>
-<head>
-   <title>Hello</title></head>
-<body><div>
-</div>
-        </body>
- </html>
-",
-expected: @"
-<html>
-<head>
-    <title>Hello</title>
-</head>
-<body>
-    <div>
-    </div>
-</body>
-</html>
-");
+                input: """
+                       <html>
+                    <head>
+                       <title>Hello</title></head>
+                    <body><div>
+                    </div>
+                            </body>
+                     </html>
+                    """,
+                expected: """
+                    <html>
+                    <head>
+                        <title>Hello</title>
+                    </head>
+                    <body>
+                        <div>
+                        </div>
+                    </body>
+                    </html>
+                    """);
         }
 
         [Fact]
         public async Task FormatsSimpleHtmlTag_Range()
         {
             await RunFormattingTestAsync(
-input: @"
-<html>
-<head>
-    <title>Hello</title>
-</head>
-<body>
-        [|<div>
-        </div>|]
-</body>
-</html>
-",
-expected: @"
-<html>
-<head>
-    <title>Hello</title>
-</head>
-<body>
-    <div>
-    </div>
-</body>
-</html>
-");
+                input: """
+                    <html>
+                    <head>
+                        <title>Hello</title>
+                    </head>
+                    <body>
+                            [|<div>
+                            </div>|]
+                    </body>
+                    </html>
+                    """,
+                expected: """
+                    <html>
+                    <head>
+                        <title>Hello</title>
+                    </head>
+                    <body>
+                        <div>
+                        </div>
+                    </body>
+                    </html>
+                    """);
         }
 
         [Fact]
         public async Task FormatsRazorHtmlBlock()
         {
             await RunFormattingTestAsync(
-input: @"@page ""/error""
+                input: """
+                    @page "/error"
 
-        <h1 class=
-""text-danger"">Error.</h1>
-    <h2 class=""text-danger"">An error occurred while processing your request.</h2>
+                            <h1 class=
+                    "text-danger">Error.</h1>
+                        <h2 class="text-danger">An error occurred while processing your request.</h2>
 
-            <h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.
-</strong>
-            <div>
- <div>
-    <div>
-<div>
-        This is heavily nested
-</div>
- </div>
-    </div>
-        </div>
-</p>
-",
-expected: @"@page ""/error""
+                                <h3>Development Mode</h3>
+                    <p>
+                        Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.</p>
+                    <p>
+                        <strong>The Development environment shouldn't be enabled for deployed applications.
+                    </strong>
+                                <div>
+                     <div>
+                        <div>
+                    <div>
+                            This is heavily nested
+                    </div>
+                     </div>
+                        </div>
+                            </div>
+                    </p>
+                    """,
+                expected: """
+                    @page "/error"
 
-<h1 class=""text-danger"">
-    Error.
-</h1>
-<h2 class=""text-danger"">An error occurred while processing your request.</h2>
+                    <h1 class="text-danger">
+                        Error.
+                    </h1>
+                    <h2 class="text-danger">An error occurred while processing your request.</h2>
 
-<h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-</p>
-<p>
-    <strong>
-        The Development environment shouldn't be enabled for deployed applications.
-    </strong>
-    <div>
-        <div>
-            <div>
-                <div>
-                    This is heavily nested
-                </div>
-            </div>
-        </div>
-    </div>
-</p>
-");
+                    <h3>Development Mode</h3>
+                    <p>
+                        Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
+                    </p>
+                    <p>
+                        <strong>
+                            The Development environment shouldn't be enabled for deployed applications.
+                        </strong>
+                        <div>
+                            <div>
+                                <div>
+                                    <div>
+                                        This is heavily nested
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </p>
+                    """);
         }
 
         [Fact]
         public async Task FormatsMixedHtmlBlock()
         {
             await RunFormattingTestAsync(
-input: @"@page ""/test""
-@{
-<p>
-        @{
-                var t = 1;
-if (true)
-{
+                input: """
+                    @page "/test"
+                    @{
+                    <p>
+                            @{
+                                    var t = 1;
+                    if (true)
+                    {
 
-            }
-        }
-        </p>
-<div>
- @{
-    <div>
-<div>
-        This is heavily nested
-</div>
- </div>
-    }
-        </div>
-}
-",
-expected: @"@page ""/test""
-@{
-    <p>
-        @{
-            var t = 1;
-            if (true)
-            {
+                                }
+                            }
+                            </p>
+                    <div>
+                     @{
+                        <div>
+                    <div>
+                            This is heavily nested
+                    </div>
+                     </div>
+                        }
+                            </div>
+                    }
+                    """,
+                expected: """
+                    @page "/test"
+                    @{
+                        <p>
+                            @{
+                                var t = 1;
+                                if (true)
+                                {
 
-            }
-        }
-    </p>
-    <div>
-        @{
-            <div>
-                <div>
-                    This is heavily nested
-                </div>
-            </div>
-        }
-    </div>
-}
-");
+                                }
+                            }
+                        </p>
+                        <div>
+                            @{
+                                <div>
+                                    <div>
+                                        This is heavily nested
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    }
+                    """);
         }
 
         [Fact]
         public async Task FormatsMixedRazorBlock()
         {
             await RunFormattingTestAsync(
-input: @"@page ""/test""
+                input: """
+                    @page "/test"
 
-<div class=@className>Some Text</div>
+                    <div class=@className>Some Text</div>
 
-@{
-@: Hi!
-var x = 123;
-<p>
-        @if (true) {
-                var t = 1;
-if (true)
-{
-<div>@DateTime.Now</div>
-            }
+                    @{
+                    @: Hi!
+                    var x = 123;
+                    <p>
+                            @if (true) {
+                                    var t = 1;
+                    if (true)
+                    {
+                    <div>@DateTime.Now</div>
+                                }
 
-            @while(true){
- }
-        }
-        </p>
-}
-",
-expected: @"@page ""/test""
+                                @while(true){
+                     }
+                            }
+                            </p>
+                    }
+                    """,
+                expected: """
+                    @page "/test"
 
-<div class=@className>Some Text</div>
+                    <div class=@className>Some Text</div>
 
-@{
-    @: Hi!
-    var x = 123;
-    <p>
-        @if (true)
-        {
-            var t = 1;
-            if (true)
-            {
-                <div>@DateTime.Now</div>
-            }
+                    @{
+                        @: Hi!
+                        var x = 123;
+                        <p>
+                            @if (true)
+                            {
+                                var t = 1;
+                                if (true)
+                                {
+                                    <div>@DateTime.Now</div>
+                                }
 
-            @while (true)
-            {
-            }
-        }
-    </p>
-}
-");
+                                @while (true)
+                                {
+                                }
+                            }
+                        </p>
+                    }
+                    """);
         }
 
         [Fact]
         public async Task FormatsMixedContentWithMultilineExpressions()
         {
             await RunFormattingTestAsync(
-input: @"@page ""/test""
+                input: """
+                    @page "/test"
 
-<div
-attr='val'
-class=@className>Some Text</div>
+                    <div
+                    attr='val'
+                    class=@className>Some Text</div>
 
-@{
-@: Hi!
-var x = DateTime
-    .Now.ToString();
-<p>
-        @if (true) {
-                var t = 1;
-        }
-        </p>
-}
+                    @{
+                    @: Hi!
+                    var x = DateTime
+                        .Now.ToString();
+                    <p>
+                            @if (true) {
+                                    var t = 1;
+                            }
+                            </p>
+                    }
 
-@(DateTime
-    .Now
-.ToString())
+                    @(DateTime
+                        .Now
+                    .ToString())
 
-@(
-    Foo.Values.Select(f =>
-    {
-        return f.ToString();
-    })
-)
-",
-expected: @"@page ""/test""
+                    @(
+                        Foo.Values.Select(f =>
+                        {
+                            return f.ToString();
+                        })
+                    )
+                    """,
+                expected: """
+                    @page "/test"
 
-<div attr='val'
-     class=@className>
-    Some Text
-</div>
+                    <div attr='val'
+                         class=@className>
+                        Some Text
+                    </div>
 
-@{
-    @: Hi!
-    var x = DateTime
-        .Now.ToString();
-    <p>
-        @if (true)
-        {
-            var t = 1;
-        }
-    </p>
-}
+                    @{
+                        @: Hi!
+                        var x = DateTime
+                            .Now.ToString();
+                        <p>
+                            @if (true)
+                            {
+                                var t = 1;
+                            }
+                        </p>
+                    }
 
-@(DateTime
-    .Now
-.ToString())
+                    @(DateTime
+                        .Now
+                    .ToString())
 
-@(
-    Foo.Values.Select(f =>
-    {
-        return f.ToString();
-    })
-)
-");
+                    @(
+                        Foo.Values.Select(f =>
+                        {
+                            return f.ToString();
+                        })
+                    )
+                    """);
         }
 
         [Fact]
         public async Task FormatsComplexBlock()
         {
             await RunFormattingTestAsync(
-input: @"@page ""/""
+                input: """
+                    @page "/"
 
-<h1>Hello, world!</h1>
+                    <h1>Hello, world!</h1>
 
-        Welcome to your new app.
+                            Welcome to your new app.
 
-<SurveyPrompt Title=""How is Blazor working for you?"" />
+                    <SurveyPrompt Title="How is Blazor working for you?" />
 
-<div class=""FF""
-     id=""ERT"">
-     asdf
-    <div class=""3""
-         id=""3"">
-             @if(true){<p></p>}
-         </div>
-</div>
+                    <div class="FF"
+                         id="ERT">
+                         asdf
+                        <div class="3"
+                             id="3">
+                                 @if(true){<p></p>}
+                             </div>
+                    </div>
 
-@{
-<div class=""FF""
-    id=""ERT"">
-    asdf
-    <div class=""3""
-        id=""3"">
-            @if(true){<p></p>}
-        </div>
-</div>
-}
+                    @{
+                    <div class="FF"
+                        id="ERT">
+                        asdf
+                        <div class="3"
+                            id="3">
+                                @if(true){<p></p>}
+                            </div>
+                    </div>
+                    }
 
-@functions {
-        public class Foo
-    {
-        @* This is a Razor Comment *@
-        void Method() { }
-    }
-}
-",
-expected: @"@page ""/""
+                    @functions {
+                            public class Foo
+                        {
+                            @* This is a Razor Comment *@
+                            void Method() { }
+                        }
+                    }
+                    """,
+                expected: """
+                    @page "/"
 
-<h1>Hello, world!</h1>
+                    <h1>Hello, world!</h1>
 
-        Welcome to your new app.
+                            Welcome to your new app.
 
-<SurveyPrompt Title=""How is Blazor working for you?"" />
+                    <SurveyPrompt Title="How is Blazor working for you?" />
 
-<div class=""FF""
-     id=""ERT"">
-    asdf
-    <div class=""3""
-         id=""3"">
-        @if (true)
-        {
-            <p></p>
-        }
-    </div>
-</div>
+                    <div class="FF"
+                         id="ERT">
+                        asdf
+                        <div class="3"
+                             id="3">
+                            @if (true)
+                            {
+                                <p></p>
+                            }
+                        </div>
+                    </div>
 
-@{
-    <div class=""FF""
-         id=""ERT"">
-        asdf
-        <div class=""3""
-             id=""3"">
-            @if (true)
-            {
-                <p></p>
-            }
-        </div>
-    </div>
-}
+                    @{
+                        <div class="FF"
+                             id="ERT">
+                            asdf
+                            <div class="3"
+                                 id="3">
+                                @if (true)
+                                {
+                                    <p></p>
+                                }
+                            </div>
+                        </div>
+                    }
 
-@functions {
-    public class Foo
-    {
-        @* This is a Razor Comment *@
-        void Method() { }
-    }
-}
-", tagHelpers: GetSurveyPrompt());
+                    @functions {
+                        public class Foo
+                        {
+                            @* This is a Razor Comment *@
+                            void Method() { }
+                        }
+                    }
+                    """,
+                tagHelpers: GetSurveyPrompt());
         }
 
         [Fact]
@@ -385,52 +396,56 @@ expected: @"@page ""/""
         {
             var tagHelpers = GetComponents();
             await RunFormattingTestAsync(
-input: @"
-   <Counter>
-    @if(true){
-        <p>@DateTime.Now</p>
-}
-</Counter>
+                input: """
+                       <Counter>
+                        @if(true){
+                            <p>@DateTime.Now</p>
+                    }
+                    </Counter>
 
-    <GridTable>
-    @foreach (var row in rows){
-        <GridRow @onclick=""SelectRow(row)"">
-        @foreach (var cell in row){
-    <GridCell>@cell</GridCell>}</GridRow>
-    }
-</GridTable>
-",
-expected: @"
-<Counter>
-    @if (true)
-    {
-        <p>@DateTime.Now</p>
-    }
-</Counter>
+                        <GridTable>
+                        @foreach (var row in rows){
+                            <GridRow @onclick="SelectRow(row)">
+                            @foreach (var cell in row){
+                        <GridCell>@cell</GridCell>}</GridRow>
+                        }
+                    </GridTable>
+                    """,
+                expected: """
+                    <Counter>
+                        @if (true)
+                        {
+                            <p>@DateTime.Now</p>
+                        }
+                    </Counter>
 
-<GridTable>
-    @foreach (var row in rows)
-    {
-        <GridRow @onclick=""SelectRow(row)"">
-            @foreach (var cell in row)
-            {
-                <GridCell>@cell</GridCell>
-            }
-        </GridRow>
-    }
-</GridTable>
-",
-tagHelpers: tagHelpers);
+                    <GridTable>
+                        @foreach (var row in rows)
+                        {
+                            <GridRow @onclick="SelectRow(row)">
+                                @foreach (var cell in row)
+                                {
+                                    <GridCell>@cell</GridCell>
+                                }
+                            </GridRow>
+                        }
+                    </GridTable>
+                    """,
+                tagHelpers: tagHelpers);
         }
 
         [Fact]
         public async Task FormatsShortBlock()
         {
             await RunFormattingTestAsync(
-                input: @"@{<p></p>}",
-                expected: @"@{
-    <p></p>
-}");
+                input: """
+                    @{<p></p>}
+                    """,
+                expected: """
+                    @{
+                        <p></p>
+                    }
+                    """);
         }
 
         [Fact]
@@ -438,28 +453,30 @@ tagHelpers: tagHelpers);
         public async Task FormatNestedBlock()
         {
             await RunFormattingTestAsync(
-input: @"@code {
-    public string DoSomething()
-    {
-        <strong>
-            @DateTime.Now.ToString()
-        </strong>
+                input: """
+                    @code {
+                        public string DoSomething()
+                        {
+                            <strong>
+                                @DateTime.Now.ToString()
+                            </strong>
 
-        return String.Empty;
-    }
-}
-",
-expected: @"@code {
-    public string DoSomething()
-    {
-        <strong>
-            @DateTime.Now.ToString()
-        </strong>
+                            return String.Empty;
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public string DoSomething()
+                        {
+                            <strong>
+                                @DateTime.Now.ToString()
+                            </strong>
 
-        return String.Empty;
-    }
-}
-");
+                            return String.Empty;
+                        }
+                    }
+                    """);
         }
 
         [Fact]
@@ -467,30 +484,32 @@ expected: @"@code {
         public async Task FormatNestedBlock_Tabs()
         {
             await RunFormattingTestAsync(
-input: @"@code {
-    public string DoSomething()
-    {
-        <strong>
-            @DateTime.Now.ToString()
-        </strong>
+                input: """
+                    @code {
+                        public string DoSomething()
+                        {
+                            <strong>
+                                @DateTime.Now.ToString()
+                            </strong>
 
-        return String.Empty;
-    }
-}
-",
-expected: @"@code {
-	public string DoSomething()
-	{
-		<strong>
-			@DateTime.Now.ToString()
-		</strong>
+                            return String.Empty;
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                    	public string DoSomething()
+                    	{
+                    		<strong>
+                    			@DateTime.Now.ToString()
+                    		</strong>
 
-		return String.Empty;
-	}
-}
-",
-tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
-insertSpaces: false);
+                    		return String.Empty;
+                    	}
+                    }
+                    """,
+                tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
+                insertSpaces: false);
         }
 
         [Fact]
@@ -498,44 +517,45 @@ insertSpaces: false);
         public async Task FormatHtmlWithTabs1()
         {
             await RunFormattingTestAsync(
-input: @"
-@page ""/""
-@{
- ViewData[""Title""] = ""Create"";
- <hr />
- <div class=""row"">
-  <div class=""col-md-4"">
-   <form method=""post"">
-    <div class=""form-group"">
-     <label asp-for=""Movie.Title"" class=""control-label""></label>
-     <input asp-for=""Movie.Title"" class=""form-control"" />
-     <span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
-    </div>
-   </form>
-  </div>
- </div>
-}
-",
-expected: @"@page ""/""
-@{
-	ViewData[""Title""] = ""Create"";
-	<hr />
-	<div class=""row"">
-		<div class=""col-md-4"">
-			<form method=""post"">
-				<div class=""form-group"">
-					<label asp-for=""Movie.Title"" class=""control-label""></label>
-					<input asp-for=""Movie.Title"" class=""form-control"" />
-					<span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
-				</div>
-			</form>
-		</div>
-	</div>
-}
-",
-tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
-insertSpaces: false,
-fileKind: FileKinds.Legacy);
+                input: """
+                    @page "/"
+                    @{
+                     ViewData["Title"] = "Create";
+                     <hr />
+                     <div class="row">
+                      <div class="col-md-4">
+                       <form method="post">
+                        <div class="form-group">
+                         <label asp-for="Movie.Title" class="control-label"></label>
+                         <input asp-for="Movie.Title" class="form-control" />
+                         <span asp-validation-for="Movie.Title" class="text-danger"></span>
+                        </div>
+                       </form>
+                      </div>
+                     </div>
+                    }
+                    """,
+                expected: """
+                    @page "/"
+                    @{
+                    	ViewData["Title"] = "Create";
+                    	<hr />
+                    	<div class="row">
+                    		<div class="col-md-4">
+                    			<form method="post">
+                    				<div class="form-group">
+                    					<label asp-for="Movie.Title" class="control-label"></label>
+                    					<input asp-for="Movie.Title" class="form-control" />
+                    					<span asp-validation-for="Movie.Title" class="text-danger"></span>
+                    				</div>
+                    			</form>
+                    		</div>
+                    	</div>
+                    }
+                    """,
+                tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
+                insertSpaces: false,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
@@ -543,40 +563,41 @@ fileKind: FileKinds.Legacy);
         public async Task FormatHtmlWithTabs2()
         {
             await RunFormattingTestAsync(
-input: @"
-@page ""/""
+                input: """
+                    @page "/"
 
- <hr />
- <div class=""row"">
-  <div class=""col-md-4"">
-   <form method=""post"">
-    <div class=""form-group"">
-     <label asp-for=""Movie.Title"" class=""control-label""></label>
-     <input asp-for=""Movie.Title"" class=""form-control"" />
-     <span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
-    </div>
-   </form>
-  </div>
- </div>
-",
-expected: @"@page ""/""
+                     <hr />
+                     <div class="row">
+                      <div class="col-md-4">
+                       <form method="post">
+                        <div class="form-group">
+                         <label asp-for="Movie.Title" class="control-label"></label>
+                         <input asp-for="Movie.Title" class="form-control" />
+                         <span asp-validation-for="Movie.Title" class="text-danger"></span>
+                        </div>
+                       </form>
+                      </div>
+                     </div>
+                    """,
+                expected: """
+                    @page "/"
 
-<hr />
-<div class=""row"">
-	<div class=""col-md-4"">
-		<form method=""post"">
-			<div class=""form-group"">
-				<label asp-for=""Movie.Title"" class=""control-label""></label>
-				<input asp-for=""Movie.Title"" class=""form-control"" />
-				<span asp-validation-for=""Movie.Title"" class=""text-danger""></span>
-			</div>
-		</form>
-	</div>
-</div>
-",
-tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
-insertSpaces: false,
-fileKind: FileKinds.Legacy);
+                    <hr />
+                    <div class="row">
+                    	<div class="col-md-4">
+                    		<form method="post">
+                    			<div class="form-group">
+                    				<label asp-for="Movie.Title" class="control-label"></label>
+                    				<input asp-for="Movie.Title" class="form-control" />
+                    				<span asp-validation-for="Movie.Title" class="text-danger"></span>
+                    			</div>
+                    		</form>
+                    	</div>
+                    </div>
+                    """,
+                tabSize: 4, // Due to a bug in the HTML formatter, this needs to be 4
+                insertSpaces: false,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
@@ -584,44 +605,44 @@ fileKind: FileKinds.Legacy);
         public async Task FormatNestedComponents()
         {
             await RunFormattingTestAsync(
-input: @"
-<CascadingAuthenticationState>
-<Router AppAssembly=""@typeof(Program).Assembly"">
-    <Found Context=""routeData"">
-        <RouteView RouteData=""@routeData"" DefaultLayout=""@typeof(MainLayout)"" />
-    </Found>
-    <NotFound>
-        <LayoutView Layout=""@typeof(MainLayout)"">
-            <p>Sorry, there's nothing at this address.</p>
+                input: """
+                    <CascadingAuthenticationState>
+                    <Router AppAssembly="@typeof(Program).Assembly">
+                        <Found Context="routeData">
+                            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+                        </Found>
+                        <NotFound>
+                            <LayoutView Layout="@typeof(MainLayout)">
+                                <p>Sorry, there's nothing at this address.</p>
 
-            @if (true)
-                    {
-                        <strong></strong>
-                }
-        </LayoutView>
-    </NotFound>
-</Router>
-</CascadingAuthenticationState>
-",
-expected: @"
-<CascadingAuthenticationState>
-    <Router AppAssembly=""@typeof(Program).Assembly"">
-        <Found Context=""routeData"">
-            <RouteView RouteData=""@routeData"" DefaultLayout=""@typeof(MainLayout)"" />
-        </Found>
-        <NotFound>
-            <LayoutView Layout=""@typeof(MainLayout)"">
-                <p>Sorry, there's nothing at this address.</p>
+                                @if (true)
+                                        {
+                                            <strong></strong>
+                                    }
+                            </LayoutView>
+                        </NotFound>
+                    </Router>
+                    </CascadingAuthenticationState>
+                    """,
+                expected: """
+                    <CascadingAuthenticationState>
+                        <Router AppAssembly="@typeof(Program).Assembly">
+                            <Found Context="routeData">
+                                <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+                            </Found>
+                            <NotFound>
+                                <LayoutView Layout="@typeof(MainLayout)">
+                                    <p>Sorry, there's nothing at this address.</p>
 
-                @if (true)
-                {
-                    <strong></strong>
-                }
-            </LayoutView>
-        </NotFound>
-    </Router>
-</CascadingAuthenticationState>
-");
+                                    @if (true)
+                                    {
+                                        <strong></strong>
+                                    }
+                                </LayoutView>
+                            </NotFound>
+                        </Router>
+                    </CascadingAuthenticationState>
+                    """);
         }
 
         [Fact]
@@ -629,46 +650,47 @@ expected: @"
         public async Task FormatNestedComponents2()
         {
             await RunFormattingTestAsync(
-input: @"
-<GridTable>
-<ChildContent>
-<GridRow>
-<ChildContent>
-<GridCell>
-<ChildContent>
-<strong></strong>
-@if (true)
-{
-<strong></strong>
-}
-<strong></strong>
-</ChildContent>
-</GridCell>
-</ChildContent>
-</GridRow>
-</ChildContent>
-</GridTable>
-",
-expected: @"
-<GridTable>
-    <ChildContent>
-        <GridRow>
-            <ChildContent>
-                <GridCell>
+                input: """
+                    <GridTable>
                     <ChildContent>
-                        <strong></strong>
-                        @if (true)
-                        {
-                            <strong></strong>
-                        }
-                        <strong></strong>
+                    <GridRow>
+                    <ChildContent>
+                    <GridCell>
+                    <ChildContent>
+                    <strong></strong>
+                    @if (true)
+                    {
+                    <strong></strong>
+                    }
+                    <strong></strong>
                     </ChildContent>
-                </GridCell>
-            </ChildContent>
-        </GridRow>
-    </ChildContent>
-</GridTable>
-", tagHelpers: GetComponents());
+                    </GridCell>
+                    </ChildContent>
+                    </GridRow>
+                    </ChildContent>
+                    </GridTable>
+                    """,
+                expected: """
+                    <GridTable>
+                        <ChildContent>
+                            <GridRow>
+                                <ChildContent>
+                                    <GridCell>
+                                        <ChildContent>
+                                            <strong></strong>
+                                            @if (true)
+                                            {
+                                                <strong></strong>
+                                            }
+                                            <strong></strong>
+                                        </ChildContent>
+                                    </GridCell>
+                                </ChildContent>
+                            </GridRow>
+                        </ChildContent>
+                    </GridTable>
+                    """,
+                tagHelpers: GetComponents());
         }
 
         [Fact]
@@ -676,46 +698,47 @@ expected: @"
         public async Task FormatNestedComponents2_Range()
         {
             await RunFormattingTestAsync(
-input: @"
-<GridTable>
-<ChildContent>
-<GridRow>
-<ChildContent>
-<GridCell>
-<ChildContent>
-<strong></strong>
-@if (true)
-{
-[|<strong></strong>|]
-}
-<strong></strong>
-</ChildContent>
-</GridCell>
-</ChildContent>
-</GridRow>
-</ChildContent>
-</GridTable>
-",
-expected: @"
-<GridTable>
-<ChildContent>
-<GridRow>
-<ChildContent>
-<GridCell>
-<ChildContent>
-<strong></strong>
-@if (true)
-{
-                            <strong></strong>
-}
-<strong></strong>
-</ChildContent>
-</GridCell>
-</ChildContent>
-</GridRow>
-</ChildContent>
-</GridTable>
-", tagHelpers: GetComponents());
+                input: """
+                    <GridTable>
+                    <ChildContent>
+                    <GridRow>
+                    <ChildContent>
+                    <GridCell>
+                    <ChildContent>
+                    <strong></strong>
+                    @if (true)
+                    {
+                    [|<strong></strong>|]
+                    }
+                    <strong></strong>
+                    </ChildContent>
+                    </GridCell>
+                    </ChildContent>
+                    </GridRow>
+                    </ChildContent>
+                    </GridTable>
+                    """,
+                expected: """
+                    <GridTable>
+                    <ChildContent>
+                    <GridRow>
+                    <ChildContent>
+                    <GridCell>
+                    <ChildContent>
+                    <strong></strong>
+                    @if (true)
+                    {
+                                                <strong></strong>
+                    }
+                    <strong></strong>
+                    </ChildContent>
+                    </GridCell>
+                    </ChildContent>
+                    </GridRow>
+                    </ChildContent>
+                    </GridTable>
+                    """,
+                tagHelpers: GetComponents());
         }
 
         [Fact]
@@ -723,43 +746,44 @@ expected: @"
         public async Task FormatHtmlInIf()
         {
             await RunFormattingTestAsync(
-input: @"
-@if (true)
-{
-    <p><em>Loading...</em></p>
-}
-else
-{
-    <table class=""table"">
-        <thead>
-            <tr>
-        <th>Date</th>
-        <th>Temp. (C)</th>
-        <th>Temp. (F)</th>
-        <th>Summary</th>
-            </tr>
-        </thead>
-    </table>
-}
-",
-expected: @"@if (true)
-{
-    <p><em>Loading...</em></p>
-}
-else
-{
-    <table class=""table"">
-        <thead>
-            <tr>
-                <th>Date</th>
-                <th>Temp. (C)</th>
-                <th>Temp. (F)</th>
-                <th>Summary</th>
-            </tr>
-        </thead>
-    </table>
-}
-");
+                input: """
+                    @if (true)
+                    {
+                        <p><em>Loading...</em></p>
+                    }
+                    else
+                    {
+                        <table class="table">
+                            <thead>
+                                <tr>
+                            <th>Date</th>
+                            <th>Temp. (C)</th>
+                            <th>Temp. (F)</th>
+                            <th>Summary</th>
+                                </tr>
+                            </thead>
+                        </table>
+                    }
+                    """,
+                expected: """
+                    @if (true)
+                    {
+                        <p><em>Loading...</em></p>
+                    }
+                    else
+                    {
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Temp. (C)</th>
+                                    <th>Temp. (F)</th>
+                                    <th>Summary</th>
+                                </tr>
+                            </thead>
+                        </table>
+                    }
+                    """);
         }
 
         [Fact]
@@ -767,44 +791,44 @@ else
         public async Task FormatHtmlInIf_Range()
         {
             await RunFormattingTestAsync(
-input: @"
-@if (true)
-{
-    <p><em>Loading...</em></p>
-}
-else
-{
-    <table class=""table"">
-        <thead>
-            <tr>
-[|      <th>Date</th>
-        <th>Temp. (C)</th>
-        <th>Temp. (F)</th>
-        <th>Summary</th>|]
-            </tr>
-        </thead>
-    </table>
-}
-",
-expected: @"
-@if (true)
-{
-    <p><em>Loading...</em></p>
-}
-else
-{
-    <table class=""table"">
-        <thead>
-            <tr>
-                <th>Date</th>
-                <th>Temp. (C)</th>
-                <th>Temp. (F)</th>
-                <th>Summary</th>
-            </tr>
-        </thead>
-    </table>
-}
-");
+                input: """
+                    @if (true)
+                    {
+                        <p><em>Loading...</em></p>
+                    }
+                    else
+                    {
+                        <table class="table">
+                            <thead>
+                                <tr>
+                    [|      <th>Date</th>
+                            <th>Temp. (C)</th>
+                            <th>Temp. (F)</th>
+                            <th>Summary</th>|]
+                                </tr>
+                            </thead>
+                        </table>
+                    }
+                    """,
+                expected: """
+                    @if (true)
+                    {
+                        <p><em>Loading...</em></p>
+                    }
+                    else
+                    {
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Temp. (C)</th>
+                                    <th>Temp. (F)</th>
+                                    <th>Summary</th>
+                                </tr>
+                            </thead>
+                        </table>
+                    }
+                    """);
         }
 
         [Fact]
@@ -818,35 +842,36 @@ else
             FormattingContext.SkipValidateComponents = true;
 
             await RunFormattingTestAsync(
-input: @"
-@code
-{
-    public void DoStuff(RenderFragment renderFragment)
-    {
-        renderFragment(@<SurveyPrompt Title=""Foo"" />);
+                input: """
+                    @code
+                    {
+                        public void DoStuff(RenderFragment renderFragment)
+                        {
+                            renderFragment(@<SurveyPrompt Title="Foo" />);
 
-        @* comment *@
-<div></div>
+                            @* comment *@
+                    <div></div>
 
-        @* comment *@<div></div>
-    }
-}
-",
-expected: @"@code
-{
-    public void DoStuff(RenderFragment renderFragment)
-    {
-        renderFragment(@<SurveyPrompt Title=""Foo"" />);
+                            @* comment *@<div></div>
+                        }
+                    }
+                    """,
+                expected: """
+                    @code
+                    {
+                        public void DoStuff(RenderFragment renderFragment)
+                        {
+                            renderFragment(@<SurveyPrompt Title="Foo" />);
 
-        @* comment *@
-        <div></div>
+                            @* comment *@
+                            <div></div>
 
-        @* comment *@
-        <div></div>
-    }
-}
-",
-tagHelpers: GetSurveyPrompt());
+                            @* comment *@
+                            <div></div>
+                        }
+                    }
+                    """,
+                tagHelpers: GetSurveyPrompt());
         }
 
         [Fact]
@@ -854,33 +879,34 @@ tagHelpers: GetSurveyPrompt());
         public async Task FormatHtmlCommentsInsideCSharp1()
         {
             await RunFormattingTestAsync(
-input: @"
-@foreach (var num in Enumerable.Range(1, 10))
-{
-    <span class=""skill_result btn"">
-        <!--asdfasd-->
-        <span style=""margin-left:0px"">
-            <svg>
-                <rect width=""1"" height=""1"" />
-            </svg>
-        </span>
-        <!--adfasfd-->
-    </span>
-}
-",
-expected: @"@foreach (var num in Enumerable.Range(1, 10))
-{
-    <span class=""skill_result btn"">
-        <!--asdfasd-->
-        <span style=""margin-left:0px"">
-            <svg>
-                <rect width=""1"" height=""1"" />
-            </svg>
-        </span>
-        <!--adfasfd-->
-    </span>
-}
-");
+                input: """
+                    @foreach (var num in Enumerable.Range(1, 10))
+                    {
+                        <span class="skill_result btn">
+                            <!--asdfasd-->
+                            <span style="margin-left:0px">
+                                <svg>
+                                    <rect width="1" height="1" />
+                                </svg>
+                            </span>
+                            <!--adfasfd-->
+                        </span>
+                    }
+                    """,
+                expected: """
+                    @foreach (var num in Enumerable.Range(1, 10))
+                    {
+                        <span class="skill_result btn">
+                            <!--asdfasd-->
+                            <span style="margin-left:0px">
+                                <svg>
+                                    <rect width="1" height="1" />
+                                </svg>
+                            </span>
+                            <!--adfasfd-->
+                        </span>
+                    }
+                    """);
         }
 
         [Fact]
@@ -888,25 +914,26 @@ expected: @"@foreach (var num in Enumerable.Range(1, 10))
         public async Task FormatHtmlCommentsInsideCSharp2()
         {
             await RunFormattingTestAsync(
-input: @"
-@foreach (var num in Enumerable.Range(1, 10))
-{
-    <span class=""skill_result btn"">
-        <!--asdfasd-->
-        <input type=""text"" />
-        <!--adfasfd-->
-    </span>
-}
-",
-expected: @"@foreach (var num in Enumerable.Range(1, 10))
-{
-    <span class=""skill_result btn"">
-        <!--asdfasd-->
-        <input type=""text"" />
-        <!--adfasfd-->
-    </span>
-}
-");
+                input: """
+                    @foreach (var num in Enumerable.Range(1, 10))
+                    {
+                        <span class="skill_result btn">
+                            <!--asdfasd-->
+                            <input type="text" />
+                            <!--adfasfd-->
+                        </span>
+                    }
+                    """,
+                expected: """
+                    @foreach (var num in Enumerable.Range(1, 10))
+                    {
+                        <span class="skill_result btn">
+                            <!--asdfasd-->
+                            <input type="text" />
+                            <!--adfasfd-->
+                        </span>
+                    }
+                    """);
         }
 
         [Fact]
@@ -914,63 +941,66 @@ expected: @"@foreach (var num in Enumerable.Range(1, 10))
         public async Task FormatCascadingValueWithCascadingTypeParameter()
         {
             await RunFormattingTestAsync(
-input: @"
-<div>
-    @foreach ( var i in new int[] { 1, 23 } )
-    {
-        <div></div>
-    }
-</div>
-<Select TValue=""string"">
-    @foreach ( var i in new int[] { 1, 23 } )
-    {
-        <SelectItem Value=""@i"">@i</SelectItem>
-    }
-</Select>
-",
-expected: @"
-<div>
-    @foreach (var i in new int[] { 1, 23 })
-    {
-        <div></div>
-    }
-</div>
-<Select TValue=""string"">
-    @foreach (var i in new int[] { 1, 23 })
-    {
-        <SelectItem Value=""@i"">@i</SelectItem>
-    }
-</Select>
-", tagHelpers: CreateTagHelpers());
+                input: """
+
+                    <div>
+                        @foreach ( var i in new int[] { 1, 23 } )
+                        {
+                            <div></div>
+                        }
+                    </div>
+                    <Select TValue="string">
+                        @foreach ( var i in new int[] { 1, 23 } )
+                        {
+                            <SelectItem Value="@i">@i</SelectItem>
+                        }
+                    </Select>
+                    """,
+                expected: """
+
+                    <div>
+                        @foreach (var i in new int[] { 1, 23 })
+                        {
+                            <div></div>
+                        }
+                    </div>
+                    <Select TValue="string">
+                        @foreach (var i in new int[] { 1, 23 })
+                        {
+                            <SelectItem Value="@i">@i</SelectItem>
+                        }
+                    </Select>
+                    """,
+                tagHelpers: CreateTagHelpers());
 
             IReadOnlyList<TagHelperDescriptor> CreateTagHelpers()
             {
-                var select = @"
-@typeparam TValue
-@attribute [CascadingTypeParameter(nameof(TValue))]
-<CascadingValue Value=""@this"" IsFixed>
-    <select>
-        @ChildContent
-    </select>
-</CascadingValue>
+                var select = """
+                    @typeparam TValue
+                    @attribute [CascadingTypeParameter(nameof(TValue))]
+                    <CascadingValue Value="@this" IsFixed>
+                        <select>
+                            @ChildContent
+                        </select>
+                    </CascadingValue>
 
-@code
-{
-    [Parameter] public TValue SelectedValue { get; set; }
-}
-";
-                var selectItem = @"
-@typeparam TValue
-<option value=""@StringValue"">@ChildContent</option>
+                    @code
+                    {
+                        [Parameter] public TValue SelectedValue { get; set; }
+                    }
+                    """;
+                var selectItem = """
+                    @typeparam TValue
+                    <option value="@StringValue">@ChildContent</option>
 
-@code
-{
-    [Parameter] public TValue Value { get; set; }
-    [Parameter] public RenderFragment ChildContent { get; set; }
+                    @code
+                    {
+                        [Parameter] public TValue Value { get; set; }
+                        [Parameter] public RenderFragment ChildContent { get; set; }
 
-    protected string StringValue => Value?.ToString();
-}
-";
+                        protected string StringValue => Value?.ToString();
+                    }
+                    """;
 
                 var selectComponent = CompileToCSharp("Select.razor", select, throwOnFailure: true, fileKind: FileKinds.Component);
                 var selectItemComponent = CompileToCSharp("SelectItem.razor", selectItem, throwOnFailure: true, fileKind: FileKinds.Component);
@@ -987,107 +1017,108 @@ expected: @"
         public async Task FormatExplicitCSharpInsideHtml()
         {
             await RunFormattingTestAsync(
-input: @"
-@using System.Text;
+                input: """
+                    @using System.Text;
 
-<div>
-    @(new C()
-            .M(""Hello"")
-        .M(""World"")
-        .M(source =>
-        {
-        if (source.Length > 0)
-        {
-        source.ToString();
-        }
-        }))
+                    <div>
+                        @(new C()
+                                .M("Hello")
+                            .M("World")
+                            .M(source =>
+                            {
+                            if (source.Length > 0)
+                            {
+                            source.ToString();
+                            }
+                            }))
 
-    @(DateTime.Now)
+                        @(DateTime.Now)
 
-    @(DateTime
-.Now
-.ToString())
+                        @(DateTime
+                    .Now
+                    .ToString())
 
-                @(   Html.DisplayNameFor (@<text>
-        <p >
-        <h2 ></h2>
-        </p>
-        </text>)
-        .ToString())
+                                    @(   Html.DisplayNameFor (@<text>
+                            <p >
+                            <h2 ></h2>
+                            </p>
+                            </text>)
+                            .ToString())
 
-@{
-var x = @<p>Hi there!</p>
-}
-@x()
-@(@x())
-</div>
+                    @{
+                    var x = @<p>Hi there!</p>
+                    }
+                    @x()
+                    @(@x())
+                    </div>
 
-@functions {
-    class C
-    {
-        C M(string a) => this;
-        C M(Func<string, C> a) => this;
-    }
-}
-",
-expected: @"@using System.Text;
+                    @functions {
+                        class C
+                        {
+                            C M(string a) => this;
+                            C M(Func<string, C> a) => this;
+                        }
+                    }
+                    """,
+                expected: """
+                    @using System.Text;
 
-<div>
-    @(new C()
-        .M(""Hello"")
-        .M(""World"")
-        .M(source =>
-        {
-            if (source.Length > 0)
-            {
-                source.ToString();
-            }
-        }))
+                    <div>
+                        @(new C()
+                            .M("Hello")
+                            .M("World")
+                            .M(source =>
+                            {
+                                if (source.Length > 0)
+                                {
+                                    source.ToString();
+                                }
+                            }))
 
-    @(DateTime.Now)
+                        @(DateTime.Now)
 
-    @(DateTime
-        .Now
-        .ToString())
+                        @(DateTime
+                            .Now
+                            .ToString())
 
-    @(Html.DisplayNameFor(@<text>
-        <p>
-            <h2></h2>
-        </p>
-    </text>)
-        .ToString())
+                        @(Html.DisplayNameFor(@<text>
+                            <p>
+                                <h2></h2>
+                            </p>
+                        </text>)
+                            .ToString())
 
-    @{
-        var x = @<p>Hi there!</p>
-    }
-    @x()
-    @(@x())
-</div>
+                        @{
+                            var x = @<p>Hi there!</p>
+                        }
+                        @x()
+                        @(@x())
+                    </div>
 
-@functions {
-    class C
-    {
-        C M(string a) => this;
-        C M(Func<string, C> a) => this;
-    }
-}
-",
-            fileKind: FileKinds.Legacy);
+                    @functions {
+                        class C
+                        {
+                            C M(string a) => this;
+                            C M(Func<string, C> a) => this;
+                        }
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         private IReadOnlyList<TagHelperDescriptor> GetSurveyPrompt()
         {
-            AdditionalSyntaxTrees.Add(Parse(@"
-using Microsoft.AspNetCore.Components;
-namespace Test
-{
-    public class SurveyPrompt : ComponentBase
-    {
-        [Parameter]
-        public string Title { get; set; }
-    }
-}
-"));
+            AdditionalSyntaxTrees.Add(Parse("""
+                using Microsoft.AspNetCore.Components;
+                namespace Test
+                {
+                    public class SurveyPrompt : ComponentBase
+                    {
+                        [Parameter]
+                        public string Title { get; set; }
+                    }
+                }
+                """));
 
             var generated = CompileToCSharp("SurveyPrompt.razor", string.Empty, throwOnFailure: false, fileKind: FileKinds.Component);
             var tagHelpers = generated.CodeDocument.GetTagHelperContext().TagHelpers;
@@ -1096,29 +1127,29 @@ namespace Test
 
         private IReadOnlyList<TagHelperDescriptor> GetComponents()
         {
-            AdditionalSyntaxTrees.Add(Parse(@"
-using Microsoft.AspNetCore.Components;
-namespace Test
-{
-    public class GridTable : ComponentBase
-    {
-        [Parameter]
-        public RenderFragment ChildContent { get; set; }
-    }
+            AdditionalSyntaxTrees.Add(Parse("""
+                using Microsoft.AspNetCore.Components;
+                namespace Test
+                {
+                    public class GridTable : ComponentBase
+                    {
+                        [Parameter]
+                        public RenderFragment ChildContent { get; set; }
+                    }
 
-    public class GridRow : ComponentBase
-    {
-        [Parameter]
-        public RenderFragment ChildContent { get; set; }
-    }
+                    public class GridRow : ComponentBase
+                    {
+                        [Parameter]
+                        public RenderFragment ChildContent { get; set; }
+                    }
 
-    public class GridCell : ComponentBase
-    {
-        [Parameter]
-        public RenderFragment ChildContent { get; set; }
-    }
-}
-"));
+                    public class GridCell : ComponentBase
+                    {
+                        [Parameter]
+                        public RenderFragment ChildContent { get; set; }
+                    }
+                }
+                """));
 
             var generated = CompileToCSharp("Test.razor", string.Empty, throwOnFailure: false, fileKind: FileKinds.Component);
             var tagHelpers = generated.CodeDocument.GetTagHelperContext().TagHelpers;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
@@ -21,289 +21,304 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task CodeBlock_SpansMultipleLines()
         {
             await RunFormattingTestAsync(
-input: @"
-@code
-        {
-    private int currentCount = 0;
+                input: """
+                    @code
+                            {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-expected: @"@code
-{
-    private int currentCount = 0;
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                expected: """
+                    @code
+                    {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-");
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task CodeBlock_IndentedBlock_MaintainsIndent()
         {
             await RunFormattingTestAsync(
-input: @"
-<boo>
-    @code
-            {
-        private int currentCount = 0;
+                input: """
+                    <boo>
+                        @code
+                                {
+                            private int currentCount = 0;
 
-        private void IncrementCount()
-        {
-            currentCount++;
-        }
-    }
-</boo>
-",
-expected: @"
-<boo>
-    @code
-    {
-        private int currentCount = 0;
+                            private void IncrementCount()
+                            {
+                                currentCount++;
+                            }
+                        }
+                    </boo>
+                    """,
+                expected: """
+                    <boo>
+                        @code
+                        {
+                            private int currentCount = 0;
 
-        private void IncrementCount()
-        {
-            currentCount++;
-        }
-    }
-</boo>
-");
+                            private void IncrementCount()
+                            {
+                                currentCount++;
+                            }
+                        }
+                    </boo>
+                    """);
         }
 
         [Fact]
         public async Task CodeBlock_TooMuchWhitespace()
         {
             await RunFormattingTestAsync(
-input: @"
-@code        {
-    private int currentCount = 0;
+                input: """
+                    @code        {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-expected: @"@code {
-    private int currentCount = 0;
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-");
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task CodeBlock_NonSpaceWhitespace()
         {
             await RunFormattingTestAsync(
-input: @"
-@code	{
-    private int currentCount = 0;
+                input: """
+                    @code	{
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-expected: @"@code {
-    private int currentCount = 0;
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-");
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task CodeBlock_NoWhitespace()
         {
             await RunFormattingTestAsync(
-input: @"
-@code{
-    private int currentCount = 0;
+                input: """
+                    @code{
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-expected: @"@code {
-    private int currentCount = 0;
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-");
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """);
         }
 
         [Fact]
         public async Task FunctionsBlock_BraceOnNewLine()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions
-        {
-    private int currentCount = 0;
+                input: """
+                    @functions
+                            {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-expected: @"@functions
-{
-    private int currentCount = 0;
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                expected: """
+                    @functions
+                    {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-fileKind: FileKinds.Legacy);
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task FunctionsBlock_TooManySpaces()
         {
             await RunFormattingTestAsync(
-input: @"
-@functions        {
-    private int currentCount = 0;
+                input: """
+                    @functions        {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-expected: @"@functions {
-    private int currentCount = 0;
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        private int currentCount = 0;
 
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-",
-fileKind: FileKinds.Legacy);
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task Layout()
         {
             await RunFormattingTestAsync(
-input: @"
-@layout    MyLayout
-",
-expected: @"@layout MyLayout
-");
+                input: """
+                    @layout    MyLayout
+                    """,
+                expected: """
+                    @layout MyLayout
+                    """);
         }
 
         [Fact]
         public async Task Inherits()
         {
             await RunFormattingTestAsync(
-input: @"
-@inherits    MyBaseClass
-",
-expected: @"@inherits MyBaseClass
-");
+                input: """
+                    @inherits    MyBaseClass
+                    """,
+                expected: """
+                    @inherits MyBaseClass
+                    """);
         }
 
         [Fact]
         public async Task Implements()
         {
             await RunFormattingTestAsync(
-input: @"
-@implements    IDisposable
-",
-expected: @"@implements IDisposable
-");
+                input: """
+                    @implements    IDisposable
+                    """,
+                expected: """
+                    @implements IDisposable
+                    """);
         }
 
         [Fact]
         public async Task PreserveWhitespace()
         {
             await RunFormattingTestAsync(
-input: @"
-@preservewhitespace    true
-",
-expected: @"@preservewhitespace true
-");
+                input: """
+                    @preservewhitespace    true
+                    """,
+                expected: """
+                    @preservewhitespace true
+                    """);
         }
 
         [Fact]
         public async Task Inject()
         {
             await RunFormattingTestAsync(
-input: @"
-@inject    MyClass     myClass
-",
-expected: @"@inject MyClass myClass
-");
+                input: """
+                    @inject    MyClass     myClass
+                    """,
+                expected: """
+                    @inject MyClass myClass
+                    """);
         }
 
         [Fact]
         public async Task Inject_TrailingWhitespace()
         {
             await RunFormattingTestAsync(
-input: @"
-@inject    MyClass     myClass
-",
-expected: @"@inject MyClass myClass
-");
+                input: """
+                    @inject    MyClass     myClass
+                    """,
+                expected: """
+                    @inject MyClass myClass
+                    """);
         }
 
         [Fact]
         public async Task Attribute()
         {
             await RunFormattingTestAsync(
-input: @"
-@attribute     [Obsolete(   ""asdf""   , error:    false)]
-",
-expected: @"@attribute [Obsolete(""asdf"", error: false)]
-");
+                input: """
+                    @attribute     [Obsolete(   "asdf"   , error:    false)]
+                    """,
+                expected: """
+                    @attribute [Obsolete("asdf", error: false)]
+                    """);
         }
 
         [Fact]
         public async Task Model()
         {
             await RunFormattingTestAsync(
-input: @"
-@model    MyModel
-",
-expected: @"@model MyModel
-",
-            fileKind: FileKinds.Legacy);
+                input: """
+                    @model    MyModel
+                    """,
+                expected: """
+                    @model MyModel
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         [Fact]
         public async Task Page()
         {
             await RunFormattingTestAsync(
-input: @"
-@page    ""MyPage""
-",
-expected: @"@page ""MyPage""
-",
-            fileKind: FileKinds.Legacy);
+                input: """
+                    @page    "MyPage"
+                    """,
+                expected: """
+                    @page "MyPage"
+                    """,
+                fileKind: FileKinds.Legacy);
         }
 
         // Regression prevention tests:
@@ -311,53 +326,57 @@ expected: @"@page ""MyPage""
         public async Task Using()
         {
             await RunFormattingTestAsync(
-input: @"
-@using   System;
-",
-expected: @"@using System;
-");
+                input: """
+                    @using   System;
+                    """,
+                expected: """
+                    @using System;
+                    """);
         }
 
         [Fact]
         public async Task UsingStatic()
         {
             await RunFormattingTestAsync(
-input: @"
-@using  static   System.Math;
-",
-expected: @"@using static System.Math;
-");
+                input: """
+                    @using  static   System.Math;
+                    """,
+                expected: """
+                    @using static System.Math;
+                    """);
         }
 
         [Fact]
         public async Task UsingAlias()
         {
             await RunFormattingTestAsync(
-input: @"
-@using  M   =    System.Math;
-",
-expected: @"@using M = System.Math;
-");
+                input: """
+                    @using  M   =    System.Math;
+                    """,
+                expected: """
+                    @using M = System.Math;
+                    """);
         }
 
         [Fact]
         public async Task TagHelpers()
         {
             await RunFormattingTestAsync(
-input: @"
-@addTagHelper    *,    Microsoft.AspNetCore.Mvc.TagHelpers
-@removeTagHelper    *,     Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper    ""*,  Microsoft.AspNetCore.Mvc.TagHelpers""
-@removeTagHelper    ""*,  Microsoft.AspNetCore.Mvc.TagHelpers""
-@tagHelperPrefix    th:
-",
-expected: @"@addTagHelper    *,    Microsoft.AspNetCore.Mvc.TagHelpers
-@removeTagHelper    *,     Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper    ""*,  Microsoft.AspNetCore.Mvc.TagHelpers""
-@removeTagHelper    ""*,  Microsoft.AspNetCore.Mvc.TagHelpers""
-@tagHelperPrefix    th:
-",
-            fileKind: FileKinds.Legacy);
+                input: """
+                    @addTagHelper    *,    Microsoft.AspNetCore.Mvc.TagHelpers
+                    @removeTagHelper    *,     Microsoft.AspNetCore.Mvc.TagHelpers
+                    @addTagHelper    "*,  Microsoft.AspNetCore.Mvc.TagHelpers"
+                    @removeTagHelper    "*,  Microsoft.AspNetCore.Mvc.TagHelpers"
+                    @tagHelperPrefix    th:
+                    """,
+                expected: """
+                    @addTagHelper    *,    Microsoft.AspNetCore.Mvc.TagHelpers
+                    @removeTagHelper    *,     Microsoft.AspNetCore.Mvc.TagHelpers
+                    @addTagHelper    "*,  Microsoft.AspNetCore.Mvc.TagHelpers"
+                    @removeTagHelper    "*,  Microsoft.AspNetCore.Mvc.TagHelpers"
+                    @tagHelperPrefix    th:
+                    """,
+                fileKind: FileKinds.Legacy);
         }
     }
 }


### PR DESCRIPTION
More C# 11 goodness.

Sorry, there is no good way to review this.

In case you weren't aware, raw string literals don't include whitespace that appears at the start of each line, up until the point where the end `"""` starts, which means all of these changes don't actually change the contents of the strings*. Visual Studio also draws a vertical line so its easy to see the true content. And of course, we can use quotes in strings without needing to escape them, which is cool.

Vertical line looks like:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/754264/167976610-810ab08e-8996-4432-a740-aaa1710ee833.png">

\* with the exception of some whitespace before and after, but that was always annoying that we had to include that to make the tests look okay.