### PR TITLE
Allow templates to stay on a single line in on type formatting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -316,7 +316,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     continue;
                 }
 
-
                 CleanupSourceMappingStart(context, mappingRange, changes, out var newLineAdded);
 
                 CleanupSourceMappingEnd(context, mappingRange, changes, newLineAdded);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
@@ -663,6 +663,80 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         }
 
         [Fact]
+        public async Task ComponentInCSharp1()
+        {
+            await RunOnTypeFormattingTestAsync(
+                input: """
+                    @code {
+                        public void Sink(RenderFragment r)
+                        {
+                        }
+                    
+                        public void M()
+                        {
+                            Sink(@<PageTitle />);$$ // <-- this should not move
+                    
+                            Console.WriteLine("Hello");
+                            Console.WriteLine("World"); // <-- type/replace semicolon here
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public void Sink(RenderFragment r)
+                        {
+                        }
+                    
+                        public void M()
+                        {
+                            Sink(@<PageTitle />); // <-- this should not move
+                    
+                            Console.WriteLine("Hello");
+                            Console.WriteLine("World"); // <-- type/replace semicolon here
+                        }
+                    }
+                    """,
+                triggerCharacter: ';');
+        }
+
+        [Fact]
+        public async Task ComponentInCSharp2()
+        {
+            await RunOnTypeFormattingTestAsync(
+                input: """
+                    @code {
+                        public void Sink(RenderFragment r)
+                        {
+                        }
+                    
+                        public void M()
+                        {
+                            Sink(@<PageTitle />); // <-- this should not move
+                    
+                            Console.WriteLine("Hello");
+                            Console.WriteLine("World");$$ // <-- type/replace semicolon here
+                        }
+                    }
+                    """,
+                expected: """
+                    @code {
+                        public void Sink(RenderFragment r)
+                        {
+                        }
+                    
+                        public void M()
+                        {
+                            Sink(@<PageTitle />); // <-- this should not move
+                    
+                            Console.WriteLine("Hello");
+                            Console.WriteLine("World"); // <-- type/replace semicolon here
+                        }
+                    }
+                    """,
+                triggerCharacter: ';');
+        }
+
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/6158")]
         public async Task Format_NestedLambdas()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6191