### PR TITLE
Vs contracts linked editing range

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/LinkedEditingRange/ILinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/LinkedEditingRange/ILinkedEditingRangeEndpoint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.LinkedEditingRange
+{
+    [Parallel, Method(Methods.TextDocumentLinkedEditingRangeName)]
+    internal interface ILinkedEditingRangeEndpoint : IJsonRpcRequestHandler<LinkedEditingRangeParamsBridge, LinkedEditingRanges?>, IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/LinkedEditingRange/LinkedEditingRangeParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/LinkedEditingRange/LinkedEditingRangeParamsBridge.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.LinkedEditingRange
+{
+    /// <summary>
+    /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="LinkedEditingRangeParams"/>
+    /// type does not implement <see cref="IRequest{TResponse}"/>.
+    /// </summary>
+    internal class LinkedEditingRangeParamsBridge : LinkedEditingRangeParams, IRequest<LinkedEditingRanges?>
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
 {
     internal static class LinePositionSpanExtensions
     {
-        public static Range AsRange(this LinePositionSpan linePositionSpan)
+        public static Range AsVSRange(this LinePositionSpan linePositionSpan)
         {
             var range = new Range
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -2,26 +2,32 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.CodeAnalysis.Text;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using System.Diagnostics.CodeAnalysis;
-using OmniSharp.Extensions.LanguageServer.Protocol.Document;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
 {
-    internal class LinkedEditingRangeEndpoint : ILinkedEditingRangeHandler
+    internal class LinkedEditingRangeParamsBridge : LinkedEditingRangeParams, IRequest<,>
+    {
+    }
+
+    [Parallel, Method(Methods.TextDocumentLinkedEditingRangeName)]
+    internal interface ILinkedEditingRangeEndpoint: IJsonRpcRequestHandler<LinkedEditingRangeParamsBridge, LinkedEditingRanges>
+
+    internal class LinkedEditingRangeEndpoint : ILinkedEditingRangeEndpoint
     {
         // The regex below excludes characters that can never be valid in a TagHelper name.
         // This is loosely based off logic from the Razor compiler:

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
@@ -9,15 +9,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.LinkedEditingRange;
 using Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
 {
@@ -32,9 +33,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument, documentFound: false);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <te[||]st1></test1>
             };
 
@@ -54,9 +55,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <te[||]st1></test1>
             };
 
@@ -91,9 +92,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 6 } // <test1[||]></test1>
             };
 
@@ -128,9 +129,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 9 } // <test1></[||]test1>
             };
 
@@ -165,9 +166,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 0, Character = 1 } // @[||]addTagHelper *
             };
 
@@ -187,9 +188,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <te[||]st1 />
             };
 
@@ -209,9 +210,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 1 } // <[||]test1><test1></test1></test1>
             };
 
@@ -246,9 +247,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <bo[||]dy></body>
             };
 
@@ -283,9 +284,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 8 } // <body></[||]body>
             };
 
@@ -320,9 +321,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentResolver(uri.GetAbsoluteOrUNCPath(), codeDocument);
             var endpoint = new LinkedEditingRangeEndpoint(Dispatcher, documentResolver, LoggerFactory);
-            var request = new LinkedEditingRangeParams
+            var request = new LinkedEditingRangeParamsBridge
             {
-                TextDocument = new TextDocumentIdentifier(uri),
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <bo[||]dy />
             };
 


### PR DESCRIPTION
### Summary of the changes

- Move `ILinkedEditingRangeHandler` to VS Contracts.

Fixes: https://github.com/dotnet/razor-tooling/issues/6379
