### PR TITLE
Add support for delegated response rewriters.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionResponseRewriter.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    internal abstract class DelegatedCompletionResponseRewriter
+    {
+        /// <summary>
+        /// Defines the order in which the rewriter will run. Implementors of <see cref="DelegatedCompletionResponseRewriter"/> should utilize
+        /// the <see cref="ExecutionBehaviorOrder"/> type to determine order.
+        ///
+        /// <see cref="Order"/> is only called once to determine order (needs to represent a static order).
+        /// </summary>
+        public abstract int Order { get; }
+
+        public abstract Task<VSInternalCompletionList> RewriteAsync(
+            VSInternalCompletionList completionList,
+            int hostDocumentIndex,
+            DocumentContext hostDocumentContext,
+            DelegatedCompletionParams delegatedParameters,
+            CancellationToken cancellationToken);
+
+        protected static class ExecutionBehaviorOrder
+        {
+            public static readonly int FiltersCompletionItems = -20;
+
+            public static readonly int AddsCompletionItems = -10;
+
+            public static readonly int Default = 0;
+
+            public static readonly int ChangesCompletionItems = 10;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/TextEditResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/TextEditResponseRewriter.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    internal class TextEditResponseRewriter : DelegatedCompletionResponseRewriter
+    {
+        public override int Order => ExecutionBehaviorOrder.ChangesCompletionItems;
+
+        public override async Task<VSInternalCompletionList> RewriteAsync(
+            VSInternalCompletionList completionList,
+            int hostDocumentIndex,
+            DocumentContext hostDocumentContext,
+            DelegatedCompletionParams delegatedParameters,
+            CancellationToken cancellationToken)
+        {
+            if (delegatedParameters.ProjectedKind != RazorLanguageKind.CSharp)
+            {
+                return completionList;
+            }
+
+            var sourceText = await hostDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+
+            sourceText.GetLineAndOffset(hostDocumentIndex, out var lineNumber, out var characterOffset);
+            var hostDocumentPosition = new Position(lineNumber, characterOffset);
+            completionList = TranslateTextEdits(hostDocumentPosition, delegatedParameters.ProjectedPosition, completionList);
+
+            if (completionList.ItemDefaults?.EditRange != null)
+            {
+                completionList.ItemDefaults.EditRange = TranslateRange(hostDocumentPosition, delegatedParameters.ProjectedPosition, completionList.ItemDefaults.EditRange);
+            }
+
+            return completionList;
+        }
+
+        private static VSInternalCompletionList TranslateTextEdits(
+            Position hostDocumentPosition,
+            Position projectedPosition,
+            VSInternalCompletionList completionList)
+        {
+            // The TextEdit positions returned to us from the C#/HTML language servers are positions correlating to the virtual document.
+            // We need to translate these positions to apply to the Razor document instead. Performance is a big concern here, so we want to
+            // make the logic as simple as possible, i.e. no asynchronous calls.
+            // The current logic takes the approach of assuming the original request's position (Razor doc) correlates directly to the positions
+            // returned by the C#/HTML language servers. We use this assumption (+ math) to map from the virtual (projected) doc positions ->
+            // Razor doc positions.
+
+            foreach (var item in completionList.Items)
+            {
+                if (item.TextEdit != null)
+                {
+                    var translatedRange = TranslateRange(hostDocumentPosition, projectedPosition, item.TextEdit.Range);
+                    item.TextEdit.Range = translatedRange;
+                }
+                else if (item.AdditionalTextEdits != null)
+                {
+                    // Additional text edits should typically only be provided at resolve time. We don't support them in the normal completion flow.
+                    item.AdditionalTextEdits = null;
+                }
+            }
+
+            return completionList;
+        }
+
+        private static Range TranslateRange(Position hostDocumentPosition, Position projectedPosition, Range textEditRange)
+        {
+            var offset = projectedPosition.Character - hostDocumentPosition.Character;
+
+            var editStartPosition = textEditRange.Start;
+            var translatedStartPosition = TranslatePosition(offset, hostDocumentPosition, editStartPosition);
+            var editEndPosition = textEditRange.End;
+            var translatedEndPosition = TranslatePosition(offset, hostDocumentPosition, editEndPosition);
+            var translatedRange = new Range()
+            {
+                Start = translatedStartPosition,
+                End = translatedEndPosition,
+            };
+
+            return translatedRange;
+        }
+
+        private static Position TranslatePosition(int offset, Position hostDocumentPosition, Position editPosition)
+        {
+            var translatedCharacter = editPosition.Character - offset;
+
+            // Note: If this completion handler ever expands to deal with multi-line TextEdits, this logic will likely need to change since
+            // it assumes we're only dealing with single-line TextEdits.
+            var translatedPosition = new Position(hostDocumentPosition.Line, translatedCharacter);
+            return translatedPosition;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -243,6 +243,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<AggregateCompletionListProvider>();
                         services.AddSingleton<CompletionListProvider, DelegatedCompletionListProvider>();
                         services.AddSingleton<CompletionListProvider, RazorCompletionListProvider>();
+                        services.AddSingleton<DelegatedCompletionResponseRewriter, TextEditResponseRewriter>();
+
                         services.AddSingleton<AggregateCompletionItemResolver>();
                         services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();
                         services.AddSingleton<TagHelperCompletionService, LanguageServerTagHelperCompletionService>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -3,16 +3,12 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
 
@@ -248,47 +244,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
                 completionList.Items = completionList.Items.Concat(new[] { completionItem }).ToArray();
 
                 return Task.FromResult(completionList);
-            }
-        }
-
-        private class TestDelegatedCompletionListProvider : DelegatedCompletionListProvider
-        {
-            private readonly DelegatedCompletionRequestResponseFactory _completionFactory;
-
-            private TestDelegatedCompletionListProvider(DelegatedCompletionResponseRewriter[] responseRewriters, ILoggerFactory loggerFactory, DelegatedCompletionRequestResponseFactory completionFactory) :
-                base(
-                    responseRewriters,
-                    new DefaultRazorDocumentMappingService(loggerFactory),
-                    new TestOmnisharpLanguageServer(new Dictionary<string, Func<object, object>>()
-                    {
-                        [LanguageServerConstants.RazorCompletionEndpointName] = completionFactory.OnDelegation,
-                    }))
-            {
-                _completionFactory = completionFactory;
-            }
-
-            public static TestDelegatedCompletionListProvider Create(ILoggerFactory loggerFactory, params DelegatedCompletionResponseRewriter[] responseRewriters)
-            {
-                var requestResponseFactory = new DelegatedCompletionRequestResponseFactory();
-                var provider = new TestDelegatedCompletionListProvider(responseRewriters, loggerFactory, requestResponseFactory);
-                return provider;
-            }
-
-            public DelegatedCompletionParams DelegatedParams => _completionFactory.DelegatedParams;
-
-            private class DelegatedCompletionRequestResponseFactory
-            {
-                public DelegatedCompletionParams DelegatedParams { get; private set; }
-
-                public object OnDelegation(object parameters)
-                {
-                    DelegatedParams = (DelegatedCompletionParams)parameters;
-
-                    return new VSInternalCompletionList()
-                    {
-                        Items = Array.Empty<CompletionItem>(),
-                    };
-                }
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    public abstract class ResponseRewriterTestBase : LanguageServerTestBase
+    {
+        private protected abstract DelegatedCompletionResponseRewriter Rewriter { get; }
+
+        protected async Task<VSInternalCompletionList> GetRewrittenCompletionListAsync(int absoluteIndex, string documentContent, VSInternalCompletionList initialCompletionList)
+        {
+            var completionContext = new VSInternalCompletionContext();
+            var codeDocument = CreateCodeDocument(documentContent);
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument);
+            var provider = TestDelegatedCompletionListProvider.Create(LoggerFactory, initialCompletionList, Rewriter);
+            var clientCapabilities = new VSInternalClientCapabilities();
+            var completionList = await provider.GetCompletionListAsync(absoluteIndex, completionContext, documentContext, clientCapabilities, CancellationToken.None);
+            return completionList;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    internal class TestDelegatedCompletionListProvider : DelegatedCompletionListProvider
+    {
+        private readonly DelegatedCompletionRequestResponseFactory _completionFactory;
+
+        private TestDelegatedCompletionListProvider(DelegatedCompletionResponseRewriter[] responseRewriters, ILoggerFactory loggerFactory, DelegatedCompletionRequestResponseFactory completionFactory) :
+            base(
+                responseRewriters,
+                new DefaultRazorDocumentMappingService(loggerFactory),
+                new TestOmnisharpLanguageServer(new Dictionary<string, Func<object, object>>()
+                {
+                    [LanguageServerConstants.RazorCompletionEndpointName] = completionFactory.OnDelegation,
+                }))
+        {
+            _completionFactory = completionFactory;
+        }
+
+        public static TestDelegatedCompletionListProvider Create(ILoggerFactory loggerFactory, params DelegatedCompletionResponseRewriter[] responseRewriters) =>
+            Create(loggerFactory, delegatedCompletionList: null, responseRewriters);
+
+        public static TestDelegatedCompletionListProvider Create(ILoggerFactory loggerFactory, VSInternalCompletionList delegatedCompletionList, params DelegatedCompletionResponseRewriter[] responseRewriters)
+        {
+            delegatedCompletionList ??= new VSInternalCompletionList()
+            {
+                Items = Array.Empty<CompletionItem>(),
+            };
+            var requestResponseFactory = new DelegatedCompletionRequestResponseFactory(delegatedCompletionList);
+            var provider = new TestDelegatedCompletionListProvider(responseRewriters, loggerFactory, requestResponseFactory);
+            return provider;
+        }
+
+        public DelegatedCompletionParams DelegatedParams => _completionFactory.DelegatedParams;
+
+        private class DelegatedCompletionRequestResponseFactory
+        {
+            private readonly VSInternalCompletionList _completionResponse;
+
+            public DelegatedCompletionRequestResponseFactory(VSInternalCompletionList completionResponse)
+            {
+                _completionResponse = completionResponse;
+            }
+
+            public DelegatedCompletionParams DelegatedParams { get; private set; }
+
+            public object OnDelegation(object parameters)
+            {
+                DelegatedParams = (DelegatedCompletionParams)parameters;
+
+                return _completionResponse;
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TextEditResponseRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TextEditResponseRewriterTest.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    public class TextEditResponseRewriterTest : ResponseRewriterTestBase
+    {
+        private protected override DelegatedCompletionResponseRewriter Rewriter => new TextEditResponseRewriter();
+
+        [Fact]
+        public async Task RewriteAsync_NotCSharp_Noops()
+        {
+            // Arrange
+            var getCompletionsAt = 1;
+            var documentContent = "<";
+            var textEditRange = new Range()
+            {
+                Start = new Position(0, 0),
+                End = new Position(0, 1),
+            };
+            var delegatedCompletionList = GenerateCompletionList(textEditRange);
+
+            // Act
+            var rewrittenCompletionList = await GetRewrittenCompletionListAsync(getCompletionsAt, documentContent, delegatedCompletionList);
+
+            // Assert
+            Assert.Equal(textEditRange, rewrittenCompletionList.Items[0].TextEdit.Range);
+        }
+
+        [Fact]
+        public async Task RewriteAsync_CSharp_AdjustsItemRange()
+        {
+            // Arrange
+            var getCompletionsAt = 1;
+            var documentContent = "@DateTime";
+            var textEditRange = new Range()
+            {
+                // Line 19: __o = DateTime
+                Start = new Position(19, 6),
+                End = new Position(19, 14),
+            };
+            var delegatedCompletionList = GenerateCompletionList(textEditRange);
+            var expectedRange = new Range()
+            {
+                Start = new Position(0, 1),
+                End = new Position(0, 9),
+            };
+
+            // Act
+            var rewrittenCompletionList = await GetRewrittenCompletionListAsync(getCompletionsAt, documentContent, delegatedCompletionList);
+
+            // Assert
+            Assert.Equal(expectedRange, rewrittenCompletionList.Items[0].TextEdit.Range);
+        }
+
+        [Fact]
+        public async Task RewriteAsync_CSharp_AdjustsListRange()
+        {
+            // Arrange
+            var getCompletionsAt = 1;
+            var documentContent = "@DateTime";
+            var textEditRange = new Range()
+            {
+                // Line 19: __o = DateTime
+                Start = new Position(19, 6),
+                End = new Position(19, 14),
+            };
+            var delegatedCompletionList = GenerateCompletionList(textEditRange);
+            delegatedCompletionList.ItemDefaults = new CompletionListItemDefaults()
+            {
+                EditRange = textEditRange,
+            };
+            var expectedRange = new Range()
+            {
+                Start = new Position(0, 1),
+                End = new Position(0, 9),
+            };
+
+            // Act
+            var rewrittenCompletionList = await GetRewrittenCompletionListAsync(getCompletionsAt, documentContent, delegatedCompletionList);
+
+            // Assert
+            Assert.Equal(expectedRange, rewrittenCompletionList.ItemDefaults.EditRange);
+        }
+
+        private static VSInternalCompletionList GenerateCompletionList(Range textEditRange)
+        {
+            return new VSInternalCompletionList()
+            {
+                Items = new[]
+                {
+                    new VSInternalCompletionItem()
+                    {
+                        TextEdit = new TextEdit()
+                        {
+                            NewText = "Hello",
+                            Range = textEditRange,
+                        }
+                    }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
- This introduces a new concept `DelegatedCompletionResponseRewriter` that allows completion lists to be "rewritten" prior to returning them from our delegation completion list provider.
- Ultimately this will be used to remove preselection, design time items and even rewrite text edit ranges for completion lists (in follow up PRs).
- Added a test to validate ordering.

Part of #6448