### PR TITLE
Move DocumentSync to VSContracts

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidChangeTextDocumentParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidChangeTextDocumentParamsBridge.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    /// <summary>
+    /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="DidChangeTextDocumentParams"/>
+    /// type does not implement <see cref="IRequest"/>.
+    /// </summary>
+    internal class DidChangeTextDocumentParamsBridge : DidChangeTextDocumentParams, IRequest
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidCloseTextDocumentParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidCloseTextDocumentParamsBridge.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    /// <summary>
+    /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="DidCloseTextDocumentParamsBridge"/>
+    /// type does not implement <see cref="IRequest"/>.
+    /// </summary>
+    internal class DidCloseTextDocumentParamsBridge : DidCloseTextDocumentParams, IRequest
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidOpenTextDocumentParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidOpenTextDocumentParamsBridge.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    /// <summary>
+    /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="DidOpenTextDocumentParamsBridge"/>
+    /// type does not implement <see cref="IRequest"/>.
+    /// </summary>
+    internal class DidOpenTextDocumentParamsBridge : DidOpenTextDocumentParams, IRequest
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidSaveTextDocumentParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidSaveTextDocumentParamsBridge.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    /// <summary>
+    /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="DidSaveTextDocumentParamsBridge"/>
+    /// type does not implement <see cref="IRequest"/>.
+    /// </summary>
+    internal class DidSaveTextDocumentParamsBridge : DidSaveTextDocumentParams, IRequest
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidChangeTextDocumentEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidChangeTextDocumentEndpoint.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    [Serial, Method(Methods.TextDocumentDidChangeName)]
+    internal interface IVSDidChangeTextDocumentEndpoint : IJsonRpcNotificationHandler<DidChangeTextDocumentParamsBridge>, IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidCloseTextDocumentEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidCloseTextDocumentEndpoint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    [Serial, Method(Methods.TextDocumentDidCloseName)]
+    internal interface IVSDidCloseTextDocumentEndpoint: IJsonRpcNotificationHandler<DidCloseTextDocumentParamsBridge>,
+        IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidOpenTextDocumentEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidOpenTextDocumentEndpoint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    [Serial, Method(Methods.TextDocumentDidOpenName)]
+    internal interface IVSDidOpenTextDocumentEndpoint : IJsonRpcNotificationHandler<DidOpenTextDocumentParamsBridge>,
+        IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidSaveTextDocumentEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSDidSaveTextDocumentEndpoint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    [Serial, Method(Methods.TextDocumentDidSaveName)]
+    internal interface IVSDidSaveTextDocumentEndpoint : IJsonRpcNotificationHandler<DidSaveTextDocumentParamsBridge>,
+        IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSTextDocumentSyncHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSTextDocumentSyncHandler.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    internal interface IVSTextDocumentSyncHandler
+        : IVSDidChangeTextDocumentEndpoint, IVSDidOpenTextDocumentEndpoint, IVSDidCloseTextDocumentEndpoint, IVSDidSaveTextDocumentEndpoint,
+        IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -6,20 +6,17 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
-using OmniSharp.Extensions.LanguageServer.Protocol;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
-using OmniSharp.Extensions.LanguageServer.Protocol.Document;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal class RazorDocumentSynchronizationEndpoint : ITextDocumentSyncHandler
+    internal class RazorDocumentSynchronizationEndpoint : IVSTextDocumentSyncHandler
     {
         private readonly ILogger _logger;
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
@@ -58,9 +55,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _logger = loggerFactory.CreateLogger<RazorDocumentSynchronizationEndpoint>();
         }
 
-        public TextDocumentSyncKind Change { get; } = TextDocumentSyncKind.Incremental;
-
-        public async Task<Unit> Handle(DidChangeTextDocumentParams notification, CancellationToken token)
+        public async Task<Unit> Handle(DidChangeTextDocumentParamsBridge notification, CancellationToken token)
         {
             var uri = notification.TextDocument.Uri.GetAbsoluteOrUNCPath();
             var document = await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>
@@ -78,82 +73,38 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var sourceText = await document.GetTextAsync();
             sourceText = ApplyContentChanges(notification.ContentChanges, sourceText);
 
-            if (notification.TextDocument.Version is null)
-            {
-                throw new InvalidOperationException(RazorLS.Resources.Version_Should_Not_Be_Null);
-            }
-
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
-                () => _projectService.UpdateDocument(document.FilePath, sourceText, notification.TextDocument.Version.Value),
+                () => _projectService.UpdateDocument(document.FilePath, sourceText, notification.TextDocument.Version),
                 CancellationToken.None).ConfigureAwait(false);
 
             return Unit.Value;
         }
 
