### PR TITLE
Add support for requesting basic C#/HTML completions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -33,6 +33,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public const string RazorDocumentOnTypeFormattingEndpoint = "textDocument/onTypeFormatting";
 
+        public const string RazorCompletionEndpointName = "razor/completion";
+
         // RZLS Custom Message Targets
         public const string RazorUpdateCSharpBufferEndpoint = "razor/updateCSharpBuffer";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionParams.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Protocol
+{
+    internal record DelegatedCompletionParams(
+        VersionedTextDocumentIdentifier HostDocument,
+        Position ProjectedPosition,
+        RazorLanguageKind ProjectedKind,
+        VSInternalCompletionContext Context);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    internal class DelegatedCompletionListProvider : CompletionListProvider
+    {
+        private static readonly IReadOnlyList<string> s_razorTriggerCharacters = new[] { "@" };
+        private static readonly IReadOnlyList<string> s_cSharpTriggerCharacters = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", "~" };
+        private static readonly IReadOnlyList<string> s_htmlTriggerCharacters = new[] { ":", "@", "#", ".", "!", "*", ",", "(", "[", "-", "<", "&", "\\", "/", "'", "\"", "=", ":", " ", "`" };
+        private static readonly ImmutableHashSet<string> s_allTriggerCharacters =
+            s_cSharpTriggerCharacters
+                .Concat(s_htmlTriggerCharacters)
+                .Concat(s_razorTriggerCharacters)
+                .ToImmutableHashSet();
+        private readonly RazorDocumentMappingService _documentMappingService;
+        private readonly ClientNotifierServiceBase _languageServer;
+
+        public DelegatedCompletionListProvider(
+            RazorDocumentMappingService documentMappingService,
+            ClientNotifierServiceBase languageServer)
+        {
+            _documentMappingService = documentMappingService;
+            _languageServer = languageServer;
+        }
+
+        public override ImmutableHashSet<string> TriggerCharacters => s_allTriggerCharacters;
+
+        public override async Task<VSInternalCompletionList?> GetCompletionListAsync(
+            int absoluteIndex,
+            VSInternalCompletionContext completionContext,
+            DocumentContext documentContext,
+            VSInternalClientCapabilities clientCapabilities,
+            CancellationToken cancellationToken)
+        {
+            var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+            var projection = GetProjection(absoluteIndex, codeDocument, sourceText);
+
+            completionContext = RewriteContext(completionContext, projection.LanguageKind);
+
+            var delegatedParams = new DelegatedCompletionParams(
+                documentContext.Identifier,
+                projection.Position,
+                projection.LanguageKind,
+                completionContext);
+            var delegatedRequest = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorCompletionEndpointName, delegatedParams).ConfigureAwait(false);
+            var delegatedResponse = await delegatedRequest.Returning<VSInternalCompletionList?>(cancellationToken).ConfigureAwait(false);
+
+            return delegatedResponse;
+        }
+
+        private CompletionProjection GetProjection(int absoluteIndex, RazorCodeDocument codeDocument, SourceText sourceText)
+        {
+            sourceText.GetLineAndOffset(absoluteIndex, out var line, out var character);
+            var projectedPosition = new Position(line, character);
+
+            var languageKind = _documentMappingService.GetLanguageKind(codeDocument, absoluteIndex, rightAssociative: false);
+            if (languageKind == RazorLanguageKind.CSharp)
+            {
+                if (_documentMappingService.TryMapToProjectedDocumentVSPosition(codeDocument, absoluteIndex, out var mappedPosition, out _))
+                {
+                    // For C# locations, we attempt to return the corresponding position
+                    // within the projected document
+                    projectedPosition = mappedPosition;
+                }
+                else
+                {
+                    // It no longer makes sense to think of this location as C#, since it doesn't
+                    // correspond to any position in the projected document. This should not happen
+                    // since there should be source mappings for all the C# spans.
+                    languageKind = RazorLanguageKind.Razor;
+                }
+            }
+
+            return new CompletionProjection(languageKind, projectedPosition);
+        }
+
+        private static VSInternalCompletionContext RewriteContext(VSInternalCompletionContext context, RazorLanguageKind languageKind)
+        {
+            if (context.TriggerKind != CompletionTriggerKind.TriggerCharacter)
+            {
+                // Non-triggered based completion, the existing context is valid.
+                return context;
+            }
+
+            if (languageKind == RazorLanguageKind.CSharp && s_cSharpTriggerCharacters.Contains(context.TriggerCharacter))
+            {
+                // C# trigger character for C# content
+                return context;
+            }
+
+            if (languageKind == RazorLanguageKind.Html && s_htmlTriggerCharacters.Contains(context.TriggerCharacter))
+            {
+                // HTML trigger character for HTML content
+                return context;
+            }
+
+            // Trigger character not associated with the current langauge. Transform the context into an invoked context.
+            var rewrittenContext = new VSInternalCompletionContext()
+            {
+                InvokeKind = context.InvokeKind,
+                TriggerKind = CompletionTriggerKind.Invoked,
+            };
+
+            if (languageKind == RazorLanguageKind.CSharp && s_razorTriggerCharacters.Contains(context.TriggerCharacter))
+            {
+                // The C# language server will not return any completions for the '@' character unless we
+                // send the completion request explicitly.
+                rewrittenContext.InvokeKind = VSInternalCompletionInvokeKind.Explicit;
+            }
+
+            return rewrittenContext;
+        }
+
+        private record class CompletionProjection(RazorLanguageKind LanguageKind, Position Position);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -37,6 +38,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public string FileKind => Snapshot.FileKind;
 
         public ProjectSnapshot Project => Snapshot.Project;
+
+        public VersionedTextDocumentIdentifier Identifier => new VersionedTextDocumentIdentifier()
+        {
+            Uri = Uri,
+            Version = Version,
+        };
 
         public async Task<RazorCodeDocument> GetCodeDocumentAsync(CancellationToken cancellationToken)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorSyntaxTreeExtensions.cs
@@ -59,6 +59,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
             return statements;
         }
 
