### PR TITLE
Don't re-resolve SyntaxNode owners for every completion handler.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
@@ -6,6 +6,7 @@
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
@@ -86,10 +87,11 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.Serialization
             var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
             var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, DefaultTagHelpers);
 
-            var completionQueryLocation = new SourceSpan(queryIndex, length: 0);
-            var context = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var queryableChange = new SourceChange(queryIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            var context = new RazorCompletionContext(queryIndex, owner, syntaxTree, tagHelperDocumentContext);
 
-            var razorCompletionItems = componentCompletionProvider.GetCompletionItems(context, completionQueryLocation);
+            var razorCompletionItems = componentCompletionProvider.GetCompletionItems(context);
             var completionList = RazorCompletionEndpoint.CreateLSPCompletionList(
                 razorCompletionItems,
                 new CompletionListCache(),

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.Razor.Completion;
@@ -44,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         private static readonly IReadOnlyList<RazorCompletionItem> s_completions = new[] { TransitionCompletionItem };
 
-        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context, SourceSpan location)
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
         {
             if (!FileKinds.IsComponent(context.SyntaxTree.Options.FileKind))
             {
@@ -52,9 +51,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            var change = new SourceChange(location, string.Empty);
-            var owner = context.SyntaxTree.Root.LocateOwner(change);
-
+            var owner = context.Owner;
             if (owner is null)
             {
                 return Array.Empty<RazorCompletionItem>();
@@ -72,13 +69,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            if (attributeNameLocation.IntersectsWith(location.AbsoluteIndex) && attributeName.StartsWith("@", StringComparison.Ordinal))
+            if (attributeNameLocation.IntersectsWith(context.AbsoluteIndex) && attributeName.StartsWith("@", StringComparison.Ordinal))
             {
                 // The transition is already provided for the attribute name
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            if (!IsValidCompletionPoint(location, prefixLocation, attributeNameLocation))
+            if (!IsValidCompletionPoint(context.AbsoluteIndex, prefixLocation, attributeNameLocation))
             {
                 // Not operating in the attribute name area
                 return Array.Empty<RazorCompletionItem>();
@@ -89,28 +86,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         // Internal for testing
-        internal static bool IsValidCompletionPoint(SourceSpan location, TextSpan? prefixLocation, TextSpan attributeNameLocation)
+        internal static bool IsValidCompletionPoint(int absoluteIndex, TextSpan? prefixLocation, TextSpan attributeNameLocation)
         {
-            if (location.AbsoluteIndex == (prefixLocation?.Start ?? -1))
+            if (absoluteIndex == (prefixLocation?.Start ?? -1))
             {
                 // <input| class="test" />
                 // Starts of prefix locations belong to the previous SyntaxNode. It could be the end of an attribute value, the tag name, C# etc.
                 return false;
             }
 
-            if (attributeNameLocation.Start == location.AbsoluteIndex)
+            if (attributeNameLocation.Start == absoluteIndex)
             {
                 // <input |class="test" />
                 return false;
             }
 
-            if (prefixLocation?.IntersectsWith(location.AbsoluteIndex) ?? false)
+            if (prefixLocation?.IntersectsWith(absoluteIndex) ?? false)
             {
                 // <input   |  class="test" />
                 return true;
             }
 
-            if (attributeNameLocation.IntersectsWith(location.AbsoluteIndex))
+            if (attributeNameLocation.IntersectsWith(absoluteIndex))
             {
                 // <input cla|ss="test" />
                 return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
@@ -135,9 +136,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 _ => CompletionReason.Typing,
             };
             var completionOptions = new RazorCompletionOptions(SnippetsSupported: true);
-            var completionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext, reason, completionOptions);
+            var queryableChange = new SourceChange(hostDocumentIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            var completionContext = new RazorCompletionContext(hostDocumentIndex, owner, syntaxTree, tagHelperDocumentContext, reason, completionOptions);
 
-            var razorCompletionItems = _completionFactsService.GetCompletionItems(completionContext, location);
+            var razorCompletionItems = _completionFactsService.GetCompletionItems(completionContext);
 
             _logger.LogTrace($"Resolved {razorCompletionItems.Count} completion items.");
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
@@ -132,9 +133,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 _ => CompletionReason.Typing,
             };
             var completionOptions = new RazorCompletionOptions(SnippetsSupported: true);
-            var completionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext, reason, completionOptions);
+            var queryableChange = new SourceChange(hostDocumentIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            var completionContext = new RazorCompletionContext(hostDocumentIndex, owner, syntaxTree, tagHelperDocumentContext, reason, completionOptions);
 
-            var razorCompletionItems = _completionFactsService.GetCompletionItems(completionContext, location);
+            var razorCompletionItems = _completionFactsService.GetCompletionItems(completionContext);
 
             _logger.LogTrace($"Resolved {razorCompletionItems.Count} completion items.");
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DefaultRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DefaultRazorCompletionFactsService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             _completionItemProviders = completionItemProviders.ToArray();
         }
 
-        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context, SourceSpan location)
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
         {
             if (context is null)
             {
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             for (var i = 0; i < _completionItemProviders.Count; i++)
             {
                 var completionItemProvider = _completionItemProviders[i];
-                var items = completionItemProvider.GetCompletionItems(context, location);
+                var items = completionItemProvider.GetCompletionItems(context);
                 completions.AddRange(items);
             }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.Editor.Razor;
 
@@ -33,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             _tagHelperFactsService = tagHelperFactsService;
         }
 
-        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context, SourceSpan location)
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
         {
             if (context is null)
             {
@@ -51,9 +50,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 return s_noDirectiveAttributeCompletionItems;
             }
 
-            var change = new SourceChange(location, string.Empty);
-            var owner = context.SyntaxTree.Root.LocateOwner(change);
-
+            var owner = context.Owner;
             if (owner is null)
             {
                 return s_noDirectiveAttributeCompletionItems;
@@ -65,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 return s_noDirectiveAttributeCompletionItems;
             }
 
-            if (!attributeNameLocation.IntersectsWith(location.AbsoluteIndex))
+            if (!attributeNameLocation.IntersectsWith(context.AbsoluteIndex))
             {
                 // We're trying to retrieve completions on a portion of the name that is not supported (such as a parameter).
                 return s_noDirectiveAttributeCompletionItems;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.Editor.Razor;
 
@@ -31,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             _tagHelperFactsService = tagHelperFactsService;
         }
 
-        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context, SourceSpan location)
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
         {
             if (context is null)
             {
@@ -49,9 +48,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            var change = new SourceChange(location, string.Empty);
-            var owner = context.SyntaxTree.Root.LocateOwner(change);
-
+            var owner = context.Owner;
             if (owner is null)
             {
                 return Array.Empty<RazorCompletionItem>();
@@ -63,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 return Array.Empty<RazorCompletionItem>();
             }
 
-            if (!parameterNameLocation.IntersectsWith(location.AbsoluteIndex))
+            if (!parameterNameLocation.IntersectsWith(context.AbsoluteIndex))
             {
                 // We're trying to retrieve completions on a portion of the name that is not supported (such as the name, i.e., |@bind|:format).
                 return Array.Empty<RazorCompletionItem>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
         };
 
-        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context, SourceSpan location)
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
         {
             if (context is null)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             }
 
             var completions = new List<RazorCompletionItem>();
-            if (ShouldProvideCompletions(context, location))
+            if (ShouldProvideCompletions(context))
             {
                 var directiveCompletions = GetDirectiveCompletionItems(context.SyntaxTree);
                 completions.AddRange(directiveCompletions);
@@ -45,16 +45,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         }
 
         // Internal for testing
-        internal static bool ShouldProvideCompletions(RazorCompletionContext context, SourceSpan location)
+        internal static bool ShouldProvideCompletions(RazorCompletionContext context)
         {
             if (context is null)
             {
                 return false;
             }
 
-            var change = new SourceChange(location, string.Empty);
-            var owner = context.SyntaxTree.Root.LocateOwner(change);
-
+            var owner = context.Owner;
             if (owner is null)
             {
                 return false;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -4,12 +4,11 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Razor.Language;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
-using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.VisualStudio.Editor.Razor;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
@@ -51,16 +50,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             _htmlFactsService = htmlFactsService;
         }
 
-        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context, SourceSpan location)
+        public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
         {
             if (context is null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var change = new SourceChange(location, string.Empty);
-            var owner = context.SyntaxTree.Root.LocateOwner(change);
-
+            var owner = context.Owner;
             if (owner is null)
             {
                 Debug.Fail("Owner should never be null.");
@@ -77,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Also helps filter out edge cases like `< te` and `< te=""`
             // (see comment in AtMarkupTransitionCompletionPoint)
             if (!_htmlFactsService.TryGetElementInfo(parent, out var containingTagNameToken, out _) ||
-                !containingTagNameToken.Span.IntersectsWith(location.AbsoluteIndex))
+                !containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
             {
                 return Array.Empty<RazorCompletionItem>();
             }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionContext.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language;
+using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     internal record RazorCompletionContext(
+        int AbsoluteIndex,
+        RazorSyntaxNode? Owner,
         RazorSyntaxTree SyntaxTree,
         TagHelperDocumentContext TagHelperDocumentContext,
         CompletionReason Reason = CompletionReason.Invoked,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
@@ -8,6 +8,6 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     internal abstract class RazorCompletionFactsService
     {
-        public abstract IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext razorCompletionContext, SourceSpan location);
+        public abstract IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext razorCompletionContext);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemProvider.cs
@@ -4,12 +4,11 @@
 #nullable disable
 
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     internal abstract class RazorCompletionItemProvider
     {
-        public abstract IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context, SourceSpan location);
+        public abstract IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveAttributeCompletionSource.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
@@ -94,10 +95,11 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
                 var syntaxTree = codeDocument.GetSyntaxTree();
                 var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-                var location = new SourceSpan(triggerLocation.Position, 0);
-
-                var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
-                var razorCompletionItems = _completionFactsService.GetCompletionItems(razorCompletionContext, location);
+                var absoluteIndex = triggerLocation.Position;
+                var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+                var owner = syntaxTree.Root.LocateOwner(queryableChange);
+                var razorCompletionContext = new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
+                var razorCompletionItems = _completionFactsService.GetCompletionItems(razorCompletionContext);
 
                 if (razorCompletionItems.Count == 0)
                 {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.VisualStudio.Core.Imaging;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
@@ -72,8 +73,11 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 var location = new SourceSpan(triggerLocation.Position, 0);
                 var syntaxTree = codeDocument.GetSyntaxTree();
                 var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-                var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
-                var razorCompletionItems = _completionFactsService.GetCompletionItems(razorCompletionContext, location);
+                var absoluteIndex = triggerLocation.Position;
+                var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+                var owner = syntaxTree.Root.LocateOwner(queryableChange);
+                var razorCompletionContext = new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
+                var razorCompletionItems = _completionFactsService.GetCompletionItems(razorCompletionContext);
 
                 var completionItems = new List<CompletionItem>();
                 foreach (var razorCompletionItem in razorCompletionItems)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Xunit;
@@ -31,12 +32,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
 
             // <p| class=""></p>
-            var location = new SourceSpan(2, 0);
+            var absoluteIndex = 2;
             var prefixLocation = new TextSpan(2, 1);
             var attributeNameLocation = new TextSpan(3, 5);
 
             // Act
-            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(location, prefixLocation, attributeNameLocation);
+            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(absoluteIndex, prefixLocation, attributeNameLocation);
 
             // Assert
             Assert.False(result);
@@ -48,12 +49,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
 
             // <p | class=""></p>
-            var location = new SourceSpan(3, 0);
+            var absoluteIndex = 3;
             var prefixLocation = new TextSpan(2, 2);
             var attributeNameLocation = new TextSpan(4, 5);
 
             // Act
-            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(location, prefixLocation, attributeNameLocation);
+            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(absoluteIndex, prefixLocation, attributeNameLocation);
 
             // Assert
             Assert.True(result);
@@ -65,12 +66,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
 
             // <svg xml:base="abc"xm| ></svg>
-            var location = new SourceSpan(21, 0);
+            var absoluteIndex = 21;
             TextSpan? prefixLocation = null;
             var attributeNameLocation = new TextSpan(4, 5);
 
             // Act
-            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(location, prefixLocation, attributeNameLocation);
+            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(absoluteIndex, prefixLocation, attributeNameLocation);
 
             // Assert
             Assert.False(result);
@@ -82,12 +83,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
 
             // <p |class=""></p>
-            var location = new SourceSpan(3, 0);
+            var absoluteIndex = 3;
             var prefixLocation = new TextSpan(2, 1);
             var attributeNameLocation = new TextSpan(3, 5);
 
             // Act
-            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(location, prefixLocation, attributeNameLocation);
+            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(absoluteIndex, prefixLocation, attributeNameLocation);
 
             // Assert
             Assert.False(result);
@@ -99,12 +100,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
 
             // <p cl|ass=""></p>
-            var location = new SourceSpan(5, 0);
+            var absoluteIndex = 5;
             var prefixLocation = new TextSpan(2, 1);
             var attributeNameLocation = new TextSpan(3, 5);
 
             // Act
-            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(location, prefixLocation, attributeNameLocation);
+            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(absoluteIndex, prefixLocation, attributeNameLocation);
 
             // Assert
             Assert.False(result);
@@ -116,12 +117,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
 
             // <p class=|""></p>
-            var location = new SourceSpan(9, 0);
+            var absoluteIndex = 9;
             var prefixLocation = new TextSpan(2, 1);
             var attributeNameLocation = new TextSpan(3, 5);
 
             // Act
-            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(location, prefixLocation, attributeNameLocation);
+            var result = DirectiveAttributeTransitionCompletionItemProvider.IsValidCompletionPoint(absoluteIndex, prefixLocation, attributeNameLocation);
 
             // Assert
             Assert.False(result);
@@ -131,12 +132,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_AttributeAreaInNonComponentFile_ReturnsEmptyList()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input  />", FileKinds.Legacy);
-            var location = new SourceSpan(7, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 7, "<input  />", FileKinds.Legacy);
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -146,12 +145,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_OutsideOfFile_ReturnsEmptyList()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input  />");
-            var location = new SourceSpan(50, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 50, "<input  />");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -161,12 +158,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_NonAttribute_ReturnsEmptyList()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input  />");
-            var location = new SourceSpan(2, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 2, "<input  />");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -176,12 +171,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_ExistingAttribute_ReturnsEmptyList()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input @ />");
-            var location = new SourceSpan(8, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 8, "<input @ />");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -191,13 +184,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_InbetweenSelfClosingEnd_ReturnsEmptyList()
         {
             // Arrange
-
-            var syntaxTree = GetSyntaxTree("<input /" + Environment.NewLine);
-            var location = new SourceSpan(8, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 8, "<input /" + Environment.NewLine);
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -207,12 +197,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_AttributeAreaInComponentFile_ReturnsTransitionCompletionItem()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input  />");
-            var location = new SourceSpan(7, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 7, "<input  />");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             var item = Assert.Single(result);
@@ -223,12 +211,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_AttributeAreaEndOfSelfClosingTag_ReturnsTransitionCompletionItem()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input />");
-            var location = new SourceSpan(7, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 7, "<input />");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             var item = Assert.Single(result);
@@ -239,12 +225,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_AttributeAreaEndOfOpeningTag_ReturnsTransitionCompletionItem()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input ></input>");
-            var location = new SourceSpan(7, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 7, "<input ></input>");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             var item = Assert.Single(result);
@@ -255,12 +239,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_ExistingAttribute_LeadingEdge_ReturnsEmptyList()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input src=\"xyz\" />");
-            var location = new SourceSpan(7, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 7, "<input src=\"xyz\" />");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -270,12 +252,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_ExistingAttribute_TrailingEdge_ReturnsEmptyList()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input src=\"xyz\" />");
-            var location = new SourceSpan(16, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 16, "<input src=\"xyz\" />");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -285,12 +265,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_ExistingAttribute_Partial_ReturnsEmptyList()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<svg xml: ></svg>");
-            var location = new SourceSpan(9, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 9, "<svg xml: ></svg>");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(result);
@@ -300,12 +278,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_AttributeAreaInIncompleteAttributeTransition_ReturnsTransitionCompletionItem()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<input   @{");
-            var location = new SourceSpan(7, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 7, "<input   @{");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             var item = Assert.Single(result);
@@ -316,12 +292,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetCompletionItems_AttributeAreaInIncompleteComponent_ReturnsTransitionCompletionItem()
         {
             // Arrange
-            var syntaxTree = GetSyntaxTree("<svg  xml:base=\"d\"></svg>");
-            var location = new SourceSpan(5, 0);
-            var context = new RazorCompletionContext(syntaxTree, TagHelperDocumentContext);
+            var context = CreateContext(absoluteIndex: 5, "<svg  xml:base=\"d\"></svg>");
 
             // Act
-            var result = Provider.GetCompletionItems(context, location);
+            var result = Provider.GetCompletionItems(context);
 
             // Assert
             var item = Assert.Single(result);
@@ -337,6 +311,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var syntaxTree = codeDocument.GetSyntaxTree();
 
             return syntaxTree;
+        }
+
+        private RazorCompletionContext CreateContext(int absoluteIndex, string documentContent, string fileKind = null)
+        {
+            var syntaxTree = GetSyntaxTree(documentContent, fileKind);
+            var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            var context = new RazorCompletionContext(absoluteIndex, owner, syntaxTree, TagHelperDocumentContext);
+            return context;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -57,11 +57,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetNearestAncestorTagInfo_MarkupElement()
         {
             // Arrange
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<p><strong></strong></p>", isRazorFile: false);
-            var sourceSpan = new SourceSpan(33 + Environment.NewLine.Length, 0);
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var owner = syntaxTree.Root.LocateOwner(new SourceChange(sourceSpan, string.Empty));
-            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
+            var context = CreateRazorCompletionContext(absoluteIndex: 33 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<p><strong></strong></p>", isRazorFile: false);
+            var element = context.Owner.FirstAncestorOrSelf<MarkupElementSyntax>();
             var service = new DefaultTagHelperFactsService();
 
             // Act
@@ -76,11 +73,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public void GetNearestAncestorTagInfo_TagHelperElement()
         {
             // Arrange
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><test2></test2></test1>", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(37 + Environment.NewLine.Length, 0);
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var owner = syntaxTree.Root.LocateOwner(new SourceChange(sourceSpan, string.Empty));
-            var element = owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
+            var context = CreateRazorCompletionContext(absoluteIndex: 37 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><test2></test2></test1>", isRazorFile: false, tagHelpers: DefaultTagHelpers);
+            var element = context.Owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
             var service = new DefaultTagHelperFactsService();
 
             // Act
@@ -96,12 +90,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 30 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -115,12 +107,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(33 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 33 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -131,12 +121,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}</t", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(32 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 32 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}</t", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -156,12 +144,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(32 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 32 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<br />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -172,12 +158,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 35 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -188,12 +172,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 36 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -217,13 +199,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
             var options = new RazorCompletionOptions(SnippetsSupported: true);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext(), Options: options);
+            var context = CreateRazorCompletionContext(absoluteIndex: 36 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />", isRazorFile: false, options, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -249,12 +229,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<title  mutator />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 36 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<title  mutator />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -272,12 +250,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2><</test2>", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(37 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 37 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2><</test2>", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -297,12 +273,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><</test1>", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(37 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 37 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><</test1>", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -326,12 +300,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 36 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -365,12 +337,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 attribute.AsDictionary("bool-val-", typeof(bool).FullName);
             });
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", isRazorFile: false, tagHelper.Build());
-            var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 35 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", isRazorFile: false, tagHelpers: tagHelper.Build());
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -404,12 +374,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 attribute.AsDictionary("int-val-", typeof(int).FullName);
             });
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", isRazorFile: false, tagHelper.Build());
-            var sourceSpan = new SourceSpan(35 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 35 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test />", isRazorFile: false, tagHelpers: tagHelper.Build());
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Collection(
@@ -433,12 +401,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 unbound />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 38 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 unbound />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -449,12 +415,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 bool-val />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 38 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 bool-val />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -465,12 +429,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 38 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -481,12 +443,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int-val='123' />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 38 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int-val='123' />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -498,12 +458,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int-val='>";
-            var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 38 + Environment.NewLine.Length, txt, isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -514,12 +472,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int->", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(36 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 36 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 int->", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             AssertBoolIntCompletions(completions);
@@ -530,12 +486,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
-            var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(43 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 43 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 class='' />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -547,12 +501,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2        class=''>";
-            var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-            var sourceSpan = new SourceSpan(38 + Environment.NewLine.Length, 0);
-            var context = new RazorCompletionContext(codeDocument.GetSyntaxTree(), codeDocument.GetTagHelperContext());
+            var context = CreateRazorCompletionContext(absoluteIndex: 38 + Environment.NewLine.Length, txt, isRazorFile: false, tagHelpers: DefaultTagHelpers);
 
             // Act
-            var completions = service.GetCompletionItems(context, sourceSpan);
+            var completions = service.GetCompletionItems(context);
 
             // Assert
             AssertBoolIntCompletions(completions);
@@ -572,6 +524,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
                 }
             );
+        }
+
+        private RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, string documentContent, bool isRazorFile, RazorCompletionOptions options = default, params TagHelperDescriptor[] tagHelpers)
+        {
+            var codeDocument = CreateCodeDocument(documentContent, isRazorFile, tagHelpers);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+
+            var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext, Options: options);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -19,14 +19,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create());
             var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: null, Enumerable.Empty<TagHelperDescriptor>());
             var completionItem1 = new RazorCompletionItem("displayText1", "insertText1", RazorCompletionItemKind.Directive);
-            var context = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
-            var provider1 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(context, default) == new[] { completionItem1 }, MockBehavior.Strict);
+            var context = new RazorCompletionContext(0, null, syntaxTree, tagHelperDocumentContext);
+            var provider1 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(context) == new[] { completionItem1 }, MockBehavior.Strict);
             var completionItem2 = new RazorCompletionItem("displayText2", "insertText2", RazorCompletionItemKind.Directive);
-            var provider2 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(context, default) == new[] { completionItem2 }, MockBehavior.Strict);
+            var provider2 = Mock.Of<RazorCompletionItemProvider>(p => p.GetCompletionItems(context) == new[] { completionItem2 }, MockBehavior.Strict);
             var completionFactsService = new DefaultRazorCompletionFactsService(new[] { provider1, provider2 });
 
             // Act
-            var completionItems = completionFactsService.GetCompletionItems(context, default);
+            var completionItems = completionFactsService.GetCompletionItems(context);
 
             // Assert
             Assert.Equal(new[] { completionItem1, completionItem2 }, completionItems);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
@@ -49,14 +50,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_LocationHasNoOwner_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(30, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 30, "<input @  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -66,14 +63,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_OnNonAttributeArea_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(3, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 3, "<input @  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -83,14 +76,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_OnDirectiveAttributeParameter_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @bind:fo  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(14, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 14, "<input @bind:fo  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -100,14 +89,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_OnDirectiveAttributeName_bind_ReturnsCompletions()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(8, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 8, "<input @  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             AssertContains(completions, "bind", "@bind", new[] { "=", ":" });
@@ -117,14 +102,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_OnDirectiveAttributeName_attributes_ReturnsCompletions()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(8, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 8, "<input @  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             AssertContains(completions, "attributes", "@attributes", new[] { "=" });
@@ -134,14 +115,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_AttributeAreaEndOfSelfClosingTag_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @bind:fo  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(16, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 16, "<input @bind:fo  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -151,14 +128,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_AttributeAreaEndOfOpeningTag_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @bind:fo   ></input>");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(16, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 16, "<input @bind:fo   ></input>");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -168,14 +141,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_ExistingAttribute_LeadingEdge_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input src=\"xyz\" />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(7, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 7, "<input src=\"xyz\" />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -185,14 +154,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_ExistingAttribute_TrailingEdge_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input src=\"xyz\" />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(16, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 16, "<input src=\"xyz\" />");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -202,14 +167,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_ExistingAttribute_Partial_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<svg xml: ></svg>");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(9, 0);
-            var razorCompletionContext = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 9, "<svg xml: ></svg>");
 
             // Act
-            var completions = Provider.GetCompletionItems(razorCompletionContext, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -332,6 +293,17 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.DoesNotContain(completions, completion => insertText == completion.InsertText &&
                    displayText == completion.DisplayText &&
                    RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
+        }
+
+        private RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, string documentContent)
+        {
+            var codeDocument = GetCodeDocument(documentContent);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+
+            var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
@@ -48,14 +49,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_LocationHasNoOwner_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(30, 0);
-            var context = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 30, "<input @  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(context, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -65,14 +62,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_OnNonAttributeArea_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(3, 0);
-            var context = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 3, "<input @  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(context, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -82,14 +75,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_OnDirectiveAttributeName_ReturnsEmptyCollection()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @bind:fo  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(8, 0);
-            var context = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 8, "<input @bind:fo  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(context, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Empty(completions);
@@ -99,14 +88,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         public void GetCompletionItems_OnDirectiveAttributeParameter_ReturnsCompletions()
         {
             // Arrange
-            var codeDocument = GetCodeDocument("<input @bind:fo  />");
-            var syntaxTree = codeDocument.GetSyntaxTree();
-            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
-            var span = new SourceSpan(14, 0);
-            var context = new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var context = CreateRazorCompletionContext(absoluteIndex: 14, "<input @bind:fo  />");
 
             // Act
-            var completions = Provider.GetCompletionItems(context, span);
+            var completions = Provider.GetCompletionItems(context);
 
             // Assert
             Assert.Equal(3, completions.Count);
@@ -201,6 +186,17 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.DoesNotContain(completions, completion => insertText == completion.InsertText &&
                    insertText == completion.DisplayText &&
                    RazorCompletionItemKind.DirectiveAttributeParameter == completion.Kind);
+        }
+
+        private RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, string documentContent)
+        {
+            var codeDocument = GetCodeDocument(documentContent);
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+
+            var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -145,11 +145,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@");
-            var location = new SourceSpan(2, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 2, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -160,11 +159,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@{");
-            var location = new SourceSpan(2, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 2, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -175,11 +173,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@DateTime.Now");
-            var location = new SourceSpan(2, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 2, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -190,11 +187,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@(something)");
-            var location = new SourceSpan(4, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 4, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -205,11 +201,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@{ @ }");
-            var location = new SourceSpan(4, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 4, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -220,11 +215,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("<p>@ </p>");
-            var location = new SourceSpan(4, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 4, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -235,11 +229,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("<p @ >");
-            var location = new SourceSpan(4, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 4, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -250,11 +243,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@functions { @  }", FunctionsDirective.Directive);
-            var location = new SourceSpan(14, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 14, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -265,11 +257,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@m");
-            var location = new SourceSpan(1, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 1, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.True(result);
@@ -280,11 +271,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@mod");
-            var location = new SourceSpan(2, 0);
-            var context = CreateRazorCompletionContext(syntaxTree, CompletionReason.Typing);
+            var context = CreateRazorCompletionContext(absoluteIndex: 2, syntaxTree, CompletionReason.Typing);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.False(result);
@@ -295,11 +285,10 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@mod");
-            var location = new SourceSpan(2, 0);
-            var context = CreateRazorCompletionContext(syntaxTree);
+            var context = CreateRazorCompletionContext(absoluteIndex: 2, syntaxTree);
 
             // Act
-            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context, location);
+            var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
 
             // Assert
             Assert.True(result);
@@ -371,11 +360,12 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.False(result);
         }
 
-        private static RazorCompletionContext CreateRazorCompletionContext(RazorSyntaxTree syntaxTree, CompletionReason reason = CompletionReason.Invoked)
+        private static RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, RazorSyntaxTree syntaxTree, CompletionReason reason = CompletionReason.Invoked)
         {
             var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Array.Empty<TagHelperDescriptor>());
-
-            return new RazorCompletionContext(syntaxTree, tagHelperDocumentContext, reason);
+            var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext, reason);
         }
 
         private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item, IReadOnlyList<RazorCommitCharacter> commitCharacters = null)

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
@@ -26,11 +26,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("<div>");
-            var location = new SourceSpan(5, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 5;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -41,11 +41,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("<div><");
-            var location = new SourceSpan(6, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 6;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -56,11 +56,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("<div><span><p></p><p>< </p></span></div>");
-            var location = new SourceSpan(22, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 22;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -71,11 +71,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@{<");
-            var location = new SourceSpan(3, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 3;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Collection(completionItems, AssertRazorCompletionItem);
@@ -86,11 +86,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@{<te");
-            var location = new SourceSpan(5, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 5;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Collection(completionItems, AssertRazorCompletionItem);
@@ -101,11 +101,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@if (true) {< }");
-            var location = new SourceSpan(13, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 13;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Collection(completionItems, AssertRazorCompletionItem);
@@ -116,11 +116,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@functions {public string GetHello(){< return \"pi\";}}", FunctionsDirective.Directive);
-            var location = new SourceSpan(38, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 38;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Collection(completionItems, AssertRazorCompletionItem);
@@ -141,11 +141,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 {
     <
 })");
-            var location = new SourceSpan(121 + (Environment.NewLine.Length * 9), 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 121 + (Environment.NewLine.Length * 9);
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -159,11 +159,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     @* @: Here's some Markup | <-- You shouldn't get a <text> tag completion here. *@
     @: Here's some markup <
 }");
-            var location = new SourceSpan(114 + (Environment.NewLine.Length * 2), 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 114 + (Environment.NewLine.Length * 2);
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -179,11 +179,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
   < @* Should get text completion here *@
 }
 </div>");
-            var location = new SourceSpan(19 + (Environment.NewLine.Length * 3), 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 19 + (Environment.NewLine.Length * 3);
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Collection(completionItems, AssertRazorCompletionItem);
@@ -199,11 +199,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
   < @* Shouldn't get text completion here *@
 </div>
 }");
-            var location = new SourceSpan(19 + (Environment.NewLine.Length * 3), 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 19 + (Environment.NewLine.Length * 3);
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -221,11 +221,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
 
     private bool _collapseNavMenu => true;
 }", FunctionsDirective.Directive);
-            var location = new SourceSpan(59 + (Environment.NewLine.Length * 3), 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 59 + (Environment.NewLine.Length * 3);
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Collection(completionItems, AssertRazorCompletionItem);
@@ -236,11 +236,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@{<></>");
-            var location = new SourceSpan(3, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 3;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Collection(completionItems, AssertRazorCompletionItem);
@@ -251,11 +251,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@DateTime.Now<");
-            var location = new SourceSpan(14, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 14;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -266,11 +266,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@(something)<");
-            var location = new SourceSpan(13, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 13;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -281,11 +281,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@{< ");
-            var location = new SourceSpan(4, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 4;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -296,11 +296,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("@{< te=\"\"");
-            var location = new SourceSpan(6, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 6;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -311,11 +311,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         {
             // Arrange
             var syntaxTree = CreateSyntaxTree("<p < >");
-            var location = new SourceSpan(4, 0);
-            var razorCompletionContext = CreateRazorCompletionContext(syntaxTree);
+            var absoluteIndex = 4;
+            var razorCompletionContext = CreateRazorCompletionContext(absoluteIndex, syntaxTree);
 
             // Act
-            var completionItems = Provider.GetCompletionItems(razorCompletionContext, location);
+            var completionItems = Provider.GetCompletionItems(razorCompletionContext);
 
             // Assert
             Assert.Empty(completionItems);
@@ -329,11 +329,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Equal(CodeAnalysisResources.MarkupTransition_Description, completionDescription.Description);
         }
 
-        private static RazorCompletionContext CreateRazorCompletionContext(RazorSyntaxTree syntaxTree)
+        private static RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, RazorSyntaxTree syntaxTree)
         {
             var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Array.Empty<TagHelperDescriptor>());
 
-            return new RazorCompletionContext(syntaxTree, tagHelperDocumentContext);
+            var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(queryableChange);
+            return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
         }
 
         private static RazorSyntaxTree CreateSyntaxTree(string text, params DirectiveDescriptor[] directives)


### PR DESCRIPTION
- This is pre-requisite work for building centralized aggregation systems. The gist is to pre-compute as much data as possible and in the midst of prototyping the work I found that completion was a significant offender in this area.
    - One hugely positive impact of this will be that we wont need to re-resolve owners for SyntaxTrees (not always cheap) at completion time.
- Updated tests and all call sites to no longer compute owners / absolute indexes and instead rely on the contexts.

Part of #6432