-        public async Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken token)
+        public async Task<Unit> Handle(DidOpenTextDocumentParamsBridge notification, CancellationToken token)
         {
             var sourceText = SourceText.From(notification.TextDocument.Text);
 
-            if (notification.TextDocument.Version is null)
-            {
-                throw new InvalidOperationException(RazorLS.Resources.Version_Should_Not_Be_Null);
-            }
-
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
-                () => _projectService.OpenDocument(notification.TextDocument.Uri.GetAbsoluteOrUNCPath(), sourceText, notification.TextDocument.Version.Value),
+                () => _projectService.OpenDocument(notification.TextDocument.Uri.GetAbsoluteOrUNCPath(), sourceText, notification.TextDocument.Version),
                 CancellationToken.None).ConfigureAwait(false);
 
             return Unit.Value;
         }
 
-        public async Task<Unit> Handle(DidCloseTextDocumentParams notification, CancellationToken token)
+        public async Task<Unit> Handle(DidCloseTextDocumentParamsBridge notification, CancellationToken token)
         {
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(
                 () => _projectService.CloseDocument(notification.TextDocument.Uri.GetAbsoluteOrUNCPath()),
-                CancellationToken.None).ConfigureAwait(false);
+                token).ConfigureAwait(false);
 
             return Unit.Value;
         }
 
-        public Task<Unit> Handle(DidSaveTextDocumentParams notification, CancellationToken token)
+        public Task<Unit> Handle(DidSaveTextDocumentParamsBridge notification, CancellationToken _)
         {
             _logger.LogInformation($"Saved Document {notification.TextDocument.Uri.GetAbsoluteOrUNCPath()}");
 
             return Unit.Task;
-        }
-
-        public TextDocumentChangeRegistrationOptions GetRegistrationOptions(SynchronizationCapability capability, ClientCapabilities clientCapabilities)
-        {
-            return new TextDocumentChangeRegistrationOptions()
-            {
-                DocumentSelector = RazorDefaults.Selector,
-                SyncKind = Change
-            };
-        }
-
-        TextDocumentOpenRegistrationOptions IRegistration<TextDocumentOpenRegistrationOptions, SynchronizationCapability>.GetRegistrationOptions(SynchronizationCapability capability, ClientCapabilities clientCapabilities)
-        {
-            return new TextDocumentOpenRegistrationOptions()
-            {
-                DocumentSelector = RazorDefaults.Selector
-            };
-        }
-
-        TextDocumentCloseRegistrationOptions IRegistration<TextDocumentCloseRegistrationOptions, SynchronizationCapability>.GetRegistrationOptions(SynchronizationCapability capability, ClientCapabilities clientCapabilities)
-        {
-            return new TextDocumentCloseRegistrationOptions()
-            {
-                DocumentSelector = RazorDefaults.Selector
-            };
-        }
-
-        TextDocumentSaveRegistrationOptions IRegistration<TextDocumentSaveRegistrationOptions, SynchronizationCapability>.GetRegistrationOptions(SynchronizationCapability capability, ClientCapabilities clientCapabilities)
-        {
-            return new TextDocumentSaveRegistrationOptions()
-            {
-                DocumentSelector = RazorDefaults.Selector,
-                IncludeText = true
-            };
         }
 
         // Internal for testing
@@ -166,12 +117,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     throw new ArgumentNullException(nameof(change.Range), "Range of change should not be null.");
                 }
 
-                var linePosition = new LinePosition(change.Range.Start.Line, change.Range.Start.Character);
-                var position = sourceText.Lines.GetPosition(linePosition);
-                var textSpan = new TextSpan(position, change.RangeLength);
+                var startLinePosition = new LinePosition(change.Range.Start.Line, change.Range.Start.Character);
+                var startPosition = sourceText.Lines.GetPosition(startLinePosition);
+                var endLinePosition = new LinePosition(change.Range.End.Line, change.Range.End.Character);
+                var endPosition = sourceText.Lines.GetPosition(endLinePosition);
+
+                var textSpan = new TextSpan(startPosition, change.RangeLength ?? endPosition - startPosition);
                 var textChange = new TextChange(textSpan, change.Text);
 
