### PR TITLE
Protect against `null` CodeActionCapability's.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         public CodeActionRegistrationOptions GetRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities)
         {
             _capability = capability;
-            _supportsCodeActionResolve = _capability.ResolveSupport != null;
+            _supportsCodeActionResolve = _capability?.ResolveSupport != null;
             return new CodeActionRegistrationOptions()
             {
                 DocumentSelector = RazorDefaults.Selector,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             _logger = loggerFactory.CreateLogger<RazorDefinitionEndpoint>();
         }
 
-        public DefinitionRegistrationOptions GetRegistrationOptions(DefinitionCapability capability, ClientCapabilities clientCapabilities)
+        public DefinitionRegistrationOptions GetRegistrationOptions(DefinitionCapability? capability, ClientCapabilities clientCapabilities)
         {
             return new DefinitionRegistrationOptions
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
 
             _languageServer = languageServer;
         }
-        public DocumentColorRegistrationOptions GetRegistrationOptions(ColorProviderCapability capability, ClientCapabilities clientCapabilities)
+        public DocumentColorRegistrationOptions GetRegistrationOptions(ColorProviderCapability? capability, ClientCapabilities clientCapabilities)
         {
             return new DocumentColorRegistrationOptions()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingEndpoint.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             _logger = loggerFactory.CreateLogger<RazorFormattingEndpoint>();
         }
 
-        public DocumentFormattingRegistrationOptions GetRegistrationOptions(DocumentFormattingCapability capability, ClientCapabilities clientCapabilities)
+        public DocumentFormattingRegistrationOptions GetRegistrationOptions(DocumentFormattingCapability? capability, ClientCapabilities clientCapabilities)
         {
             return new DocumentFormattingRegistrationOptions
             {
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             };
         }
 
-        public DocumentRangeFormattingRegistrationOptions GetRegistrationOptions(DocumentRangeFormattingCapability capability, ClientCapabilities clientCapabilities)
+        public DocumentRangeFormattingRegistrationOptions GetRegistrationOptions(DocumentRangeFormattingCapability? capability, ClientCapabilities clientCapabilities)
         {
             return new DocumentRangeFormattingRegistrationOptions
             {
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             };
         }
 
-        public DocumentOnTypeFormattingRegistrationOptions GetRegistrationOptions(DocumentOnTypeFormattingCapability capability, ClientCapabilities clientCapabilities)
+        public DocumentOnTypeFormattingRegistrationOptions GetRegistrationOptions(DocumentOnTypeFormattingCapability? capability, ClientCapabilities clientCapabilities)
         {
             Assumes.NotNullOrEmpty(s_allTriggerCharacters);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
         }
 
         public LinkedEditingRangeRegistrationOptions GetRegistrationOptions(
-            LinkedEditingRangeClientCapabilities capability,
+            LinkedEditingRangeClientCapabilities? capability,
             ClientCapabilities clientCapabilities)
         {
             return new LinkedEditingRangeRegistrationOptions


### PR DESCRIPTION
- On VS4Mac we'd explode during initialize because VS4Mac doesn't yet support LSP light bulbs and their `CodeActionCapability` comes in as `null`. Ultimately it'd be great of O# didn't call our registration endpoints if the client didn't support the corresponding features but that seems like another bug for another day.
- For other endpoints that were null annotated I also went through and decorated existing capabilities with `?`. For ones that weren't nullable enabled I wasn't able to do this. I attempted to migrate a few to `nullable` enabled; however, that broke down a bit given the O# APIs themselves weren't. Upon moving to VS APIs this will become possible again.

Fixes #6457

### Summary of the changes

-

Fixes:
