### PR TITLE
Add support for provisional completions to single server completion.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionParams.cs
@@ -9,5 +9,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Protocol
         VersionedTextDocumentIdentifier HostDocument,
         Position ProjectedPosition,
         RazorLanguageKind ProjectedKind,
-        VSInternalCompletionContext Context);
+        VSInternalCompletionContext Context,
+        TextEdit? ProvisionalTextEdit);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VisualStudioTextChange.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/VisualStudioTextChange.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
@@ -14,6 +15,19 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         {
             OldSpan = new Span(oldStart, oldLength);
             NewText = newText;
+        }
+
+        public VisualStudioTextChange(TextEdit textEdit, ITextSnapshot textSnapshot)
+        {
+            var startRange = textEdit.Range.Start;
+            var startLine = textSnapshot.GetLineFromLineNumber(startRange.Line);
+            var startAbsoluteIndex = startLine.Start + startRange.Character;
+            var endRange = textEdit.Range.End;
+            var endLine = textSnapshot.GetLineFromLineNumber(endRange.Line);
+            var endAbsoluteIndex = endLine.Start + endRange.Character;
+            var length = endAbsoluteIndex - startAbsoluteIndex;
+            OldSpan = new Span(startAbsoluteIndex, length);
+            NewText = textEdit.NewText;
         }
 
         public Span OldSpan { get; }


### PR DESCRIPTION
- This adds a new way to enable provisional completion via a single server. The route I took was to enable a `ProvisionalTextEdit` to be provided along side the delegation params that is applied then reverted before / after requesting completions.
- Expanded the `DelegatedCompletionListProvider` to detect provisional completion scenarios and then build a corresponding `TextEdit`. Ultimately this logic is identical to the existing `CompletionHandler` logic with the one exception that it doesn't actually apply the text edit (it returns it to the client to apply).
- Updated the `ProvideCompletionListAsync` message target logic to allow understanding of provisional text edits and to apply / revert them as expected. Currently the revert logic can only work for single line provisional text edits which in our case is 100% OK because we only ever do `.` provisional completions today.
- Added tests to validate existing & new scenarios.

### Before

![before gif showing provisional completion not working](https://i.imgur.com/HqmUnbH.gif)

### After

![after gif showing provisional completion working](https://i.imgur.com/dolio5C.gif)

Fixes #6450