### PR TITLE
Add collapsed text usage in Razor

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,7 +77,7 @@
     <MicrosoftVisualStudioShellPackagesVersion>17.2.32330.158</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.3.37-preview</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.3.0-2.22267.5</RoslynPackageVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.3.15</VisualStudioLanguageServerProtocolVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.3.2017</VisualStudioLanguageServerProtocolVersion>
     <MicrosoftNetCompilersToolsetVersion>4.2.0-1.final</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 return null;
             }
 
-            List<FoldingRange> mappedRanges = new();
+                List<FoldingRange> mappedRanges = new();
 
             foreach (var foldingRange in foldingResponse.CSharpRanges)
             {
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                     range,
                     out var mappedRange))
                 {
-                    mappedRanges.Add(GetFoldingRange(mappedRange));
+                    mappedRanges.Add(GetFoldingRange(mappedRange, foldingRange.CollapsedText));
                 }
             }
 
@@ -145,6 +145,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
         {
             Debug.Assert(range.StartLine < range.EndLine);
 
+            // If the range has collapsed text set, we don't need
+            // to adjust anything. Just take that value as what
+            // should be shown
+            if (!string.IsNullOrEmpty(range.CollapsedText))
+            {
+                return range;
+            }
+
             var sourceText = codeDocument.GetSourceText();
             var startLine = range.StartLine;
             var lineSpan = sourceText.Lines[startLine].Span;
@@ -180,13 +188,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 }
             };
 
-        private static FoldingRange GetFoldingRange(Range range)
+        private static FoldingRange GetFoldingRange(Range range, string? collapsedText)
            => new FoldingRange()
            {
                StartLine = range.Start.Line,
                StartCharacter = range.Start.Character,
                EndCharacter = range.End.Character,
-               EndLine = range.End.Line
+               EndLine = range.End.Line,
+               CollapsedText = collapsedText
            };
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 return null;
             }
 
-                List<FoldingRange> mappedRanges = new();
+            List<FoldingRange> mappedRanges = new();
 
             foreach (var foldingRange in foldingResponse.CSharpRanges)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/RazorCodeBlockFoldingProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/RazorCodeBlockFoldingProvider.cs
@@ -29,7 +29,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                     StartLine = startLine,
                     EndCharacter = endOffset,
                     EndLine = endLine,
-                    CollapsedText = codeBlock.DirectiveDescriptor.Directive
+
+                    // Directives remove the "@" but for collapsing we want to keep it for users.
+                    // Shows "@code" instead of "code".
+                    CollapsedText = "@" + codeBlock.DirectiveDescriptor.Directive 
                 };
 
                 builder.Add(foldingRange);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/RazorCodeBlockFoldingProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/RazorCodeBlockFoldingProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                     StartLine = startLine,
                     EndCharacter = endOffset,
                     EndLine = endLine,
+                    CollapsedText = codeBlock.DirectiveDescriptor.Directive
                 };
 
                 builder.Add(foldingRange);


### PR DESCRIPTION
### Summary of the changes
- Forwards collapsed text for FoldingRange if it's provided by Roslyn or HTML
- Adds CollapsedText for our own implementations
- If no CollapsedText is found, fall back to old behavior of modifying the start to be the end of the line

![be0befd3-c0a4-47c9-897b-a45b1a84ca9e](https://user-images.githubusercontent.com/475144/172255773-0e67c2e2-b7e2-4891-968d-de22bcc507c0.gif)

