### PR TITLE
Use a known indentation where possible because it might be better than nothing

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -171,6 +171,19 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     // We use binary search to find that spot.
 
                     var index = Array.BinarySearch(sourceMappingIndentationScopes, lineStart);
+
+                    if (index < 0 && context.SourceText[lineStart] == '@')
+                    {
+                        // Sometimes we are only off by one in finding a source mapping, for example with a simple if statement:
+                        //
+                        // @|if (true)
+                        //
+                        // The sourceMappingIndentationScopes knows about where the pipe is (ie, after the "@") but we're asking
+                        // for indentation at the line start. In these cases we are better off using the real indentation scope,
+                        // than hoping the one before it is correct.
+                        index = Array.BinarySearch(sourceMappingIndentationScopes, lineStart + 1);
+                    }
+
                     if (index < 0)
                     {
                         // Couldn't find the exact value. Find the index of the element to the left of the searched value.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -350,6 +350,47 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/6401")]
+        public async Task Format_SectionDirectiveBlock4()
+        {
+            await RunFormattingTestAsync(
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
+
+                    @section Scripts {
+                    <script></script>
+                    }
+
+                    @if (true)
+                    {
+                        <p></p>
+                    }
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
+
+                    @section Scripts {
+                        <script></script>
+                    }
+
+                    @if (true)
+                    {
+                        <p></p>
+                    }
+                    """,
+                fileKind: FileKinds.Legacy);
+        }
+
+        [Fact]
         public async Task Formats_CodeBlockDirectiveWithRazorComments()
         {
             await RunFormattingTestAsync(


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6401

This is quite the targetted fix but I don't think there is anything else we can do about here until we move completely off the "work out indentation based on generated C#" model, or get the compiler to add another source mapping at the end of a `@section` block. Might try the latter when the compiler is in this repo ¯\\\_(ツ)_/¯

Best thing is probably to advise people to put `@section` directives last :)