### PR TITLE
Wait for all Classifications

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models
             "enumMember", // 10
             "event",
             "function",
-            "method",
+            "member",
             "macro",
             "keyword",
             "modifier",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models
             "enumMember", // 10
             "event",
             "function",
-            "member",
+            "method",
             "macro",
             "keyword",
             "modifier",

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/RazorSemanticTokensTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/RazorSemanticTokensTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", 3);
 
             await TestServices.Editor.SetTextAsync(RazorProjectConstants.IndexPageContent, ControlledHangMitigatingCancellationToken);
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", 1);
+            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", 3);
 
             // Assert
             var expectedClassifications = await GetExpectedClassificationSpansAsync(nameof(Edits_UpdateColors), ControlledHangMitigatingCancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/RazorSemanticTokensTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/RazorSemanticTokensTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.Editor.SetTextAsync(RazorProjectConstants.MainLayoutContent, ControlledHangMitigatingCancellationToken);
 
             // Act
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", 3);
+            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", count: 3);
 
             // Assert
             var expectedClassifications = await GetExpectedClassificationSpansAsync(nameof(Components_AreColored), ControlledHangMitigatingCancellationToken);
@@ -62,10 +62,10 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.Editor.SetTextAsync(RazorProjectConstants.MainLayoutContent, ControlledHangMitigatingCancellationToken);
 
             // Act
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", 3);
+            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", count: 3);
 
             await TestServices.Editor.SetTextAsync(RazorProjectConstants.IndexPageContent, ControlledHangMitigatingCancellationToken);
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", 3);
+            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", count: 3);
 
             // Assert
             var expectedClassifications = await GetExpectedClassificationSpansAsync(nameof(Edits_UpdateColors), ControlledHangMitigatingCancellationToken);


### PR DESCRIPTION
### Summary of the changes

- Saw a random failure that seemed to be caused by not waiting for the whole TagHelper context to load. Gonna wait for that and see if it helps.
