### PR TITLE
Update DartLab pipeline to use new agent template

### DIFF
--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -29,7 +29,7 @@ variables:
   value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
 
 stages:
-- template: \stages\visual-studio\base.yml@DartLabTemplates
+- template: \stages\visual-studio\agent.yml@DartLabTemplates
   parameters:
     displayName: VS Integration
     testLabPoolName: VS-Platform


### PR DESCRIPTION
As part of the work to roll them out broadly, DartLab's templates were refactored to enable scenarios for more teams. Updating this pipeline to use the new agent template.

### Summary of the changes

Updating DartLab pipeline to use the agent template.

Fixes:
