### PR TITLE
Move DocumentColorEndpoint to VS Contracts

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -5,15 +5,13 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
-using OmniSharp.Extensions.LanguageServer.Protocol.Document;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
 {
-    internal class DocumentColorEndpoint : IDocumentColorHandler
+    internal class DocumentColorEndpoint : IDocumentColorEndpoint
     {
-        private static readonly Container<ColorInformation> EmptyDocumentColors = new Container<ColorInformation>();
         private readonly ClientNotifierServiceBase _languageServer;
 
         public DocumentColorEndpoint(ClientNotifierServiceBase languageServer)
@@ -25,22 +23,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
 
             _languageServer = languageServer;
         }
-        public DocumentColorRegistrationOptions GetRegistrationOptions(ColorProviderCapability capability, ClientCapabilities clientCapabilities)
+
+        public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            return new DocumentColorRegistrationOptions()
-            {
-                DocumentSelector = RazorDefaults.Selector,
-            };
+            const string ServerCapabilities = "colorProvider";
+            var options = new DocumentColorOptions();
+
+            return new RegistrationExtensionResult(ServerCapabilities, options);
         }
 
-        public async Task<Container<ColorInformation>> Handle(DocumentColorParams request, CancellationToken cancellationToken)
+        public async Task<ColorInformation[]> Handle(DocumentColorParamsBridge request, CancellationToken cancellationToken)
         {
             var delegatedRequest = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorProvideHtmlDocumentColorEndpoint, request).ConfigureAwait(false);
-            var documentColors = await delegatedRequest.Returning<Container<ColorInformation>?>(cancellationToken).ConfigureAwait(false);
+            var documentColors = await delegatedRequest.Returning<ColorInformation[]>(cancellationToken).ConfigureAwait(false);
 
             if (documentColors is null)
             {
-                return EmptyDocumentColors;
+                return Array.Empty<ColorInformation>();
             }
 
             // HTML and Razor documents have identical mapping locations. Because of this we can return the result as-is.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DocumentColorParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DocumentColorParamsBridge.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+
+internal class DocumentColorParamsBridge : DocumentColorParams, IRequest<ColorInformation[]>
+{
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IDocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IDocumentColorEndpoint.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+
+[Parallel, Method(Methods.TextDocumentDocumentColorName)]
+internal interface IDocumentColorEndpoint : IJsonRpcRequestHandler<DocumentColorParamsBridge, ColorInformation[]>,
+    IRegistrationExtension
+{
+}


### PR DESCRIPTION
### Summary of the changes

- Move DocumentColorEndpoint to VS Contracts

Fixes: https://github.com/dotnet/razor-tooling/issues/6385
