### PR TITLE
Remove design time helpers from delegated completion.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DesignTimeHelperResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DesignTimeHelperResponseRewriter.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    internal class DesignTimeHelperResponseRewriter : DelegatedCompletionResponseRewriter
+    {
+        private static readonly IReadOnlyList<string> s_designTimeHelpers = new string[]
+        {
+            "__builder",
+            "__o",
+            "__RazorDirectiveTokenHelpers__",
+            "__tagHelperExecutionContext",
+            "__tagHelperRunner",
+            "__typeHelper",
+            "_Imports",
+            "BuildRenderTree"
+        };
+
+        private static readonly IReadOnlyList<CompletionItem> s_designTimeHelpersCompletionItems =
+            s_designTimeHelpers
+                .Select(item => new CompletionItem { Label = item })
+                .ToArray();
+
+        public override int Order => ExecutionBehaviorOrder.FiltersCompletionItems;
+
+        public override async Task<VSInternalCompletionList> RewriteAsync(
+            VSInternalCompletionList completionList,
+            int hostDocumentIndex,
+            DocumentContext hostDocumentContext,
+            DelegatedCompletionParams delegatedParameters,
+            CancellationToken cancellationToken)
+        {
+            if (delegatedParameters.ProjectedKind != RazorLanguageKind.CSharp)
+            {
+                return completionList;
+            }
+
+            var syntaxTree = await hostDocumentContext.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var owner = syntaxTree.GetOwner(hostDocumentIndex);
+            if (owner is null)
+            {
+                Debug.Fail("Owner should never be null.");
+                return completionList;
+            }
+
+            var sourceText = await hostDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+
+            // We should remove Razor design time helpers from C#'s completion list. If the current identifier being targeted does not start with a double
+            // underscore, we trim out all items starting with "__" from the completion list. If the current identifier does start with a double underscore
+            // (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
+
+            var filteredItems = completionList.Items.Except(s_designTimeHelpersCompletionItems, CompletionItemComparer.Instance).ToArray();
+
+            if (ShouldRemoveAllDesignTimeItems(owner, sourceText))
+            {
+                filteredItems = filteredItems.Where(item => item.Label != null && !item.Label.StartsWith("__", StringComparison.Ordinal)).ToArray();
+            }
+
+            completionList.Items = filteredItems;
+            return completionList;
+        }
+
+        // If the current identifier starts with "__", only trim out common design time helpers from the list.
+        // In all other cases, trim out both common design time helpers and all completion items starting with "__".
+        private static bool ShouldRemoveAllDesignTimeItems(RazorSyntaxNode owner, SourceText sourceText)
+        {
+            if (owner.Span.Length < 2)
+            {
+                return true;
+            }
+
+            if (sourceText[owner.Span.Start] == '_' && sourceText[owner.Span.Start + 1] == '_')
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private class CompletionItemComparer : IEqualityComparer<CompletionItem>
+        {
+            public static CompletionItemComparer Instance = new();
+
+            public bool Equals(CompletionItem x, CompletionItem y)
+            {
+                if (x is null && y is null)
+                {
+                    return true;
+                }
+                else if (x is null || y is null)
+                {
+                    return false;
+                }
+
+                return x.Label.Equals(y.Label, StringComparison.Ordinal);
+            }
+
+            public int GetHashCode(CompletionItem obj) => obj?.Label?.GetHashCode() ?? 0;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -244,6 +244,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         services.AddSingleton<CompletionListProvider, DelegatedCompletionListProvider>();
                         services.AddSingleton<CompletionListProvider, RazorCompletionListProvider>();
                         services.AddSingleton<DelegatedCompletionResponseRewriter, TextEditResponseRewriter>();
+                        services.AddSingleton<DelegatedCompletionResponseRewriter, DesignTimeHelperResponseRewriter>();
 
                         services.AddSingleton<AggregateCompletionItemResolver>();
                         services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DesignTimeHelperResponseRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DesignTimeHelperResponseRewriterTest.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    public class DesignTimeHelperResponseRewriterTest : ResponseRewriterTestBase
+    {
+        private protected override DesignTimeHelperResponseRewriter Rewriter => new DesignTimeHelperResponseRewriter();
+
+        [Fact]
+        public async Task RewriteAsync_NotCSharp_Noops()
+        {
+            // Arrange
+            var getCompletionsAt = 1;
+            var documentContent = "<";
+            var delegatedCompletionList = GenerateCompletionList("p", "div");
+
+            // Act
+            var rewrittenCompletionList = await GetRewrittenCompletionListAsync(getCompletionsAt, documentContent, delegatedCompletionList);
+
+            // Assert
+            Assert.Equal(2, rewrittenCompletionList.Items.Length);
+        }
+
+        [Fact]
+        public async Task RewriteAsync_RemovesHelper()
+        {
+            // Arrange
+            var getCompletionsAt = 1;
+            var documentContent = "@DateTime";
+            var delegatedCompletionList = GenerateCompletionList("__helper", "DateTime");
+
+            // Act
+            var rewrittenCompletionList = await GetRewrittenCompletionListAsync(getCompletionsAt, documentContent, delegatedCompletionList);
+
+            // Assert
+            var item = Assert.Single(rewrittenCompletionList.Items);
+            Assert.Equal("DateTime", item.Label);
+        }
+
+        [Fact]
+        public async Task RewriteAsync_TryingToUseHelper_Noops()
+        {
+            // Arrange
+            var getCompletionsAt = 1;
+            var documentContent = "@__hel";
+            var delegatedCompletionList = GenerateCompletionList("__helper", "DateTime");
+
+            // Act
+            var rewrittenCompletionList = await GetRewrittenCompletionListAsync(getCompletionsAt, documentContent, delegatedCompletionList);
+
+            // Assert
+            Assert.Equal(2, rewrittenCompletionList.Items.Length);
+        }
+
+        [Fact]
+        public async Task RewriteAsync_AlwaysRemovesRazorHelpers()
+        {
+            // Arrange
+            var getCompletionsAt = 1;
+            var documentContent = "@__hel";
+            var delegatedCompletionList = GenerateCompletionList("__helper", "__builder");
+
+            // Act
+            var rewrittenCompletionList = await GetRewrittenCompletionListAsync(getCompletionsAt, documentContent, delegatedCompletionList);
+
+            // Assert
+            var item = Assert.Single(rewrittenCompletionList.Items);
+            Assert.Equal("__helper", item.Label);
+        }
+
+        private static VSInternalCompletionList GenerateCompletionList(params string[] itemLabels)
+        {
+            var items = itemLabels.Select(label => new VSInternalCompletionItem() { Label = label }).ToArray();
+            return new VSInternalCompletionList()
+            {
+                Items = items
+            };
+        }
+    }
+}


### PR DESCRIPTION
- This changeset includes the logic to strip C# design time helpers from the C# completion list before returning them to clients.
    - The logic on "when" to remove helpers is a direct copy from the pre-existing `CompletionHandler`
- Added tests to validate the behavior

### Before

![Before gif of design time helpers not being removed](https://i.imgur.com/KRwPEPJ.gif)

### After

![After gif of design time helpers being removed](https://i.imgur.com/dYRS3yp.gif)

Part of #6448