### PR TITLE
Handle null-ref

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -371,7 +371,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 return d.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag?.Bang != null;
             }
         }
-#nullable disable
 
         private static bool InAttributeContainingCSharp(
                 OmniSharpVSDiagnostic d,
@@ -389,6 +388,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             }
 
             var owner = syntaxTree.GetOwner(sourceText, d.Range.End, logger);
+            if (owner is null)
+            {
+                return false;
+            }
 
             var markupAttributeNode = owner.FirstAncestorOrSelf<RazorSyntaxNode>(n =>
                 n is MarkupAttributeBlockSyntax ||
@@ -494,6 +497,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
             return mappedDiagnostics.ToArray();
         }
+
+#nullable disable
 
         private static bool IsRudeEditDiagnostic(OmniSharpVSDiagnostic diagnostic)
         {


### PR DESCRIPTION
### Summary of the changes
Noticed this while testing out Semantic Tokens perf
1. Open a reasonably large razor file. Make it bigger by copy and pasting the parts of it that won't cause an error continuously.
2. Hold down Ctrl+z so it removes all the stuff you just added.
3. Check out the Razor Language Server Client log in the Output pane. You should eventually see a null-ref pertaining to this line.

My solution then is to fix the only null-ref issue from that function by accounting for the fact that sometimes we have null owners. @NTaylorMullen I don't know much about diagnostics, but this seems to generally match what we do for the other `Is...` methods in this file.