### PR TITLE
Cast non-nullable instances instead of using !

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/DefaultRazorHoverInfoService.cs
@@ -163,12 +163,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                     switch (attribute.Parent.Kind)
                     {
                         case SyntaxKind.MarkupTagHelperDirectiveAttribute:
-                            var directiveAttribute = (attribute.Parent as MarkupTagHelperDirectiveAttributeSyntax)!;
+                            var directiveAttribute = (MarkupTagHelperDirectiveAttributeSyntax)attribute.Parent;
                             range.Start.Character -= directiveAttribute.Transition.FullWidth;
                             attributeName = "@" + attributeName;
                             break;
                         case SyntaxKind.MarkupMinimizedTagHelperDirectiveAttribute:
-                            var minimizedAttribute = (containingTagNameToken.Parent as MarkupMinimizedTagHelperDirectiveAttributeSyntax)!;
+                            var minimizedAttribute = (MarkupMinimizedTagHelperDirectiveAttributeSyntax)containingTagNameToken.Parent;
                             range.Start.Character -= minimizedAttribute.Transition.FullWidth;
                             attributeName = "@" + attributeName;
                             break;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                         throw new JsonSerializationException($"Failed to serialize to {nameof(InitializeResult)}");
                     }
 
-                    _serverCapabilities.Add((languageClientInstance.Client, (initializeResult.Capabilities as VSInternalServerCapabilities)!));
+                    _serverCapabilities.Add((languageClientInstance.Client, (VSInternalServerCapabilities)initializeResult.Capabilities));
                 }
             }
 


### PR DESCRIPTION
### Summary of the changes

- Use a cast instead of pattern matching with a `!` to make sure that if there is a problem we get useful error messages.

Responding to feedback from @davidwengier on https://github.com/dotnet/razor-tooling/pull/6414.