-                _logger.LogTrace("Applying " + textChange);
+                _logger.LogTrace($"Applying {textChange}");
 
                 // If there happens to be multiple text changes we generate a new source text for each one. Due to the
                 // differences in VSCode and Roslyn's representation we can't pass in all changes simultaneously because
@@ -182,9 +136,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return sourceText;
         }
 
-        public TextDocumentAttributes GetTextDocumentAttributes(DocumentUri uri)
+        public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            return new TextDocumentAttributes(uri, "razor");
+            const string AssociatedServerCapability = "textDocumentSync";
+            var registrationOptions = new TextDocumentSyncOptions()
+            {
+                Change = TextDocumentSyncKind.Incremental,
+                OpenClose = true,
+                Save = new SaveOptions()
+                {
+                    IncludeText = true,
+                },
+                WillSave = false,
+                WillSaveWaitUntil = false,
+            };
+
+            var result = new RegistrationExtensionResult(AssociatedServerCapability, registrationOptions);
+
+            return result;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentSynchronizationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentSynchronizationEndpointTest.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -30,7 +29,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var sourceText = SourceText.From("Hello World");
             var change = new TextDocumentContentChangeEvent()
             {
-                Range = new Range(new Position(0, 5), new Position(0, 5)),
+                Range = new Range
+                {
+                    Start = new Position(0, 5),
+                    End = new Position(0, 5),
+                },
                 RangeLength = 0,
                 Text = "!"
             };
@@ -52,7 +55,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var changes = new[] {
                 new TextDocumentContentChangeEvent()
                 {
-                    Range = new Range(new Position(0, 5), new Position(0, 5)),
+                    Range = new Range{
+                        Start = new Position(0, 5),
+                        End = new Position(0, 5)
+                    },
                     RangeLength = 0,
                     Text = Environment.NewLine
                 },
@@ -61,7 +67,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 new TextDocumentContentChangeEvent()
                 {
-                    Range = new Range(new Position(1, 0), new Position(1, 0)),
+                    Range = new Range{
+                        Start = new Position(1, 0),
+                        End = new Position(1, 0),
+                    },
                     RangeLength = 0,
                     Text = "!"
                 },
@@ -70,7 +79,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 new TextDocumentContentChangeEvent()
                 {
-                    Range = new Range(new Position(0, 1), new Position(0, 1)),
+                    Range = new Range{
+                        Start = new Position(0, 1),
+                        End = new Position(0, 1)
+                    },
                     RangeLength = 4,
                     Text = "i!" + Environment.NewLine
                 },
@@ -109,14 +121,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, documentResolver, projectService.Object, LoggerFactory);
             var change = new TextDocumentContentChangeEvent()
             {
-                Range = new Range(new Position(0, 3), new Position(0, 3)),
+                Range = new Range
+                {
+                    Start = new Position(0, 3),
+                    End = new Position(0, 3),
+                },
                 RangeLength = 0,
                 Text = "</p>"
             };
-            var request = new DidChangeTextDocumentParams()
+            var request = new DidChangeTextDocumentParamsBridge()
             {
-                ContentChanges = new Container<TextDocumentContentChangeEvent>(change),
-                TextDocument = new OptionalVersionedTextDocumentIdentifier()
+                ContentChanges = new TextDocumentContentChangeEvent[] { change },
+                TextDocument = new VersionedTextDocumentIdentifier()
                 {
                     Uri = new Uri(documentPath),
                     Version = 1337,
@@ -146,7 +162,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     Assert.Equal(1337, version);
                 });
             var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, projectService.Object, LoggerFactory);
-            var request = new DidOpenTextDocumentParams()
+            var request = new DidOpenTextDocumentParamsBridge()
             {
                 TextDocument = new TextDocumentItem()
                 {
@@ -173,7 +189,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             projectService.Setup(service => service.CloseDocument(It.IsAny<string>()))
                 .Callback<string>((path) => Assert.Equal(documentPath, path));
             var endpoint = new RazorDocumentSynchronizationEndpoint(Dispatcher, DocumentResolver, projectService.Object, LoggerFactory);
-            var request = new DidCloseTextDocumentParams()
+            var request = new DidCloseTextDocumentParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {


### PR DESCRIPTION
### Summary of the changes

- Move the TextDocumentSync Endpoint to VS Contracts

Fixes: https://github.com/dotnet/razor-tooling/issues/6366
