### PR TITLE
Move IDidChangeConfigurationEndpoint to VS Contracts

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidChangeConfigurationParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DidChangeConfigurationParamsBridge.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    internal class DidChangeConfigurationParamsBridge : DidChangeConfigurationParams, IRequest
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IDidChangeConfigurationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IDidChangeConfigurationEndpoint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    [Parallel, Method(Methods.WorkspaceDidChangeConfigurationName, Direction.ClientToServer)]
+    internal interface IDidChangeConfigurationEndpoint : IJsonRpcNotificationHandler<DidChangeConfigurationParamsBridge>
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLanguageQueryHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLanguageQueryHandler.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using OmniSharp.Extensions.JsonRpc;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentEditsHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentEditsHandler.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using OmniSharp.Extensions.JsonRpc;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentRangesHandler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorMapToDocumentRangesHandler.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     [Parallel, Method(LanguageServerConstants.RazorMapToDocumentRangesEndpoint)]
-    internal interface IRazorMapToDocumentRangesHandler : IJsonRpcRequestHandler<RazorMapToDocumentRangesParams, RazorMapToDocumentRangesResponse>
+    internal interface IRazorMapToDocumentRangesHandler : IJsonRpcRequestHandler<RazorMapToDocumentRangesParams, RazorMapToDocumentRangesResponse?>
     {
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
@@ -1,24 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.Extensions.Logging;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal class RazorConfigurationEndpoint : IDidChangeConfigurationHandler
+    internal class RazorConfigurationEndpoint : IDidChangeConfigurationEndpoint
     {
         private readonly RazorLSPOptionsMonitor _optionsMonitor;
         private readonly ILogger _logger;
-        private DidChangeConfigurationCapability _capability;
 
         public RazorConfigurationEndpoint(RazorLSPOptionsMonitor optionsMonitor, ILoggerFactory loggerFactory)
         {
@@ -36,12 +31,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             _logger = loggerFactory.CreateLogger<RazorConfigurationEndpoint>();
         }
 
-        public void SetCapability(DidChangeConfigurationCapability capability, ClientCapabilities clientCapabilities)
-        {
-            _capability = capability;
-        }
-
-        public async Task<Unit> Handle(DidChangeConfigurationParams request, CancellationToken cancellationToken)
+        public async Task<Unit> Handle(DidChangeConfigurationParamsBridge request, CancellationToken cancellationToken)
         {
             _logger.LogTrace("Settings changed. Updating the server.");
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorConfigurationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorConfigurationEndpointTest.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
@@ -34,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var optionsMonitor = new TestRazorLSPOptionsMonitor(ConfigurationService, Cache);
             var endpoint = new RazorConfigurationEndpoint(optionsMonitor, LoggerFactory);
-            var request = new DidChangeConfigurationParams();
+            var request = new DidChangeConfigurationParamsBridge();
 
             // Act
             await endpoint.Handle(request, CancellationToken.None);


### PR DESCRIPTION
### Summary of the changes

- Move IDidChangeConfigurationHandler to VS Contracts

Fixes: https://github.com/dotnet/razor-tooling/issues/6369