+        public static SyntaxNode? GetOwner(this RazorSyntaxTree syntaxTree, int absoluteIndex)
+        {
+            if (syntaxTree is null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            var change = new SourceChange(absoluteIndex, 0, string.Empty);
+            var owner = syntaxTree.Root.LocateOwner(change);
+            return owner;
+        }
+
         public static SyntaxNode? GetOwner(
             this RazorSyntaxTree syntaxTree,
             SourceText sourceText,
@@ -90,9 +102,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
                 return default;
             }
 
-            var change = new SourceChange(absoluteIndex, 0, string.Empty);
-            var owner = syntaxTree.Root.LocateOwner(change);
-            return owner;
+            return GetOwner(syntaxTree, absoluteIndex);
         }
 
         public static SyntaxNode? GetOwner(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
 using Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
 using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
@@ -240,6 +241,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         // Completion
                         services.AddSingleton<CompletionListCache>();
                         services.AddSingleton<AggregateCompletionListProvider>();
+                        services.AddSingleton<CompletionListProvider, DelegatedCompletionListProvider>();
                         services.AddSingleton<CompletionListProvider, RazorCompletionListProvider>();
                         services.AddSingleton<AggregateCompletionItemResolver>();
                         services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.WrapWithTag;
+using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
@@ -83,5 +84,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [JsonRpcMethod(LanguageServerConstants.RazorUriPresentationEndpoint, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<WorkspaceEdit?> ProvideUriPresentationAsync(RazorUriPresentationParams presentationParams, CancellationToken cancellationToken);
+
+        [JsonRpcMethod(LanguageServerConstants.RazorCompletionEndpointName, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<JToken?> ProvideCompletionsAsync(DelegatedCompletionParams completionParams, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -8,6 +8,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
@@ -50,6 +53,15 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
         protected LspSerializer Serializer { get; }
 
         protected ILoggerFactory LoggerFactory { get; }
+
+        protected static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor> tagHelpers = null)
+        {
+            tagHelpers ??= Array.Empty<TagHelperDescriptor>();
+            var sourceDocument = TestRazorSourceDocument.Create(text);
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Create("/"), builder => { });
+            var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, "mvc", Array.Empty<RazorSourceDocument>(), tagHelpers);
+            return codeDocument;
+        }
 
         [Obsolete("Use " + nameof(LSPProjectSnapshotManagerDispatcher))]
         private class TestProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcher

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -1,0 +1,247 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    public class DelegatedCompletionListProviderTest : LanguageServerTestBase
+    {
+        public DelegatedCompletionListProviderTest()
+        {
+            Provider = TestDelegatedCompletionListProvider.Create(LoggerFactory);
+            ClientCapabilities = new VSInternalClientCapabilities();
+        }
+
+        private TestDelegatedCompletionListProvider Provider { get; }
+
+        private VSInternalClientCapabilities ClientCapabilities { get; }
+
+        [Fact]
+        public async Task HtmlDelegation_Invoked()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext() { TriggerKind = CompletionTriggerKind.Invoked };
+            var codeDocument = CreateCodeDocument("<");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            await Provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.NotNull(delegatedParameters);
+            Assert.Equal(RazorLanguageKind.Html, delegatedParameters.ProjectedKind);
+            Assert.Equal(new Position(0, 1), delegatedParameters.ProjectedPosition);
+            Assert.Equal(CompletionTriggerKind.Invoked, delegatedParameters.Context.TriggerKind);
+            Assert.Equal(1337, delegatedParameters.HostDocument.Version);
+        }
+
+        [Fact]
+        public async Task HtmlDelegation_TriggerCharacter()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerKind = CompletionTriggerKind.TriggerCharacter,
+                TriggerCharacter = "<",
+            };
+            var codeDocument = CreateCodeDocument("<");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            await Provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.NotNull(delegatedParameters);
+            Assert.Equal(RazorLanguageKind.Html, delegatedParameters.ProjectedKind);
+            Assert.Equal(new Position(0, 1), delegatedParameters.ProjectedPosition);
+            Assert.Equal(CompletionTriggerKind.TriggerCharacter, delegatedParameters.Context.TriggerKind);
+            Assert.Equal(VSInternalCompletionInvokeKind.Typing, delegatedParameters.Context.InvokeKind);
+            Assert.Equal(1337, delegatedParameters.HostDocument.Version);
+        }
+
+        [Fact]
+        public async Task HtmlDelegation_UnsupportedTriggerCharacter_TranslatesToInvoked()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerKind = CompletionTriggerKind.TriggerCharacter,
+                TriggerCharacter = "|",
+            };
+            var codeDocument = CreateCodeDocument("|");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            await Provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.NotNull(delegatedParameters);
+            Assert.Equal(RazorLanguageKind.Html, delegatedParameters.ProjectedKind);
+            Assert.Equal(new Position(0, 1), delegatedParameters.ProjectedPosition);
+            Assert.Equal(CompletionTriggerKind.Invoked, delegatedParameters.Context.TriggerKind);
+            Assert.Equal(VSInternalCompletionInvokeKind.Typing, delegatedParameters.Context.InvokeKind);
+            Assert.Equal(1337, delegatedParameters.HostDocument.Version);
+        }
+
+        [Fact]
+        public async Task CSharpDelegation_Invoked()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext() { TriggerKind = CompletionTriggerKind.Invoked };
+            var codeDocument = CreateCodeDocument("@");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            await Provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.NotNull(delegatedParameters);
+            Assert.Equal(RazorLanguageKind.CSharp, delegatedParameters.ProjectedKind);
+
+            // Just validating that we're generating code in a way that's different from the top-level document. Don't need to be specific.
+            Assert.True(delegatedParameters.ProjectedPosition.Line > 2);
+            Assert.Equal(CompletionTriggerKind.Invoked, delegatedParameters.Context.TriggerKind);
+            Assert.Equal(1337, delegatedParameters.HostDocument.Version);
+        }
+
+        [Fact]
+        public async Task CSharpDelegation_TriggerCharacterAt_TranslatesToInvoked()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerKind = CompletionTriggerKind.TriggerCharacter,
+                TriggerCharacter = "@",
+            };
+            var codeDocument = CreateCodeDocument("@");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            await Provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.NotNull(delegatedParameters);
+            Assert.Equal(RazorLanguageKind.CSharp, delegatedParameters.ProjectedKind);
+
+            // Just validating that we're generating code in a way that's different from the top-level document. Don't need to be specific.
+            Assert.True(delegatedParameters.ProjectedPosition.Line > 2);
+            Assert.Equal(CompletionTriggerKind.Invoked, delegatedParameters.Context.TriggerKind);
+            Assert.Equal(VSInternalCompletionInvokeKind.Explicit, delegatedParameters.Context.InvokeKind);
+            Assert.Equal(1337, delegatedParameters.HostDocument.Version);
+        }
+
+        [Fact]
+        public async Task CSharpDelegation_TriggerCharacter()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerKind = CompletionTriggerKind.TriggerCharacter,
+                TriggerCharacter = ".",
+            };
+            var codeDocument = CreateCodeDocument("@{ var abc = DateTime.;}");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            await Provider.GetCompletionListAsync(absoluteIndex: 22, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.NotNull(delegatedParameters);
+            Assert.Equal(RazorLanguageKind.CSharp, delegatedParameters.ProjectedKind);
+
+            // Just validating that we're generating code in a way that's different from the top-level document. Don't need to be specific.
+            Assert.True(delegatedParameters.ProjectedPosition.Line > 2);
+            Assert.Equal(CompletionTriggerKind.TriggerCharacter, delegatedParameters.Context.TriggerKind);
+            Assert.Equal(VSInternalCompletionInvokeKind.Typing, delegatedParameters.Context.InvokeKind);
+            Assert.Equal(1337, delegatedParameters.HostDocument.Version);
+        }
+
+        [Fact]
+        public async Task CSharpDelegation_UnsupportedTriggerCharacter_TranslatesToInvoked()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext()
+            {
+                InvokeKind= VSInternalCompletionInvokeKind.Typing,
+                TriggerKind = CompletionTriggerKind.TriggerCharacter,
+                TriggerCharacter = "o",
+            };
+            var codeDocument = CreateCodeDocument("@{ var abc = DateTime.No;}");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            await Provider.GetCompletionListAsync(absoluteIndex: 24, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.NotNull(delegatedParameters);
+            Assert.Equal(RazorLanguageKind.CSharp, delegatedParameters.ProjectedKind);
+
+            // Just validating that we're generating code in a way that's different from the top-level document. Don't need to be specific.
+            Assert.True(delegatedParameters.ProjectedPosition.Line > 2);
+            Assert.Equal(CompletionTriggerKind.Invoked, delegatedParameters.Context.TriggerKind);
+            Assert.Equal(VSInternalCompletionInvokeKind.Typing, delegatedParameters.Context.InvokeKind);
+            Assert.Equal(1337, delegatedParameters.HostDocument.Version);
+        }
+
+        private class TestDelegatedCompletionListProvider : DelegatedCompletionListProvider
+        {
+            private readonly DelegatedCompletionRequestResponseFactory _completionFactory;
+
+            private TestDelegatedCompletionListProvider(ILoggerFactory loggerFactory, DelegatedCompletionRequestResponseFactory completionFactory) :
+                base(
+                    new DefaultRazorDocumentMappingService(loggerFactory),
+                    new TestOmnisharpLanguageServer(new Dictionary<string, Func<object, object>>()
+                    {
+                        [LanguageServerConstants.RazorCompletionEndpointName] = completionFactory.OnDelegation,
+                    }))
+            {
+                _completionFactory = completionFactory;
+            }
+
+            public static TestDelegatedCompletionListProvider Create(ILoggerFactory loggerFactory)
+            {
+                var requestResponseFactory = new DelegatedCompletionRequestResponseFactory();
+                var provider = new TestDelegatedCompletionListProvider(loggerFactory, requestResponseFactory);
+                return provider;
+            }
+
+            public DelegatedCompletionParams DelegatedParams => _completionFactory.DelegatedParams;
+
+            private class DelegatedCompletionRequestResponseFactory
+            {
+                public DelegatedCompletionParams DelegatedParams { get; private set; }
+
+                public object OnDelegation(object parameters)
+                {
+                    DelegatedParams = (DelegatedCompletionParams)parameters;
+
+                    return new VSInternalCompletionList();
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -363,15 +363,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             return documentResolver.Object;
         }
 
-        private static RazorCodeDocument CreateCodeDocument(string text, IReadOnlyList<TagHelperDescriptor>? tagHelpers = null)
-        {
-            tagHelpers ??= Array.Empty<TagHelperDescriptor>();
-            var sourceDocument = TestRazorSourceDocument.Create(text);
-            var projectEngine = RazorProjectEngine.Create(builder => { });
-            var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, "mvc", Array.Empty<RazorSourceDocument>(), tagHelpers);
-            return codeDocument;
-        }
-
         private static RazorCodeDocument CreateCodeDocumentWithCSharpProjection(string razorSource, string projectedCSharpSource, IEnumerable<SourceMapping> sourceMappings)
         {
             var codeDocument = CreateCodeDocument(razorSource, Array.Empty<TagHelperDescriptor>());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestDocumentContext.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestDocumentContext.cs
@@ -10,13 +10,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
 {
     internal static class TestDocumentContext
     {
-        public static DocumentContext From(string filePath, RazorCodeDocument codeDocument)
+        public static DocumentContext From(string filePath, RazorCodeDocument codeDocument, int hostDocumentVersion)
         {
             var content = codeDocument.GetSourceText().ToString();
             var documentSnapshot = TestDocumentSnapshot.Create(filePath, content);
             documentSnapshot.With(codeDocument);
             var uri = new Uri(filePath);
-            return new DocumentContext(uri, documentSnapshot, version: 0);
+            return new DocumentContext(uri, documentSnapshot, hostDocumentVersion);
+        }
+
+        public static DocumentContext From(string filePath, RazorCodeDocument codeDocument)
+        {
+            return From(filePath, codeDocument, hostDocumentVersion: 0);
         }
 
         public static DocumentContext From(string filePath)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestOmnisharpLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestOmnisharpLanguageServer.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using InitializeParams = OmniSharp.Extensions.LanguageServer.Protocol.Models.InitializeParams;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
+{
+    internal class TestOmnisharpLanguageServer : ClientNotifierServiceBase
+    {
+        private readonly IReadOnlyDictionary<string, Func<object, object>> _requestResponseFactory;
+
+        public TestOmnisharpLanguageServer(Dictionary<string, Func<object, object>> requestResponseFactory)
+        {
+            _requestResponseFactory = requestResponseFactory;
+        }
+
+        public override InitializeParams ClientSettings => throw new NotImplementedException();
+
+        public override Task OnStarted(ILanguageServer server, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override Task<IResponseRouterReturns> SendRequestAsync(string method)
+        {
+            return SendRequestAsync(method, @params: (object)null);
+        }
+
+        public override Task<IResponseRouterReturns> SendRequestAsync<TParams>(string method, TParams @params)
+        {
+            if (!_requestResponseFactory.TryGetValue(method, out var factory))
+            {
+                throw new InvalidOperationException($"No request factory setup for {method}");
+            }
+
+            var result = factory(@params);
+            return Task.FromResult<IResponseRouterReturns>(new TestResponseRouterReturns(result));
+        }
+
+        private class TestResponseRouterReturns : IResponseRouterReturns
+        {
+            private readonly object _result;
+
+            public TestResponseRouterReturns(object result)
+            {
+                _result = result;
+            }
+
+            public Task<Response> Returning<Response>(CancellationToken cancellationToken)
+            {
+                return Task.FromResult((Response)_result);
+            }
+
+            public Task ReturningVoid(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- This changeset adds a delegated completion list provider that will invoke down into our custom message target and then into a HTML/C# language server to resolve completion items. In practice this code only really powers HTML completions because C# completion lists come back with edit ranges (not yet supported) which end up informing the client to not show C# completions.  Ultimately the code in this changeset just "invokes" C#/HTML and returns the response as-is. The response rewriting tech that exists in the completion handler is not in yet. I will bring that forward in a subsequent PR
- For many of our delegation calls we'll need to have the host document version associated with the host document. LSP has a type that represents this already, it's the `VersionedTextDocumentIdentifier`. Because this type exists I added it to the `DocumentContext` type so we can re-use it for future delegation requests.
- Added tests to validate the new `DelegatedCompletionListProvider`
    - Added a new `TestOmnisharpLanguageServer` type to make validating delegations easier
    - Expanded document context test types to support versions.

## Before
![devenv_OMuI0KwJPP](https://user-images.githubusercontent.com/2008729/170794400-dba6d325-9371-4e2a-8787-ad6302cc0a27.gif)

## After
**Note:** C# Isn't showing up because they use `Range`s in their completion results that I'm not yet re-mapping in this PR. Therefore the client throws out all C#/Directive attribute responses. That'll come in a followup
![devenv_obvmTgUbBS](https://user-images.githubusercontent.com/2008729/170794395-708e6146-ead2-4bcb-9154-ff2a3dff419f.gif)

Part of #6448