### PR TITLE
Add support for multiple completion  item resolvers.

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
@@ -94,7 +94,6 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.Serialization
             var razorCompletionItems = componentCompletionProvider.GetCompletionItems(context);
             var completionList = RazorCompletionListProvider.CreateLSPCompletionList(
                 razorCompletionItems,
-                new CompletionListCache(),
                 new VSInternalClientCapabilities()
                 {
                     TextDocument = new TextDocumentClientCapabilities()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/AggregateCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/AggregateCompletionItemResolver.cs
@@ -68,16 +68,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return null;
             }
 
-            var finalCompletionItem = resolvedCompletionItems.Dequeue();
-            while (resolvedCompletionItems.Count > 0)
-            {
-                var nextCompletionItem = resolvedCompletionItems.Dequeue();
-
-                // We don't currently handle merging completion items because it's very rare for more than one resolution to take place.
-                // Instead we'll prioritized the last completion item resolved.
-                finalCompletionItem = nextCompletionItem;
-            }
-
+            // We don't currently handle merging completion items because it's very rare for more than one resolution to take place.
+            // Instead we'll prioritized the last completion item resolved.
+            var finalCompletionItem = resolvedCompletionItems.Last();
             return finalCompletionItem;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/AggregateCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/AggregateCompletionItemResolver.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class AggregateCompletionItemResolver
+    {
+        private readonly IReadOnlyList<CompletionItemResolver> _completionItemResolvers;
+        private readonly ILogger<AggregateCompletionItemResolver> _logger;
+
+        public AggregateCompletionItemResolver(IEnumerable<CompletionItemResolver> completionItemResolvers, ILoggerFactory loggerFactory)
+        {
+            _completionItemResolvers = completionItemResolvers.ToArray();
+            _logger = loggerFactory.CreateLogger<AggregateCompletionItemResolver>();
+        }
+
+        public async Task<VSInternalCompletionItem?> ResolveAsync(
+            VSInternalCompletionItem item,
+            VSInternalCompletionList containingCompletionList,
+            object? originalRequestContext,
+            VSInternalClientCapabilities? clientCapabilities,
+            CancellationToken cancellationToken)
+        {
+            var completionItemResolverTasks = new List<Task<VSInternalCompletionItem?>>(_completionItemResolvers.Count);
+
+            foreach (var completionItemResolver in _completionItemResolvers)
+            {
+                try
+                {
+                    var task = completionItemResolver.ResolveAsync(item, containingCompletionList, originalRequestContext, clientCapabilities, cancellationToken);
+                    completionItemResolverTasks.Add(task);
+                }
+                catch (Exception ex) when (ex is not TaskCanceledException)
+                {
+                    _logger.LogError(ex, "Resolving completion item failed synchronously unexpectedly.");
+                }
+            }
+
+            var resolvedCompletionItems = new Queue<VSInternalCompletionItem>();
+            foreach (var completionItemResolverTask in completionItemResolverTasks)
+            {
+                try
+                {
+                    var resolvedCompletionItem = await completionItemResolverTask.ConfigureAwait(false);
+                    if (resolvedCompletionItem is not null)
+                    {
+                        resolvedCompletionItems.Enqueue(resolvedCompletionItem);
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogError(ex, "Resolving completion item failed unexpectedly.");
+                }
+            }
+
+            if (resolvedCompletionItems.Count == 0)
+            {
+                return null;
+            }
+
+            var finalCompletionItem = resolvedCompletionItems.Dequeue();
+            while (resolvedCompletionItems.Count > 0)
+            {
+                var nextCompletionItem = resolvedCompletionItems.Dequeue();
+
+                // We don't currently handle merging completion items because it's very rare for more than one resolution to take place.
+                // Instead we'll prioritized the last completion item resolved.
+                finalCompletionItem = nextCompletionItem;
+            }
+
+            return finalCompletionItem;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/AggregateCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/AggregateCompletionListProvider.cs
@@ -17,7 +17,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         private readonly IReadOnlyList<CompletionListProvider> _completionListProviders;
         private readonly ILogger<AggregateCompletionListProvider> _logger;
 
-        public AggregateCompletionListProvider(IEnumerable<CompletionListProvider> completionListProviders, ILoggerFactory loggerFactory)
+        public AggregateCompletionListProvider(
+            IEnumerable<CompletionListProvider> completionListProviders,
+            ILoggerFactory loggerFactory)
         {
             _completionListProviders = completionListProviders.ToArray();
             _logger = loggerFactory.CreateLogger<AggregateCompletionListProvider>();
@@ -71,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
                     cancellationToken.ThrowIfCancellationRequested();
                 }
-                catch (Exception ex) when (ex is not TaskCanceledException)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogError(ex, "Resolving completions failed unexpectedly.");
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionItemResolver.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal abstract class CompletionItemResolver
+    {
+        public abstract Task<VSInternalCompletionItem?> ResolveAsync(
+            VSInternalCompletionItem item,
+            VSInternalCompletionList containingCompletionlist,
+            object? originalRequestContext,
+            VSInternalClientCapabilities? clientCapabilities,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
@@ -3,68 +3,71 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Razor.Completion;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     internal sealed class CompletionListCache
     {
         // Internal for testing
-        internal static readonly int MaxCacheSize = 3;
+        internal static readonly int MaxCacheSize = 10;
 
         private readonly object _accessLock;
-        private readonly List<(long, IReadOnlyList<RazorCompletionItem>)> _resultIdToCompletionList;
-        private long _nextResultId;
+        private readonly List<CacheEntry> _resultIdToCacheEntry;
+        private int _nextResultId;
 
         public CompletionListCache()
         {
             _accessLock = new object();
-            _resultIdToCompletionList = new List<(long, IReadOnlyList<RazorCompletionItem>)>();
+            _resultIdToCacheEntry = new List<CacheEntry>();
         }
 
-        public long Set(IReadOnlyList<RazorCompletionItem> razorCompletionList)
+        public int Set(VSInternalCompletionList completionList, object? context)
         {
-            if (razorCompletionList is null)
+            if (completionList is null)
             {
-                throw new ArgumentNullException(nameof(razorCompletionList));
+                throw new ArgumentNullException(nameof(completionList));
             }
 
             lock (_accessLock)
             {
                 // If cache exceeds maximum size, remove the oldest list in the cache
-                if (_resultIdToCompletionList.Count >= MaxCacheSize)
+                if (_resultIdToCacheEntry.Count >= MaxCacheSize)
                 {
-                    _resultIdToCompletionList.RemoveAt(0);
+                    _resultIdToCacheEntry.RemoveAt(0);
                 }
 
                 var resultId = _nextResultId++;
-
-                _resultIdToCompletionList.Add((resultId, razorCompletionList));
+                var cacheEntry = new CacheEntry(resultId, completionList, context);
+                _resultIdToCacheEntry.Add(cacheEntry);
 
                 // Return generated resultId so completion list can later be retrieved from cache
                 return resultId;
             }
         }
 
-        public bool TryGet(long resultId, out IReadOnlyList<RazorCompletionItem>? completionList)
+        public bool TryGet(int resultId, [NotNullWhen(returnValue: true)] out CacheEntry? cachedEntry)
         {
             lock (_accessLock)
             {
                 // Search back -> front because the items in the back are the most recently added which are most frequently accessed.
-                for (var i = _resultIdToCompletionList.Count - 1; i >= 0; i--)
+                for (var i = _resultIdToCacheEntry.Count - 1; i >= 0; i--)
                 {
-                    var (cachedResultId, cachedCompletionList) = _resultIdToCompletionList[i];
-                    if (cachedResultId == resultId)
+                    var entry = _resultIdToCacheEntry[i];
+                    if (entry.ResultId == resultId)
                     {
-                        completionList = cachedCompletionList;
+                        cachedEntry = entry;
                         return true;
                     }
                 }
 
-                // A completion list associated with the given resultId was not found
-                completionList = null;
+                // A cache entry associated with the given resultId was not found
+                cachedEntry = null;
                 return false;
             }
         }
+
+        public record CacheEntry(int ResultId, VSInternalCompletionList CompletionList, object? Context);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListOptimizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListOptimizer.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             if (completionCapability is not null)
             {
                 completionList = OptimizeCommitCharacters(completionList, completionCapability);
-                completionList = OptimizeData(completionList, completionCapability);
             }
 
             // We wrap the pre-existing completion list with an optimized completion list to better control serialization/deserialization
@@ -33,19 +32,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             // The commit characters capability is a VS capability with how we utilize it, therefore we want to promote onto the VS list.
             completionList = PromoteVSCommonCommitCharactersOntoList(completionList);
-            return completionList;
-        }
-
-        private static VSInternalCompletionList OptimizeData(VSInternalCompletionList completionList, VSInternalCompletionSetting completionCapability)
-        {
-            var completionListCapability = completionCapability.CompletionList;
-            if (completionListCapability?.Data != true)
-            {
-                return completionList;
-            }
-
-            completionList = PromoteDataOntoList(completionList);
-
             return completionList;
         }
 
@@ -96,26 +82,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             }
 
             completionList.CommitCharacters = mostUsedCommitCharacterToItems.Value.VsCommitCharacters;
-            return completionList;
-        }
-
-        private static VSInternalCompletionList PromoteDataOntoList(VSInternalCompletionList completionList)
-        {
-            // This piece makes a massive assumption that all completion items will have a resultId associated with them and their
-            // data properties will all be the same. Therefore, we can inspect the first item and empty out the rest.
-            var commonData = completionList.Items.FirstOrDefault()?.Data;
-            if (commonData is null)
-            {
-                // No common data items, nothing to do
-                return completionList;
-            }
-
-            foreach (var completionItem in completionList.Items)
-            {
-                completionItem.Data = null;
-            }
-
-            completionList.Data = commonData;
             return completionList;
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal class RazorCompletionItemResolver : CompletionItemResolver
+    {
+        private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
+        private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
+
+        public RazorCompletionItemResolver(
+            LSPTagHelperTooltipFactory lspTagHelperTooltipFactory,
+            VSLSPTagHelperTooltipFactory vsLspTagHelperTooltipFactory)
+        {
+            _lspTagHelperTooltipFactory = lspTagHelperTooltipFactory;
+            _vsLspTagHelperTooltipFactory = vsLspTagHelperTooltipFactory;
+        }
+
+        public override Task<VSInternalCompletionItem?> ResolveAsync(
+            VSInternalCompletionItem completionItem,
+            VSInternalCompletionList containingCompletionList,
+            object? originalRequestContext,
+            VSInternalClientCapabilities? clientCapabilities,
+            CancellationToken cancellationToken)
+        {
+            if (originalRequestContext is not IReadOnlyList<RazorCompletionItem> razorCompletionItems)
+            {
+                // Can't recognize the original request context, bail.
+                return Task.FromResult<VSInternalCompletionItem?>(null);
+            }
+
+            var associatedRazorCompletion = razorCompletionItems.FirstOrDefault(completion => string.Equals(completion.DisplayText, completionItem.Label, StringComparison.Ordinal));
+            if (associatedRazorCompletion is null)
+            {
+                return Task.FromResult<VSInternalCompletionItem?>(null);
+            }
+
+            // If the client is VS, also fill in the Description property.
+            var useDescriptionProperty = clientCapabilities?.SupportsVisualStudioExtensions ?? false;
+            var completionSupportedKinds = clientCapabilities?.TextDocument?.Completion?.CompletionItem?.DocumentationFormat;
+            var documentationKind = completionSupportedKinds?.Contains(MarkupKind.Markdown) == true ? MarkupKind.Markdown : MarkupKind.PlainText;
+
+            MarkupContent? tagHelperMarkupTooltip = null;
+            ClassifiedTextElement? tagHelperClassifiedTextTooltip = null;
+
+            switch (associatedRazorCompletion.Kind)
+            {
+                case RazorCompletionItemKind.Directive:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
+                        if (descriptionInfo is not null)
+                        {
+                            completionItem.Documentation = descriptionInfo.Description;
+                        }
+
+                        break;
+                    }
+                case RazorCompletionItemKind.MarkupTransition:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
+                        if (descriptionInfo is not null)
+                        {
+                            completionItem.Documentation = descriptionInfo.Description;
+                        }
+
+                        break;
+                    }
+                case RazorCompletionItemKind.DirectiveAttribute:
+                case RazorCompletionItemKind.DirectiveAttributeParameter:
+                case RazorCompletionItemKind.TagHelperAttribute:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
+                        if (descriptionInfo == null)
+                        {
+                            break;
+                        }
+
+                        if (useDescriptionProperty)
+                        {
+                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                        }
+                        else
+                        {
+                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
+                        }
+
+                        break;
+                    }
+                case RazorCompletionItemKind.TagHelperElement:
+                    {
+                        var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
+                        if (descriptionInfo == null)
+                        {
+                            break;
+                        }
+
+                        if (useDescriptionProperty)
+                        {
+                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                        }
+                        else
+                        {
+                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
+                        }
+
+                        break;
+                    }
+            }
+
+            if (tagHelperMarkupTooltip != null)
+            {
+                completionItem.Documentation = tagHelperMarkupTooltip;
+            }
+
+            if (tagHelperClassifiedTextTooltip != null)
+            {
+                completionItem.Description = tagHelperClassifiedTextTooltip;
+            }
+
+            return Task.FromResult<VSInternalCompletionItem?>(completionItem);
+        }
+    }
+}
+
+

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -2,181 +2,78 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
-using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor.Completion;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.Text.Adornments;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint
     {
-        private readonly ILogger _logger;
-        private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
-        private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
+        private readonly AggregateCompletionItemResolver _completionItemResolver;
         private readonly CompletionListCache _completionListCache;
-        private VSInternalCompletionSetting? _completionCapability;
         private VSInternalClientCapabilities? _clientCapabilities;
-        private MarkupKind _documentationKind;
-
-        // Guid is magically generated and doesn't mean anything. O# magic.
-        public Guid Id => new("011c77cc-f90e-4f2e-b32c-dafc6587ccd6");
 
         public RazorCompletionResolveEndpoint(
-            LSPTagHelperTooltipFactory lspTagHelperTooltipFactory,
-            VSLSPTagHelperTooltipFactory vsLspTagHelperTooltipFactory,
-            CompletionListCache completionListCache,
-            ILoggerFactory loggerFactory)
+            AggregateCompletionItemResolver completionItemResolver,
+            CompletionListCache completionListCache)
         {
-            if (lspTagHelperTooltipFactory is null)
-            {
-                throw new ArgumentNullException(nameof(lspTagHelperTooltipFactory));
-            }
-
-            if (vsLspTagHelperTooltipFactory is null)
-            {
-                throw new ArgumentNullException(nameof(vsLspTagHelperTooltipFactory));
-            }
-
-            if (completionListCache is null)
-            {
-                throw new ArgumentNullException(nameof(completionListCache));
-            }
-
-            if (loggerFactory is null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
-
-            _lspTagHelperTooltipFactory = lspTagHelperTooltipFactory;
-            _vsLspTagHelperTooltipFactory = vsLspTagHelperTooltipFactory;
-            _logger = loggerFactory.CreateLogger<RazorCompletionEndpoint>();
+            _completionItemResolver = completionItemResolver;
             _completionListCache = completionListCache;
         }
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            _completionCapability = clientCapabilities.TextDocument?.Completion as VSInternalCompletionSetting;
             _clientCapabilities = clientCapabilities;
-
-            var completionSupportedKinds = clientCapabilities.TextDocument?.Completion?.CompletionItem?.DocumentationFormat;
-            _documentationKind = completionSupportedKinds?.Contains(MarkupKind.Markdown) == true ? MarkupKind.Markdown : MarkupKind.PlainText;
-
             return null;
         }
 
-        public Task<VSInternalCompletionItem> Handle(VSCompletionItemBridge completionItemBridge, CancellationToken cancellationToken)
+        public async Task<VSInternalCompletionItem> Handle(VSCompletionItemBridge completionItemBridge, CancellationToken cancellationToken)
         {
             VSInternalCompletionItem completionItem = completionItemBridge;
 
-            if (!completionItem.TryGetCompletionListResultId(out var resultId))
+            if (!completionItem.TryGetCompletionListResultIds(out var resultIds))
             {
-                // Couldn't resolve.
-                return Task.FromResult(completionItem);
+                // Unable to lookup completion item result info
+                return completionItem;
             }
 
-            if (!_completionListCache.TryGet(resultId.Value, out var cachedCompletionItems))
+            object? originalRequestContext = null;
+            VSInternalCompletionList? containingCompletionlist = null;
+            foreach (var resultId in resultIds)
             {
-                return Task.FromResult(completionItem);
+                if (!_completionListCache.TryGet(resultId, out var cacheEntry))
+                {
+                    continue;
+                }
+
+                // See if this is the right completion list for this corresponding completion item. We cross-check this based on label only given that
+                // is what users interact with.
+                if (cacheEntry.CompletionList.Items.Any(completion => string.Equals(completionItem.Label, completion.Label, StringComparison.Ordinal)))
+                {
+                    originalRequestContext = cacheEntry.Context;
+                    containingCompletionlist = cacheEntry.CompletionList;
+                    break;
+                }
             }
 
-            var labelQuery = completionItem.Label;
-            var associatedRazorCompletion = cachedCompletionItems.FirstOrDefault(completion => string.Equals(labelQuery, completion.DisplayText, StringComparison.Ordinal));
-            if (associatedRazorCompletion is null)
+            if (containingCompletionlist is null)
             {
-                _logger.LogError("Could not find an associated razor completion item. This should never happen since we were able to look up the cached completion list.");
-                Debug.Fail("Could not find an associated razor completion item. This should never happen since we were able to look up the cached completion list.");
-                return Task.FromResult(completionItem);
+                // Couldn't find an assocaited completion list
+                return completionItem;
             }
 
-            // If the client is VS, also fill in the Description property.
-            var useDescriptionProperty = _clientCapabilities?.SupportsVisualStudioExtensions ?? false;
+            var resolvedCompletionItem = await _completionItemResolver.ResolveAsync(
+                completionItem,
+                containingCompletionlist,
+                originalRequestContext,
+                _clientCapabilities,
+                cancellationToken).ConfigureAwait(false);
+            resolvedCompletionItem ??= completionItem;
 
-            MarkupContent? tagHelperMarkupTooltip = null;
-            ClassifiedTextElement? tagHelperClassifiedTextTooltip = null;
-
-            switch (associatedRazorCompletion.Kind)
-            {
-                case RazorCompletionItemKind.Directive:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem.Documentation = descriptionInfo.Description;
-                        }
-
-                        break;
-                    }
-                case RazorCompletionItemKind.MarkupTransition:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem.Documentation = descriptionInfo.Description;
-                        }
-
-                        break;
-                    }
-                case RazorCompletionItemKind.DirectiveAttribute:
-                case RazorCompletionItemKind.DirectiveAttributeParameter:
-                case RazorCompletionItemKind.TagHelperAttribute:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
-                        if (descriptionInfo == null)
-                        {
-                            break;
-                        }
-
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else 
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
-                        }
-
-                        break;
-                    }
-                case RazorCompletionItemKind.TagHelperElement:
-                    {
-                        var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
-                        if (descriptionInfo == null)
-                        {
-                            break;
-                        }
-
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
-                        }
-
-                        break;
-                    }
-            }
-
-            if (tagHelperMarkupTooltip != null)
-            {
-                completionItem.Documentation = tagHelperMarkupTooltip;
-            }
-
-            if (tagHelperClassifiedTextTooltip != null)
-            {
-                completionItem.Description = tagHelperClassifiedTextTooltip;
-            }
-
-            return Task.FromResult(completionItem);
+            return resolvedCompletionItem;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSInternalCompletionListExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSInternalCompletionListExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    internal static class VSInternalCompletionListExtensions
+    {
+        // This needs to match what's listed in VSInternalCompletionItemExtensions.ResultIdKey
+        private const string ResultIdKey = "_resultId";
+
+        public static void SetResultId(
+            this VSInternalCompletionList completionList,
+            int resultId,
+            VSInternalCompletionSetting? completionSetting)
+        {
+            if (completionList is null)
+            {
+                throw new ArgumentNullException(nameof(completionList));
+            }
+
+            var data = new JObject()
+            {
+                [ResultIdKey] = resultId,
+            };
+            if (completionSetting?.CompletionList?.Data == true)
+            {
+                // Can set data at the completion list level
+
+                var mergedData = CompletionListMerger.MergeData(data, completionList.Data);
+                completionList.Data = mergedData;
+            }
+            else
+            {
+                // No CompletionList.Data support
+
+                foreach (var completionItem in completionList.Items)
+                {
+                    var mergedData = CompletionListMerger.MergeData(data, completionItem.Data);
+                    completionItem.Data = mergedData;
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -239,6 +239,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<CompletionListCache>();
                         services.AddSingleton<AggregateCompletionListProvider>();
                         services.AddSingleton<CompletionListProvider, RazorCompletionListProvider>();
+                        services.AddSingleton<AggregateCompletionItemResolver>();
+                        services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();
                         services.AddSingleton<TagHelperCompletionService, LanguageServerTagHelperCompletionService>();
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
                         services.AddSingleton<RazorCompletionItemProvider, DirectiveCompletionItemProvider>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListCacheTest.cs
@@ -3,7 +3,7 @@
 
 #nullable disable
 
-using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
@@ -12,50 +12,53 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
     {
         private CompletionListCache CompletionListCache { get; } = new CompletionListCache();
 
+        private object Context { get; } = new object();
+
         [Fact]
         public void TryGet_SetCompletionList_ReturnsTrue()
         {
             // Arrange
-            var completionList = new RazorCompletionItem[1];
-            var resultId = CompletionListCache.Set(completionList);
+            var completionList = new VSInternalCompletionList();
+            var resultId = CompletionListCache.Set(completionList, Context);
 
             // Act
-            var result = CompletionListCache.TryGet(resultId, out var retrievedCompletionList);
+            var result = CompletionListCache.TryGet(resultId, out var cacheEntry);
 
             // Assert
             Assert.True(result);
-            Assert.Same(completionList, retrievedCompletionList);
+            Assert.Same(completionList, cacheEntry.CompletionList);
+            Assert.Same(Context, cacheEntry.Context);
         }
 
         [Fact]
         public void TryGet_UnknownCompletionList_ReturnsTrue()
         {
             // Act
-            var result = CompletionListCache.TryGet(1234, out var retrievedCompletionList);
+            var result = CompletionListCache.TryGet(1234, out var cachedEntry);
 
             // Assert
             Assert.False(result);
-            Assert.Null(retrievedCompletionList);
+            Assert.Null(cachedEntry);
         }
 
         [Fact]
         public void TryGet_EvictedCompletionList_ReturnsFalse()
         {
             // Arrange
-            var initialCompletionList = new RazorCompletionItem[1];
-            var initialCompletionListResultId = CompletionListCache.Set(initialCompletionList);
+            var initialCompletionList = new VSInternalCompletionList();
+            var initialCompletionListResultId = CompletionListCache.Set(initialCompletionList, Context);
             for (var i = 0; i < CompletionListCache.MaxCacheSize; i++)
             {
                 // We now fill the completion list cache up until its cache max so that the initial completion list we set gets evicted.
-                CompletionListCache.Set(new RazorCompletionItem[1]);
+                CompletionListCache.Set(new VSInternalCompletionList(), Context);
             }
 
             // Act
-            var result = CompletionListCache.TryGet(initialCompletionListResultId, out var retrievedCompletionList);
+            var result = CompletionListCache.TryGet(initialCompletionListResultId, out var cachedEntry);
 
             // Assert
             Assert.False(result);
-            Assert.Null(retrievedCompletionList);
+            Assert.Null(cachedEntry);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListOptimizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListOptimizerTest.cs
@@ -4,83 +4,12 @@
 #nullable disable
 
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 {
     public class CompletionListOptimizerTest
     {
-        [Fact]
-        public void Convert_DataTrue_RemovesDataFromItems()
-        {
-            // Arrange
-            var dataObject = new JObject()
-            {
-                ["resultId"] = 123
-            };
-            var completionList = new VSInternalCompletionList()
-            {
-                Items = new[]
-                {
-                    new VSInternalCompletionItem()
-                    {
-                        Label = "Test",
-                        Data = dataObject,
-                    }
-                }
-            };
-            var capabilities = new VSInternalCompletionSetting()
-            {
-                CompletionList = new VSInternalCompletionListSetting()
-                {
-                    Data = true,
-                }
-            };
-
-            // Act
-            var vsCompletionList = CompletionListOptimizer.Optimize(completionList, capabilities);
-
-            // Assert
-            Assert.Collection(vsCompletionList.Items, item => Assert.Null(item.Data));
-            Assert.Same(dataObject, vsCompletionList.Data);
-        }
-
-        [Fact]
-        public void Convert_DataFalse_DoesNotTouchData()
-        {
-            // Arrange
-            var dataObject = new JObject()
-            {
-                ["resultId"] = 123
-            };
-            var completionList = new VSInternalCompletionList()
-            {
-                Items = new[]
-                {
-                    new VSInternalCompletionItem()
-                    {
-                        Label = "Test",
-                        Data = dataObject,
-                    }
-                }
-            };
-            var capabilities = new VSInternalCompletionSetting()
-            {
-                CompletionList = new VSInternalCompletionListSetting()
-                {
-                    Data = false,
-                }
-            };
-
-            // Act
-            var vsCompletionList = CompletionListOptimizer.Optimize(completionList, capabilities);
-
-            // Assert
-            Assert.Collection(vsCompletionList.Items, item => Assert.Same(dataObject, item.Data));
-            Assert.Null(vsCompletionList.Data);
-        }
-
         [Fact]
         public void Convert_CommitCharactersTrue_RemovesCommitCharactersFromItems()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
@@ -233,7 +233,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         private VSInternalCompletionList CreateLSPCompletionList(IReadOnlyList<RazorCompletionItem> razorCompletionItems)
         {
-            var completionList = LegacyRazorCompletionEndpoint.CreateLSPCompletionList(razorCompletionItems, CompletionListCache, DefaultClientCapability);
+            var completionList = LegacyRazorCompletionEndpoint.CreateLSPCompletionList(razorCompletionItems, DefaultClientCapability);
+            var resultId = CompletionListCache.Set(completionList, razorCompletionItems);
+            completionList.SetResultId(resultId, completionSetting: null);
             return completionList;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -19,7 +19,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         {
             CompletionListProvider = new AggregateCompletionListProvider(Array.Empty<CompletionListProvider>(), LoggerFactory);
         }
-        private AggregateCompletionListProvider CompletionListProvider { get; set; }
+
+        private AggregateCompletionListProvider CompletionListProvider { get; }
 
         [Fact]
         public async Task Handle_NoDocumentContext_NoCompletionItems()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
+{
+    public class RazorCompletionItemResolverTest : LanguageServerTestBase
+    {
+        public RazorCompletionItemResolverTest()
+        {
+            LSPTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory();
+            VSLSPTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory();
+            CompletionCapability = new VSInternalCompletionSetting()
+            {
+                CompletionItem = new CompletionItemSetting()
+                {
+                    DocumentationFormat = new[] { MarkupKind.PlainText, MarkupKind.Markdown },
+                }
+            };
+            DefaultClientCapability = new VSInternalClientCapabilities()
+            {
+                TextDocument = new TextDocumentClientCapabilities()
+                {
+                    Completion = CompletionCapability,
+                },
+            };
+            VSClientCapability = new VSInternalClientCapabilities()
+            {
+                TextDocument = new TextDocumentClientCapabilities()
+                {
+                    Completion = CompletionCapability,
+                },
+                SupportsVisualStudioExtensions = true,
+            };
+            var attributeDescriptionInfo = new BoundAttributeDescriptionInfo("System.DateTime", "System.DateTime", "DateTime", "Returns the time.");
+            AttributeDescription = new AggregateBoundAttributeDescription(new[] { attributeDescriptionInfo });
+            var elementDescriptionInfo = new BoundElementDescriptionInfo("System.SomeTagHelper", "This is some TagHelper.");
+            ElementDescription = new AggregateBoundElementDescription(new[] { elementDescriptionInfo });
+        }
+
+        private LSPTagHelperTooltipFactory LSPTagHelperTooltipFactory { get; }
+
+        private VSLSPTagHelperTooltipFactory VSLSPTagHelperTooltipFactory { get; }
+
+        private VSInternalCompletionSetting CompletionCapability { get; }
+
+        private VSInternalClientCapabilities DefaultClientCapability { get; }
+
+        private VSInternalClientCapabilities VSClientCapability { get; }
+
+        private AggregateBoundAttributeDescription AttributeDescription { get; }
+
+        private AggregateBoundElementDescription ElementDescription { get; }
+
+        [Fact]
+        public async Task ResolveAsync_DirectiveCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.Directive);
+            razorCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription("Test directive"));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, DefaultClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_MarkupTransitionCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("@...", "@", RazorCompletionItemKind.MarkupTransition);
+            razorCompletionItem.SetMarkupTransitionCompletionDescription(new MarkupTransitionCompletionDescription("Test description"));
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, DefaultClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_DirectiveAttributeCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(AttributeDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, DefaultClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_DirectiveAttributeParameterCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttributeParameter);
+            razorCompletionItem.SetAttributeCompletionDescription(AttributeDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, DefaultClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_TagHelperElementCompletion_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
+            razorCompletionItem.SetTagHelperElementDescriptionInfo(ElementDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, DefaultClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_TagHelperAttribute_ReturnsCompletionItemWithDocumentation()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(AttributeDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, DefaultClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Documentation);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_VS_DirectiveAttributeCompletion_ReturnsCompletionItemWithDescription()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(AttributeDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, VSClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Description);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_VS_DirectiveAttributeParameterCompletion_ReturnsCompletionItemWithDescription()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttributeParameter);
+            razorCompletionItem.SetAttributeCompletionDescription(AttributeDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, VSClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Description);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_VS_TagHelperElementCompletion_ReturnsCompletionItemWithDescription()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
+            razorCompletionItem.SetTagHelperElementDescriptionInfo(ElementDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, VSClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Description);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_VS_TagHelperAttribute_ReturnsCompletionItemWithDescription()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperAttribute);
+            razorCompletionItem.SetAttributeCompletionDescription(AttributeDescription);
+            var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
+            var completionItem = completionList.Items.Single() as VSInternalCompletionItem;
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, new[] { razorCompletionItem }, VSClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(resolvedCompletionItem.Description);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_NonTagHelperCompletion_Noops()
+        {
+            // Arrange
+            var resolver = new RazorCompletionItemResolver(LSPTagHelperTooltipFactory, VSLSPTagHelperTooltipFactory);
+            var completionItem = new VSInternalCompletionItem();
+            var completionList = new VSInternalCompletionList() { Items = new[] { completionItem } };
+
+            // Act
+            var resolvedCompletionItem = await resolver.ResolveAsync(completionItem, completionList, Array.Empty<RazorCompletionItem>(), DefaultClientCapability, CancellationToken.None);
+
+            // Assert
+            Assert.Null(resolvedCompletionItem);
+        }
+
+        private VSInternalCompletionList CreateLSPCompletionList(IReadOnlyList<RazorCompletionItem> razorCompletionItems)
+        {
+            var completionList = RazorCompletionListProvider.CreateLSPCompletionList(razorCompletionItems, DefaultClientCapability);
+            return completionList;
+        }
+    }
+}


### PR DESCRIPTION
- This is the pre-requisite for allowing our completion resolve endpoint to provide both Razor & delegated (HTML/C#) completion resolution. Some of the key bits in this changeset are:
    - Ability to locate originating completion lists from an item that was present from a "merged" completion list. Since we added the support to merge completion lists we needed the opposite support to `Split` completion list info back out. This way we can ask specific resolvers "can you resolve this item given it came from X originating completion list?".
    - A re-envisioning of our `CompletionListCache` to better support future scenarios. Now the cache stores the originating LSP completion list and some generic "context" object. In legacy / Razor scenarios this context object is the Razor completion item list; however, in delegated scenarios it will be custom data to indicate where to "reinvoke" resolutions. Effectively it can serve as a key for completion item resolvers to understand if they can or cannot resolve an item.
        - This re-imagining resulted in the deletion of our Data optimization code paths within our `CompletionListOptimizer`. The primary reason is that now that we need to cache LSPCompletionList + RazorCompletionList simultaneously it means we need to cache & store the cache result id (the bit that goes in Data) at LSP completion list return time. Previously the `CompletionListOptimizer.OptimizeData` APIs would presume that each completion list item had identical Data bits and would then lift those to the top level completion list. This is done in one call to `SetResultId` now (now at the completion list level and capability aware).
    - A new completion item resolver API where you're given all the information needed to asynchronously resolve a completion item
    - A completion item resolver aggregator that's intelligent about running multiple resolvers in parallel and allowing some to fail. In practice we'll only ever see one resolver "win"; however, it's not unfounded that there will be multiple scenarios when we may want to do both delegated and razor resolutions simultaneously (think of a TagHelper that targets a plain HTML element and we want to show TagHelper info + HTML info). For now I've restricted resolutions to allow the last resolver that returned a non-null value to win.
- Migrated completion item resolution logic from the completion resolution endpoint into individual completion item resolvers
- Add new tests and fork existing ones into proper areas
- Added additional test coverage for our completion item resolver tech and moved a few bits away from moq.
- Found I made a mistake in my previous PR in handling cancellations in our aggregators. Updated cancellation logic to properly not catch cancellations (`TaskCanceledException` => `OperationCanceledException`).

Fixes #6445