### PR TITLE
Mef logging

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -47,6 +48,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             EnsureLSPEditorEnabled();
             await EnsureTextViewRolesAsync(ControlledHangMitigatingCancellationToken);
             await EnsureExtensionInstalledAsync(ControlledHangMitigatingCancellationToken);
+            EnsureMEFCompositionSuccessForRazor();
 
             await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, expectedClassification: RazorComponentElementClassification, count: 3);
 
@@ -64,6 +66,37 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
 
             var useLegacyEditor = settingsManager.GetValueOrDefault<bool>(UseLegacyASPNETCoreEditorSetting);
             Assert.AreEqual(false, useLegacyEditor, "Expected the Legacy Razor Editor to be disabled, but it was enabled");
+        }
+
+        private static void EnsureMEFCompositionSuccessForRazor()
+        {
+            var hiveDirectories = VisualStudioLogging.GetHiveDirectories();
+            if (hiveDirectories.Count() != 1)
+            {
+                throw new ArgumentOutOfRangeException("Should only have one hive");
+            }
+
+            var hiveDirectory = hiveDirectories.Single();
+            var cmcPath = Path.Combine(hiveDirectory, "ComponentModelCache");
+            if (!Directory.Exists(cmcPath))
+            {
+                throw new InvalidOperationException("ComponentModelCache directory doesn't exist");
+            }
+
+            var mefErrorFile = Path.Combine(cmcPath, "Microsoft.VisualStudio.Default.err");
+            if (!File.Exists(mefErrorFile))
+            {
+                throw new InvalidOperationException("Expected ComponentModelCache error file to exist");
+            }
+
+            var txt = File.ReadAllText(mefErrorFile);
+            const string Separator = "----------- Used assemblies -----------";
+            var content = txt.Split(new string[] { Separator }, StringSplitOptions.RemoveEmptyEntries);
+            var errors = content[0];
+            if (errors.Contains("Razor"))
+            {
+                throw new InvalidOperationException($"Razor errors detected in MEF cache: {errors}");
+            }
         }
 
         private async Task EnsureTextViewRolesAsync(CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/FeedbackLogging.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/FeedbackLogging.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
         public const string ServiceHubLogId = "ServiceHubLog";
         public const string ComponentModelCacheId = "ComponentModelCache";
         public const string ExtensionDirectoryId = "ExtensionDirectory";
+        public const string MEFErrorId = "MEFErrorsFromHive";
 
         private static readonly object s_lockObj = new();
 
@@ -39,9 +40,21 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
                     DataCollectionService.RegisterCustomLogger(RazorServiceHubLogger, ServiceHubLogId, "zip");
                     DataCollectionService.RegisterCustomLogger(RazorComponentModelCacheLogger, ComponentModelCacheId, "zip");
                     DataCollectionService.RegisterCustomLogger(RazorExtensionExplorerLogger, ExtensionDirectoryId, "txt");
+                    DataCollectionService.RegisterCustomLogger(RazorMEFErrorLogger, MEFErrorId, "txt");
 
                     s_customLoggersAdded = true;
                 }
+            }
+        }
+
+        private static void RazorMEFErrorLogger(string filePath)
+        {
+            var hiveDirectories = GetHiveDirectories();
+            var hiveDirectory = hiveDirectories.Single();
+            var errorFile = Path.Combine(hiveDirectory, "ComponentModelCache", "Microsoft.VisualStudio.Defaullt.err");
+            if (File.Exists(errorFile))
+            {
+                File.Copy(errorFile, filePath);
             }
         }
 
@@ -118,7 +131,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             File.WriteAllText(filePath, fileBuilder.ToString());
         }
 
-        private static IEnumerable<string> GetHiveDirectories()
+        internal static IEnumerable<string> GetHiveDirectories()
         {
             var localAppData = Environment.GetEnvironmentVariable("LocalAppData");
             var vsLocalDir = Path.Combine(localAppData, "Microsoft", "VisualStudio");


### PR DESCRIPTION
### Summary of the changes

- Manually collect the MEF logs from the hive because the one collected by Feedback seems to only be for the main part of VS.
- Also fail on test initialize if we have Razor errors in the MEF cache. This makes sure we fail fast and that the error is exposed early.

Fixes: https://github.com/dotnet/razor-tooling/issues/6439
