### PR TITLE
No variance in template string between calls to _logger.Log*

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -72,6 +72,9 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+# CA2254: The logging message template should not vary between calls to 'ILogger.Log*'
+dotnet_diagnostic.CA2254.severity = warning
 # csharp_style_allow_blank_lines_between_consecutive_braces_experimental
 dotnet_diagnostic.IDE2002.severity = warning
 # csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
@@ -67,7 +67,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 throw new ArgumentOutOfRangeException($"request.Data should be convertable to {nameof(RazorCodeActionResolutionParams)}");
             }
 
-            _logger.LogInformation($"Resolving workspace edit for action {GetCodeActionId(resolutionParams)}.");
+            var codeAtionId = GetCodeActionId(resolutionParams);
+            _logger.LogInformation("Resolving workspace edit for action {codeActionId}.", codeAtionId);
 
             // If it's a special "edit based code action" then the edit has been pre-computed and we
             // can extract the edit details and return to the client. This is only required for VSCode

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolutionEndpoint.cs
@@ -67,8 +67,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 throw new ArgumentOutOfRangeException($"request.Data should be convertable to {nameof(RazorCodeActionResolutionParams)}");
             }
 
-            var codeAtionId = GetCodeActionId(resolutionParams);
-            _logger.LogInformation("Resolving workspace edit for action {codeActionId}.", codeAtionId);
+            var codeActionId = GetCodeActionId(resolutionParams);
+            _logger.LogInformation("Resolving workspace edit for action {codeActionId}.", codeActionId);
 
             // If it's a special "edit based code action" then the edit has been pre-computed and we
             // can extract the edit details and return to the client. This is only required for VSCode
@@ -92,7 +92,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                         resolutionParams,
                         cancellationToken);
                 default:
-                    var codeActionId = GetCodeActionId(resolutionParams);
                     _logger.LogError("Invalid CodeAction.Data.Language. Received {codeActionId}.", codeActionId);
                     return request;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             var razorCompletionItems = _completionFactsService.GetCompletionItems(completionContext);
 
-            _logger.LogTrace($"Resolved {razorCompletionItems.Count} completion items.");
+            _logger.LogTrace("Resolved {razorCompletionItemsCount} completion items.", razorCompletionItems.Count);
 
             var completionList = CreateLSPCompletionList(razorCompletionItems);
             var completionCapability = _clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             var razorCompletionItems = _completionFactsService.GetCompletionItems(razorCompletionContext);
 
-            _logger.LogTrace($"Resolved {razorCompletionItems.Count} completion items.");
+            _logger.LogTrace("Resolved {razorCompletionItemsCount} completion items.", razorCompletionItems.Count);
 
             var completionList = CreateLSPCompletionList(razorCompletionItems, clientCapabilities);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/RazorBreakpointSpanEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/RazorBreakpointSpanEndpoint.cs
@@ -125,7 +125,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            _logger.LogTrace($"Breakpoint span request for ({request.Position.Line}, {request.Position.Character}) = ({hostDocumentRange.Start.Line}, {hostDocumentRange.Start.Character}");
+            _logger.LogTrace("Breakpoint span request for ({requestLine}, {requestCharacter}) = ({hostDocumentStartLine}, {hostDocumentStartCharacter}",
+                request.Position.Line, request.Position.Character, hostDocumentRange.Start.Line, hostDocumentRange.Start.Character);
 
             return new RazorBreakpointSpanResponse()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/RazorProximityExpressionsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/RazorProximityExpressionsEndpoint.cs
@@ -105,7 +105,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging
                 return null;
             }
 
-            _logger.LogTrace($"Proximity expressions request for ({request.Position.Line}, {request.Position.Character}) yielded {expressions.Count} results.");
+            _logger.LogTrace("Proximity expressions request for ({Line}, {Character}) yielded {expressionsCount} results.", 
+                request.Position.Line, request.Position.Character, expressions.Count);
 
             return new RazorProximityExpressionsResponse
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var namespaceName = tagHelper.GetTypeNamespace();
             if (typeName == null || namespaceName == null)
             {
-                _logger.LogWarning($"Could not split namespace and type for name {tagHelper.Name}.");
+                _logger.LogWarning("Could not split namespace and type for name {tagHelperName}.", tagHelper.Name);
                 return null;
             }
 
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var namespacesMatch = new StringSegment(namespaceNode.Content).Equals(namespaceName, StringComparison.Ordinal);
             if (!namespacesMatch)
             {
-                _logger.LogInformation($"Namespace name {namespaceNode.Content} does not match namespace name {namespaceName}.");
+                _logger.LogInformation("Namespace name {namespaceNodeContent} does not match namespace name {namespaceName}.", namespaceNode.Content, namespaceName);
             }
 
             return namespacesMatch;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Failed to sync client configuration on the server: {ex}");
+                _logger.LogWarning("Failed to sync client configuration on the server: {ex}", ex);
                 return null;
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Malformed option: Token {token} cannot be converted to type {typeof(T)}.");
+                _logger.LogError(ex, "Malformed option: Token {token} cannot be converted to type {TypeOfT}.", token, typeof(T));
                 return defaultValue;
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsEndpoint.cs
@@ -89,7 +89,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 throw new ArgumentNullException(nameof(request));
             }
 
-            _logger.LogInformation($"Received {request.Kind:G} diagnostic request for {request.RazorDocumentUri} with {request.Diagnostics.Length} diagnostics.");
+            _logger.LogInformation("Received {requestKind} diagnostic request for {razorDocumentUri} with {diagnosticsLength} diagnostics.",
+                request.Kind, request.RazorDocumentUri, request.Diagnostics.Length);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -110,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
 
             if (documentSnapshot is null)
             {
-                _logger.LogInformation($"Failed to find document {request.RazorDocumentUri}.");
+                _logger.LogInformation("Failed to find document {razorDocumentUri}.", request.RazorDocumentUri);
 
                 return new RazorDiagnosticsResponse()
                 {
@@ -146,7 +147,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 };
             }
 
-            _logger.LogInformation($"{filteredDiagnostics.Length}/{unmappedDiagnostics.Length} diagnostics remain after filtering.");
+            _logger.LogInformation("{filteredDiagnosticsLength}/{unmappedDiagnosticsLength} diagnostics remain after filtering.", filteredDiagnostics.Length, unmappedDiagnostics.Length);
 
             var mappedDiagnostics = MapDiagnostics(
                 request.Kind,
@@ -154,7 +155,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 codeDocument,
                 sourceText);
 
-            _logger.LogInformation($"Returning {mappedDiagnostics.Length} mapped diagnostics.");
+            _logger.LogInformation("Returning {mappedDiagnosticsLength} mapped diagnostics.", mappedDiagnostics.Length);
 
             return new RazorDiagnosticsResponse()
             {
@@ -532,7 +533,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 default:
                     // Unsupported owner of rude diagnostic, lets map to the entirety of the diagnostic range to be sure the diagnostic can be presented
 
-                    _logger.LogInformation($"Failed to remap rude edit for SyntaxTree owner '{owner?.Kind}'.");
+                    _logger.LogInformation("Failed to remap rude edit for SyntaxTree owner '{ownerKind}'.", owner?.Kind);
 
                     var startLineIndex = diagnosticRange.Start.Line;
                     if (startLineIndex >= sourceText.Lines.Count)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
@@ -66,12 +66,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             catch (PathTooLongException ex)
             {
-                logger?.LogWarning(ex.Message);
+                logger?.LogWarning("PathTooLong: {exception}", ex.Message);
                 yield break;
             }
             catch (IOException ex)
             {
-                logger?.LogWarning(ex.Message);
+                logger?.LogWarning("IOException: {exception}", ex.Message);
                 yield break;
             }
 
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             catch (PathTooLongException ex)
             {
-                logger?.LogWarning(ex.Message);
+                logger?.LogWarning("PathTooLong: {exception}", ex.Message);
                 yield break;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/AbstractTextDocumentPresentationEndpointBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/AbstractTextDocumentPresentationEndpointBase.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation
             var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
             if (codeDocument.IsUnsupported())
             {
-                _logger.LogWarning($"Failed to retrieve generated output for document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to retrieve generated output for document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation
 
             if (languageKind is not (RazorLanguageKind.CSharp or RazorLanguageKind.Html))
             {
-                _logger.LogInformation($"Unsupported language {languageKind:G}.");
+                _logger.LogInformation("Unsupported language {languageKind}.", languageKind);
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation
 
             if (request.Uris is null || request.Uris.Length == 0)
             {
-                _logger.LogInformation($"No URIs were included in the request?");
+                _logger.LogInformation("No URIs were included in the request?");
                 return null;
             }
 
@@ -127,12 +127,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation
 
         private async Task<string?> TryGetComponentTagAsync(Uri uri, CancellationToken cancellationToken)
         {
-            _logger.LogInformation($"Trying to find document info for dropped uri {uri}.");
+            _logger.LogInformation("Trying to find document info for dropped uri {uri}.", uri);
 
             var documentSnapshot = await TryGetDocumentSnapshotAsync(uri.GetAbsoluteOrUNCPath(), cancellationToken).ConfigureAwait(false);
             if (documentSnapshot is null)
             {
-                _logger.LogInformation($"Failed to find document for component {uri}.");
+                _logger.LogInformation("Failed to find document for component {uri}.", uri);
                 return null;
             }
 
@@ -141,14 +141,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation
             var descriptor = await _razorComponentSearchEngine.TryGetTagHelperDescriptorAsync(documentSnapshot, cancellationToken).ConfigureAwait(false);
             if (descriptor is null)
             {
-                _logger.LogInformation($"Failed to find tag helper descriptor.");
+                _logger.LogInformation("Failed to find tag helper descriptor.");
                 return null;
             }
 
             var typeName = descriptor.GetTypeNameIdentifier();
             if (string.IsNullOrWhiteSpace(typeName))
             {
-                _logger.LogWarning($"Found a tag helper, {descriptor.Name}, but it has an empty TypeNameIdentifier.");
+                _logger.LogWarning("Found a tag helper, {descriptorName}, but it has an empty TypeNameIdentifier.", descriptor.Name);
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -65,11 +65,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
             var linePosition = new LinePosition(line, character);
             if (linePosition.Line >= sourceText.Lines.Count)
             {
-                var errorMessage = Resources.FormatPositionIndex_Outside_Range(
-                    line,
-                    nameof(sourceText),
-                    sourceText.Lines.Count);
-                logger?.LogError(errorMessage);
+#pragma warning disable CA2254 // Template should be a static expression.
+// This is actually static, the compiler just doesn't know it.
+                logger?.LogError(Resources.GetResourceString("FormatPositionIndex_Outside_Range"), line, nameof(sourceText), sourceText.Lines.Count);
+#pragma warning restore CA2254 // Template should be a static expression
                 absoluteIndex = -1;
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 }
                 catch (Exception e) when (retries < MaxRetries)
                 {
-                    _logger.LogWarning(e, $"Try {retries} to get FoldingRange");
+                    _logger.LogWarning(e, "Try {retries} to get FoldingRange", retries);
                 }
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 changedText = changedText.WithChanges(csharpChanges);
                 changedContext = await changedContext.WithTextAsync(changedText);
 
-                _logger.LogTestOnly($"After FormatCSharpAsync:\r\n{changedText}");
+                _logger.LogTestOnly("After FormatCSharpAsync:\r\n{changedText}", changedText);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -78,10 +78,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 // Apply the edits that modify indentation.
                 changedText = changedText.WithChanges(indentationChanges);
 
-                _logger.LogTestOnly($"After AdjustIndentationAsync:\r\n{changedText}");
+                _logger.LogTestOnly("After AdjustIndentationAsync:\r\n{changedText}", changedText);
             }
 
-            _logger.LogTestOnly($"Generated C#:\r\n{context.CSharpSourceText}");
+            _logger.LogTestOnly("Generated C#:\r\n{context.CSharpSourceText}", context.CSharpSourceText);
 
             var finalChanges = changedText.GetTextChanges(originalText);
             var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 if (!DocumentMappingService.TryMapToProjectedDocumentPosition(codeDocument, context.HostDocumentIndex, out _, out var projectedIndex))
                 {
-                    _logger.LogWarning($"Failed to map to projected position for document {context.Uri}.");
+                    _logger.LogWarning("Failed to map to projected position for document {context.Uri}.", context.Uri);
                     return result;
                 }
 
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 }
 
                 textEdits = formattingChanges.Select(change => change.AsTextEdit(csharpText)).ToArray();
-                _logger.LogInformation($"Received {textEdits.Length} results from C#.");
+                _logger.LogInformation("Received {textEditsLength} results from C#.", textEdits.Length);
             }
 
             var normalizedEdits = NormalizeTextEdits(csharpText, textEdits, out var originalTextWithChanges);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var changedText = originalText;
             var changedContext = context;
 
-            _logger.LogTestOnly($"Before HTML formatter:\r\n{changedText}");
+            _logger.LogTestOnly("Before HTML formatter:\r\n{changedText}", changedText);
 
             if (htmlEdits.Length > 0)
             {
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 // Create a new formatting context for the changed razor document.
                 changedContext = await context.WithTextAsync(changedText);
 
-                _logger.LogTestOnly($"After normalizedEdits:\r\n{changedText}");
+                _logger.LogTestOnly("After normalizedEdits:\r\n{changedText}", changedText);
             }
 
             var indentationChanges = AdjustRazorIndentation(changedContext);
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 // Apply the edits that adjust indentation.
                 changedText = changedText.WithChanges(indentationChanges);
-                _logger.LogTestOnly($"After AdjustRazorIndentation:\r\n{changedText}");
+                _logger.LogTestOnly("After AdjustRazorIndentation:\r\n{changedText}", changedText);
             }
 
             var finalChanges = changedText.GetTextChanges(originalText);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ILoggerExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ILoggerExtensions.cs
@@ -11,11 +11,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public static bool TestOnlyLoggingEnabled = false;
 
         [Conditional("DEBUG")]
-        public static void LogTestOnly(this ILogger logger, string message)
+        public static void LogTestOnly(this ILogger logger, string message, params object?[] args)
         {
             if (TestOnlyLoggingEnabled)
             {
-                logger.LogDebug(message);
+#pragma warning disable CA2254 // Template should be a static expression
+                // This is test-only, so we don't mind losing structured logging for it.
+                logger.LogDebug(message, args);
+#pragma warning restore CA2254 // Template should be a static expression
             }
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
@@ -105,7 +105,7 @@ internal class InlineCompletionEndpoint : IVSInlineCompletionEndpoint
             throw new ArgumentNullException(nameof(request));
         }
 
-        _logger.LogInformation($"Starting request for {request.TextDocument.Uri} at {request.Position}.");
+        _logger.LogInformation("Starting request for {textDocumentUri} at {position}.", request.TextDocument.Uri, request.Position);
 
         var document = await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>
         {
@@ -135,7 +135,7 @@ internal class InlineCompletionEndpoint : IVSInlineCompletionEndpoint
         if (languageKind != RazorLanguageKind.CSharp ||
             !_documentMappingService.TryMapToProjectedDocumentPosition(codeDocument, hostDocumentIndex, out var projectedPosition, out _))
         {
-            _logger.LogInformation($"Unsupported location for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Unsupported location for {textDocumentUri}.", request.TextDocument.Uri);
             return null;
         }
 
@@ -153,7 +153,7 @@ internal class InlineCompletionEndpoint : IVSInlineCompletionEndpoint
         var list = await response.Returning<VSInternalInlineCompletionList>(cancellationToken).ConfigureAwait(false);
         if (list == null || !list.Items.Any())
         {
-            _logger.LogInformation($"Did not get any inline completions from delegation.");
+            _logger.LogInformation("Did not get any inline completions from delegation.");
             return null;
         }
 
@@ -166,7 +166,7 @@ internal class InlineCompletionEndpoint : IVSInlineCompletionEndpoint
 
             if (!_documentMappingService.TryMapFromProjectedDocumentRange(codeDocument, range, out var rangeInRazorDoc))
             {
-                _logger.LogWarning($"Could not remap projected range {range} to razor document");
+                _logger.LogWarning("Could not remap projected range {range} to razor document", range);
                 continue;
             }
 
@@ -188,11 +188,11 @@ internal class InlineCompletionEndpoint : IVSInlineCompletionEndpoint
 
         if (items.Count == 0)
         {
-            _logger.LogInformation($"Could not format / map the items from delegation.");
+            _logger.LogInformation("Could not format / map the items from delegation.");
             return null;
         }
 
-        _logger.LogInformation($"Returning {items.Count} items.");
+        _logger.LogInformation("Returning {itemsCount} items.", items.Count);
         return new VSInternalInlineCompletionList
         {
             Items = items.ToArray()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/JsonRpcRequestScheduler.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/JsonRpc/JsonRpcRequestScheduler.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.JsonRpc
             }
             catch (Exception e)
             {
-                _logger.LogCritical($"Work queue threw an uncaught exception. Stopping processing: {e.Message}");
+                _logger.LogCritical("Work queue threw an uncaught exception. Stopping processing: {exceptionMessage}", e.Message);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LanguageServerErrorReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LanguageServerErrorReporter.cs
@@ -30,12 +30,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public override void ReportError(Exception exception, ProjectSnapshot? project)
         {
-            _logger.LogError(exception, $"Error thrown from project {project?.FilePath}");
+            _logger.LogError(exception, "Error thrown from project {projectFilePath}", project?.FilePath);
         }
 
         public override void ReportError(Exception exception, Project workspaceProject)
         {
-            _logger.LogError(exception, $"Error thrown from project {workspaceProject.FilePath}");
+            _logger.LogError(exception, "Error thrown from project {workspaceProjectFilePath}", workspaceProject.FilePath);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             var defaultProject = (DefaultProjectSnapshot)projectSnapshot;
             var textLoader = _remoteTextLoaderFactory.Create(textDocumentPath);
 
-            _logger.LogInformation($"Adding document '{filePath}' to project '{projectSnapshot.FilePath}'.");
+            _logger.LogInformation("Adding document '{filePath}' to project '{projectSnapshotFilePath}'.", filePath, projectSnapshot.FilePath);
             _projectSnapshotManagerAccessor.Instance.DocumentAdded(defaultProject.HostProject, hostDocument, textLoader);
         }
 
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             var defaultProject = (DefaultProjectSnapshot)projectSnapshot;
 
-            _logger.LogInformation($"Opening document '{textDocumentPath}' in project '{projectSnapshot.FilePath}'.");
+            _logger.LogInformation("Opening document '{textDocumentPath}' in project '{projectSnapshotFilePath}'.", textDocumentPath, projectSnapshot.FilePath);
             _projectSnapshotManagerAccessor.Instance.DocumentOpened(defaultProject.HostProject.FilePath, textDocumentPath, sourceText);
 
             TrackDocumentVersion(textDocumentPath, version);
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             var textLoader = _remoteTextLoaderFactory.Create(filePath);
             var defaultProject = (DefaultProjectSnapshot)projectSnapshot;
-            _logger.LogInformation($"Closing document '{textDocumentPath}' in project '{projectSnapshot.FilePath}'.");
+            _logger.LogInformation("Closing document '{textDocumentPath}' in project '{projectSnapshotFilePath}'.", textDocumentPath, projectSnapshot.FilePath);
             _projectSnapshotManagerAccessor.Instance.DocumentClosed(defaultProject.HostProject.FilePath, textDocumentPath, textLoader);
         }
 
@@ -193,13 +193,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             if (!projectSnapshot.DocumentFilePaths.Contains(textDocumentPath, FilePathComparer.Instance))
             {
-                _logger.LogInformation($"Containing project is not tracking document '{filePath}");
+                _logger.LogInformation("Containing project is not tracking document '{filePath}", filePath);
                 return;
             }
 
             var document = (DefaultDocumentSnapshot)projectSnapshot.GetDocument(textDocumentPath);
             var defaultProject = (DefaultProjectSnapshot)projectSnapshot;
-            _logger.LogInformation($"Removing document '{textDocumentPath}' from project '{projectSnapshot.FilePath}'.");
+            _logger.LogInformation("Removing document '{textDocumentPath}' from project '{projectSnapshotFilePath}'.", textDocumentPath, projectSnapshot.FilePath);
             _projectSnapshotManagerAccessor.Instance.DocumentRemoved(defaultProject.HostProject, document.State.HostDocument);
         }
 
@@ -214,7 +214,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             }
 
             var defaultProject = (DefaultProjectSnapshot)projectSnapshot;
-            _logger.LogTrace($"Updating document '{textDocumentPath}'.");
+            _logger.LogTrace("Updating document '{textDocumentPath}'.", textDocumentPath);
             _projectSnapshotManagerAccessor.Instance.DocumentChanged(defaultProject.HostProject.FilePath, textDocumentPath, sourceText);
 
             TrackDocumentVersion(textDocumentPath, version);
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             var hostProject = new HostProject(normalizedPath, RazorDefaults.Configuration, RazorDefaults.RootNamespace);
             _projectSnapshotManagerAccessor.Instance.ProjectAdded(hostProject);
-            _logger.LogInformation($"Added project '{filePath}' to project system.");
+            _logger.LogInformation("Added project '{filePath}' to project system.", filePath);
 
             TryMigrateMiscellaneousDocumentsToProject();
         }
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                 return;
             }
 
-            _logger.LogInformation($"Removing project '{filePath}' from project system.");
+            _logger.LogInformation("Removing project '{filePath}' from project system.", filePath);
             _projectSnapshotManagerAccessor.Instance.ProjectRemoved(project.HostProject);
 
             TryMigrateDocumentsFromRemovedProject(project);
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             if (project is null)
             {
                 // Never tracked the project to begin with, noop.
-                _logger.LogInformation($"Failed to update untracked project '{filePath}'.");
+                _logger.LogInformation("Failed to update untracked project '{filePath}'.", filePath);
                 return;
             }
 
@@ -283,7 +283,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
             {
-                _logger.LogInformation($"Updating project '{filePath}' TagHelpers ({projectWorkspaceState.TagHelpers.Count}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
+                _logger.LogInformation("Updating project '{filePath}' TagHelpers ({projectWorkspaceState.TagHelpers.Count}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).",
+                    filePath, projectWorkspaceState.TagHelpers.Count, projectWorkspaceState.CSharpLanguageVersion);
             }
 
             _projectSnapshotManagerAccessor.Instance.ProjectWorkspaceStateChanged(project.FilePath, projectWorkspaceState);
@@ -293,23 +294,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
                 currentHostProject.RootNamespace == rootNamespace)
             {
-                _logger.LogTrace($"Updating project '{filePath}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
+                _logger.LogTrace("Updating project '{filePath}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.",
+                    filePath, configuration.ConfigurationName, rootNamespace);
                 return;
             }
 
             if (configuration is null)
             {
                 configuration = RazorDefaults.Configuration;
-                _logger.LogInformation($"Updating project '{filePath}' to use Razor's default configuration ('{configuration.ConfigurationName}')'.");
+                _logger.LogInformation("Updating project '{filePath}' to use Razor's default configuration ('{configuration.ConfigurationName}')'.", filePath, configuration.ConfigurationName);
             }
             else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName)
             {
-                _logger.LogInformation($"Updating project '{filePath}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.");
+                _logger.LogInformation("Updating project '{filePath}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.",
+                    filePath, configuration.ConfigurationName, configuration.LanguageVersion);
             }
 
             if (currentHostProject.RootNamespace != rootNamespace)
             {
-                _logger.LogInformation($"Updating project '{filePath}''s root namespace to '{rootNamespace}'.");
+                _logger.LogInformation("Updating project '{filePath}''s root namespace to '{rootNamespace}'.", filePath, rootNamespace);
             }
 
             var hostProject = new HostProject(project.FilePath, configuration, rootNamespace);
@@ -359,7 +362,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                     continue;
                 }
 
-                _logger.LogTrace($"Updating document '{newHostDocument.FilePath}''s file kind to '{newHostDocument.FileKind}' and target path to '{newHostDocument.TargetPath}'.");
+                _logger.LogTrace("Updating document '{newHostDocument.FilePath}''s file kind to '{newHostDocument.FileKind}' and target path to '{newHostDocument.TargetPath}'.",
+                    newHostDocument.FilePath, newHostDocument.FileKind, newHostDocument.TargetPath);
 
                 _projectSnapshotManagerAccessor.Instance.DocumentRemoved(currentHostProject, currentHostDocument);
 
@@ -390,7 +394,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                     var remoteTextLoader = _remoteTextLoaderFactory.Create(documentFilePath);
                     var newHostDocument = _hostDocumentFactory.Create(documentFilePath, documentHandle.TargetPath, documentHandle.FileKind);
 
-                    _logger.LogInformation($"Adding new document '{documentFilePath}' to project '{projectFilePath}'.");
+                    _logger.LogInformation("Adding new document '{documentFilePath}' to project '{projectFilePath}'.", documentFilePath, projectFilePath);
                     _projectSnapshotManagerAccessor.Instance.DocumentAdded(currentHostProject, newHostDocument, remoteTextLoader);
                 }
             }
@@ -407,7 +411,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             var textLoader = new DocumentSnapshotTextLoader(documentSnapshot);
             var newHostDocument = _hostDocumentFactory.Create(documentSnapshot.FilePath, documentSnapshot.TargetPath, documentSnapshot.FileKind);
 
-            _logger.LogInformation($"Moving '{documentFilePath}' from the '{fromProject.FilePath}' project to '{toProject.FilePath}' project.");
+            _logger.LogInformation("Moving '{documentFilePath}' from the '{fromProject.FilePath}' project to '{toProject.FilePath}' project.",
+                documentFilePath, fromProject.FilePath, toProject.FilePath);
             _projectSnapshotManagerAccessor.Instance.DocumentRemoved(fromProject.HostProject, currentHostDocument);
             _projectSnapshotManagerAccessor.Instance.DocumentAdded(toProject.HostProject, newHostDocument, textLoader);
         }
@@ -445,7 +450,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                 var defaultToProject = (DefaultProjectSnapshot)toProject;
                 var newHostDocument = _hostDocumentFactory.Create(documentSnapshot.FilePath, documentSnapshot.TargetPath, documentSnapshot.FileKind);
 
-                _logger.LogInformation($"Migrating '{documentFilePath}' from the '{project.FilePath}' project to '{toProject.FilePath}' project.");
+                _logger.LogInformation("Migrating '{documentFilePath}' from the '{project.FilePath}' project to '{toProject.FilePath}' project.",
+                    documentFilePath, project.FilePath, toProject.FilePath);
                 _projectSnapshotManagerAccessor.Instance.DocumentAdded(defaultToProject.HostProject, newHostDocument, textLoader);
             }
         }
@@ -475,7 +481,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                 var textLoader = new DocumentSnapshotTextLoader(documentSnapshot);
                 var defaultProject = (DefaultProjectSnapshot)projectSnapshot;
                 var newHostDocument = _hostDocumentFactory.Create(documentSnapshot.FilePath, documentSnapshot.TargetPath);
-                _logger.LogInformation($"Migrating '{documentFilePath}' from the '{miscellaneousProject.FilePath}' project to '{projectSnapshot.FilePath}' project.");
+                _logger.LogInformation("Migrating '{documentFilePath}' from the '{miscellaneousProject.FilePath}' project to '{projectSnapshot.FilePath}' project.",
+                    documentFilePath, miscellaneousProject.FilePath, projectSnapshot.FilePath);
                 _projectSnapshotManagerAccessor.Instance.DocumentAdded(defaultProject.HostProject, newHostDocument, textLoader);
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (_logger.IsEnabled(LogLevel.Trace))
             {
                 var diagnosticString = string.Join(", ", diagnostics.Select(diagnostic => diagnostic.Id));
-                _logger.LogTrace($"Publishing diagnostics for document '{document.FilePath}': {diagnosticString}");
+                _logger.LogTrace("Publishing diagnostics for document '{FilePath}': {diagnosticString}", document.FilePath, diagnosticString);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 var textSpan = new TextSpan(startPosition, change.RangeLength ?? endPosition - startPosition);
                 var textChange = new TextChange(textSpan, change.Text);
 
-                _logger.LogTrace($"Applying {textChange}");
+                _logger.LogTrace("Applying {textChange}", textChange);
 
                 // If there happens to be multiple text changes we generate a new source text for each one. Due to the
                 // differences in VSCode and Roslyn's representation we can't pass in all changes simultaneously because

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentSynchronizationEndpoint.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public Task<Unit> Handle(DidSaveTextDocumentParamsBridge notification, CancellationToken _)
         {
-            _logger.LogInformation($"Saved Document {notification.TextDocument.Uri.GetAbsoluteOrUNCPath()}");
+            _logger.LogInformation("Saved Document {textDocumentUri}", notification.TextDocument.Uri.GetAbsoluteOrUNCPath());
 
             return Unit.Task;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -129,7 +129,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 }
             }
 
-            _logger.LogTrace($"Language query request for ({request.Position.Line}, {request.Position.Character}) = {languageKind} at ({responsePosition.Line}, {responsePosition.Character})");
+            _logger.LogTrace("Language query request for ({requestPositionLine}, {requestPositionCharacter}) = {languageKind} at ({responsePositionLine}, {responsePositionCharacter})",
+                request.Position.Line, request.Position.Character, languageKind, responsePosition.Line, responsePosition.Character);
 
             return new RazorLanguageQueryResponse()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 var factory = new LoggerFactory();
                 var logger = factory.CreateLogger<RazorLanguageServer>();
                 var assemblyInformationAttribute = typeof(RazorLanguageServer).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-                logger.LogInformation("Razor Language Server version " + assemblyInformationAttribute.InformationalVersion);
+                logger.LogInformation("Razor Language Server version {RazorVersion}", assemblyInformationAttribute.InformationalVersion);
                 factory.Dispose();
             }
             catch

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             var semanticTokens = await _semanticTokensInfoService.GetSemanticTokensAsync(request.TextDocument, request.Range, cancellationToken);
             var amount = semanticTokens is null ? "no" : (semanticTokens.Data.Length / 5).ToString(Thread.CurrentThread.CurrentCulture);
 
-            _logger.LogInformation($"Returned {amount} semantic tokens for range {request.Range} in {request.TextDocument.Uri}.");
+            _logger.LogInformation("Returned {amount} semantic tokens for range {request.Range} in {request.TextDocument.Uri}.", amount, request.Range, request.TextDocument.Uri);
 
             if (semanticTokens is not null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             // `GetMatchingCSharpResponseAsync` that will cause us to retry in a bit.
             if (csharpResponse is null)
             {
-                _logger.LogWarning($"Issue with retrieving C# response for Razor range: {razorRange}");
+                _logger.LogWarning("Issue with retrieving C# response for Razor range: {razorRange}", razorRange);
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
             var languageKind = _razorDocumentMappingService.GetLanguageKind(codeDocument, hostDocumentIndex, rightAssociative: true);
             if (languageKind is not RazorLanguageKind.Html)
             {
-                _logger.LogInformation($"Unsupported language {languageKind:G}.");
+                _logger.LogInformation("Unsupported language {languageKind:G}.", languageKind);
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                     if (roslynProject is null)
                     {
                         // There's no Roslyn project associated with the Razor document.
-                        _logger.LogTrace($"Could not find a Roslyn project for Razor virtual document '{backgroundVirtualFilePath}'.");
+                        _logger.LogTrace("Could not find a Roslyn project for Razor virtual document '{backgroundVirtualFilePath}'.", backgroundVirtualFilePath);
                         return;
                     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/DefaultProjectChangePublisher.cs
@@ -126,8 +126,8 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning($@"Could not update Razor project configuration file '{publishFilePath}':
-{ex}");
+                    _logger.LogWarning(@"Could not update Razor project configuration file '{publishFilePath}':
+{ex}", publishFilePath, ex);
                 }
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/MSBuildProjectManager.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.OmnisharpPlugin
             }
             catch (Exception ex)
             {
-                _logger.LogError("Unexpected exception got thrown from the Razor plugin: " + ex);
+                _logger.LogError("Unexpected exception got thrown from the Razor plugin: {exception}", ex);
             }
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Extensions/PositionExtensions.cs
@@ -26,11 +26,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions
             var linePosition = new LinePosition(position.Line, position.Character);
             if (linePosition.Line >= sourceText.Lines.Count)
             {
-                var errorMessage = Resources.FormatPositionIndex_Outside_Range(
-                    position.Line,
+#pragma warning disable CA2254 // Template should be a static expression
+                // Resources.GetResourceString won't vary, so this is fine
+                logger?.LogError(Resources.GetResourceString("FormatPositionIndex_Outside_Range"), position.Line,
                     nameof(sourceText),
                     sourceText.Lines.Count);
-                logger?.LogError(errorMessage);
+#pragma warning restore CA2254 // Template should be a static expression
                 absoluteIndex = -1;
                 return false;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -129,17 +129,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
             if (request.Context is null)
             {
-                _logger.LogWarning($"No Context available when document was found.");
+                _logger.LogWarning("No Context available when document was found.");
                 return null;
             }
 
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     }
                 };
 
-                _logger.LogInformation($"Requesting non-provisional completions for {projectedDocumentUri}.");
+                _logger.LogInformation("Requesting non-provisional completions for {projectedDocumentUri}.", projectedDocumentUri);
 
                 var textBuffer = serverKind.GetTextBuffer(documentSnapshot);
                 var response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(
@@ -572,7 +572,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 previousCharacterProjection.LanguageKind != RazorLanguageKind.CSharp ||
                 previousCharacterProjection.HostDocumentVersion is null)
             {
-                _logger.LogInformation($"Failed to find previous char projection in {previousCharacterProjection?.LanguageKind:G} at version {previousCharacterProjection?.HostDocumentVersion}.");
+                _logger.LogInformation("Failed to find previous char projection in {previousCharacterProjection?.LanguageKind:G} at version {previousCharacterProjection?.HostDocumentVersion}.",
+                    previousCharacterProjection?.LanguageKind, previousCharacterProjection?.HostDocumentVersion);
                 return default;
             }
 
@@ -609,7 +610,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     }
                 };
 
-                _logger.LogInformation($"Requesting provisional completion for {previousCharacterProjection.Uri}.");
+                _logger.LogInformation("Requesting provisional completion for {previousCharacterProjection.Uri}.", previousCharacterProjection.Uri);
 
                 var textBuffer = LanguageServerKind.CSharp.GetTextBuffer(documentSnapshot);
                 var response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (!_documentManager.TryGetDocument(requestContext.HostDocumentUri, out var documentSnapshot))
             {
-                _logger.LogError("Could not find the associated host document for completion resolve: {0}.", requestContext.HostDocumentUri);
+                _logger.LogError("Could not find the associated host document for completion resolve: {hostDocumentUri}.", requestContext.HostDocumentUri);
                 return request;
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -126,9 +126,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 // There should always be a document version attached to an open document.
                 // Log it and move on as if it was synchronized.
-                var message = $"Could not find a document version associated with the document '{documentSnapshot.Uri}'";
-                _activityLogger.LogVerbose(message);
-                _logHubLogger?.LogWarning(message);
+                _activityLogger.LogVerbose($"Could not find a document version associated with the document '{documentSnapshot.Uri}'");
+                _logHubLogger?.LogWarning("Could not find a document version associated with the document '{documentSnapshotUri}'", documentSnapshot.Uri);
             }
             else
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DefaultLSPProjectionProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
             else
             {
-                _logHubLogger?.LogInformation($"Could not find projection for {languageResponse.Kind:G}.");
+                _logHubLogger?.LogInformation("Could not find projection for {languageResponseKind:G}.", languageResponse.Kind);
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentHighlightHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentHighlightHandler.cs
@@ -79,11 +79,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation("Requesting highlights for {projectionResult.Uri} at ({projectionResult.Position?.Line}, {projectionResult.Position?.Character}).",
+            _logger.LogInformation("Requesting highlights for {projectionUri} at ({projectionLine}, {projectionCharacter}).",
                 projectionResult.Uri, projectionResult.Position?.Line, projectionResult.Position?.Character);
 
             var languageServerName = serverKind.ToLanguageServerName();
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return highlights;
             }
 
-            _logger.LogInformation("Received {highlights.Length} results, remapping.", highlights.Length);
+            _logger.LogInformation("Received {length} results, remapping.", highlights.Length);
 
             var remappedHighlights = new List<DocumentHighlight>();
 
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             if (mappingResult?.HostDocumentVersion != documentSnapshot.Version)
             {
                 // Couldn't remap the range or the document changed in the meantime. Discard this highlight.
-                _logger.LogInformation("Mapping failed. Versions: {documentSnapshot.Version} -> {mappingResult?.HostDocumentVersion}.",
+                _logger.LogInformation("Mapping failed. Versions: {documentVersion} -> {hostDocumentVersion}.",
                     documentSnapshot.Version, mappingResult?.HostDocumentVersion);
                 return Array.Empty<DocumentHighlight>();
             }
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 remappedHighlights.Add(remappedHighlight);
             }
 
-            _logger.LogInformation("Returning {remappedHighlights.Count} highlights.", remappedHighlights.Count);
+            _logger.LogInformation("Returning {remappedHighlightsCount} highlights.", remappedHighlights.Count);
             return remappedHighlights.ToArray();
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentHighlightHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentHighlightHandler.cs
@@ -79,11 +79,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -109,7 +109,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation($"Requesting highlights for {projectionResult.Uri} at ({projectionResult.Position?.Line}, {projectionResult.Position?.Character}).");
+            _logger.LogInformation("Requesting highlights for {projectionResult.Uri} at ({projectionResult.Position?.Line}, {projectionResult.Position?.Character}).",
+                projectionResult.Uri, projectionResult.Position?.Line, projectionResult.Position?.Character);
 
             var languageServerName = serverKind.ToLanguageServerName();
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);
@@ -131,7 +132,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return highlights;
             }
 
-            _logger.LogInformation($"Received {highlights.Length} results, remapping.");
+            _logger.LogInformation("Received {highlights.Length} results, remapping.", highlights.Length);
 
             var remappedHighlights = new List<DocumentHighlight>();
 
@@ -145,7 +146,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             if (mappingResult?.HostDocumentVersion != documentSnapshot.Version)
             {
                 // Couldn't remap the range or the document changed in the meantime. Discard this highlight.
-                _logger.LogInformation($"Mapping failed. Versions: {documentSnapshot.Version} -> {mappingResult?.HostDocumentVersion}.");
+                _logger.LogInformation("Mapping failed. Versions: {documentSnapshot.Version} -> {mappingResult?.HostDocumentVersion}.",
+                    documentSnapshot.Version, mappingResult?.HostDocumentVersion);
                 return Array.Empty<DocumentHighlight>();
             }
 
@@ -168,7 +170,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 remappedHighlights.Add(remappedHighlight);
             }
 
-            _logger.LogInformation($"Returning {remappedHighlights.Count} highlights.");
+            _logger.LogInformation("Returning {remappedHighlights.Count} highlights.", remappedHighlights.Count);
             return remappedHighlights.ToArray();
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -80,11 +80,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogInformation("Document {request.TextDocument.Uri} closed or deleted, clearing diagnostics.", request.TextDocument.Uri);
+                _logger.LogInformation("Document {textDocumentUri} closed or deleted, clearing diagnostics.", request.TextDocument.Uri);
 
                 var clearedDiagnosticReport = new VSInternalDiagnosticReport[]
                 {
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
             {
-                _logger.LogWarning("Failed to find virtual C# document for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find virtual C# document for {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(false);
             if (!synchronized)
             {
-                _logger.LogInformation("Failed to synchronize document {csharpDoc.Uri}.", csharpDoc.Uri);
+                _logger.LogInformation("Failed to synchronize document {csharpDocUri}.", csharpDoc.Uri);
 
                 // Could not synchronize, report nothing changed
                 return new VSInternalDiagnosticReport[]
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 PreviousResultId = request.PreviousResultId
             };
 
-            _logger.LogInformation("Requesting diagnostics for {csharpDoc.Uri} with previous result Id of {request.PreviousResultId}.", csharpDoc.Uri, request.PreviousResultId);
+            _logger.LogInformation("Requesting diagnostics for {csharpDocUri} with previous result Id of {previousResultId}.", csharpDoc.Uri, request.PreviousResultId);
 
             var textBuffer = csharpDoc.Snapshot.TextBuffer;
             var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]>(
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             }
 
-            _logger.LogInformation("Received {resultsFromAllLanguageServers.Count} diagnostic reports.", resultsFromAllLanguageServers.Count);
+            _logger.LogInformation("Received {resultsFromAllLanguageServersCount} diagnostic reports.", resultsFromAllLanguageServers.Count);
 
             var processedResults = await RemapDocumentDiagnosticsAsync(
                 resultsFromAllLanguageServers,
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
-                _logger.LogInformation("Requesting processing of {diagnosticReport.Diagnostics.Length} diagnostics.", diagnosticReport.Diagnostics.Length);
+                _logger.LogInformation("Requesting processing of {diagnosticsLength} diagnostics.", diagnosticReport.Diagnostics.Length);
 
                 var processedDiagnostics = await _diagnosticsProvider.TranslateAsync(
                     RazorLanguageKind.CSharp,
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 if (processedDiagnostics is null || !_documentManager.TryGetDocument(razorDocumentUri, out var documentSnapshot) ||
                     documentSnapshot.Version != processedDiagnostics.HostDocumentVersion)
                 {
-                    _logger.LogInformation("Document version mismatch, discarding {diagnosticReport.Diagnostics.Length} diagnostics.", diagnosticReport.Diagnostics.Length);
+                    _logger.LogInformation("Document version mismatch, discarding {diagnosticsLength} diagnostics.", diagnosticReport.Diagnostics.Length);
 
                     // We choose to discard diagnostics in this case & report nothing changed.
                     diagnosticReport.Diagnostics = null;
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
-                _logger.LogInformation("Returning {processedDiagnostics.Diagnostics.Length} diagnostics.", processedDiagnostics.Diagnostics.Length);
+                _logger.LogInformation("Returning {diagnosticsLength} diagnostics.", processedDiagnostics.Diagnostics.Length);
                 diagnosticReport.Diagnostics = processedDiagnostics.Diagnostics;
 
                 mappedDiagnosticReports.Add(diagnosticReport);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/DocumentPullDiagnosticsHandler.cs
@@ -80,11 +80,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogInformation($"Document {request.TextDocument.Uri} closed or deleted, clearing diagnostics.");
+                _logger.LogInformation("Document {request.TextDocument.Uri} closed or deleted, clearing diagnostics.", request.TextDocument.Uri);
 
                 var clearedDiagnosticReport = new VSInternalDiagnosticReport[]
                 {
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
             {
-                _logger.LogWarning($"Failed to find virtual C# document for {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find virtual C# document for {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(false);
             if (!synchronized)
             {
-                _logger.LogInformation($"Failed to synchronize document {csharpDoc.Uri}.");
+                _logger.LogInformation("Failed to synchronize document {csharpDoc.Uri}.", csharpDoc.Uri);
 
                 // Could not synchronize, report nothing changed
                 return new VSInternalDiagnosticReport[]
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 PreviousResultId = request.PreviousResultId
             };
 
-            _logger.LogInformation($"Requesting diagnostics for {csharpDoc.Uri} with previous result Id of {request.PreviousResultId}.");
+            _logger.LogInformation("Requesting diagnostics for {csharpDoc.Uri} with previous result Id of {request.PreviousResultId}.", csharpDoc.Uri, request.PreviousResultId);
 
             var textBuffer = csharpDoc.Snapshot.TextBuffer;
             var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]>(
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             }
 
-            _logger.LogInformation($"Received {resultsFromAllLanguageServers.Count} diagnostic reports.");
+            _logger.LogInformation("Received {resultsFromAllLanguageServers.Count} diagnostic reports.", resultsFromAllLanguageServers.Count);
 
             var processedResults = await RemapDocumentDiagnosticsAsync(
                 resultsFromAllLanguageServers,
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
-                _logger.LogInformation($"Requesting processing of {diagnosticReport.Diagnostics.Length} diagnostics.");
+                _logger.LogInformation("Requesting processing of {diagnosticReport.Diagnostics.Length} diagnostics.", diagnosticReport.Diagnostics.Length);
 
                 var processedDiagnostics = await _diagnosticsProvider.TranslateAsync(
                     RazorLanguageKind.CSharp,
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 if (processedDiagnostics is null || !_documentManager.TryGetDocument(razorDocumentUri, out var documentSnapshot) ||
                     documentSnapshot.Version != processedDiagnostics.HostDocumentVersion)
                 {
-                    _logger.LogInformation($"Document version mismatch, discarding {diagnosticReport.Diagnostics.Length} diagnostics.");
+                    _logger.LogInformation("Document version mismatch, discarding {diagnosticReport.Diagnostics.Length} diagnostics.", diagnosticReport.Diagnostics.Length);
 
                     // We choose to discard diagnostics in this case & report nothing changed.
                     diagnosticReport.Diagnostics = null;
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                     continue;
                 }
 
-                _logger.LogInformation($"Returning {processedDiagnostics.Diagnostics.Length} diagnostics.");
+                _logger.LogInformation("Returning {processedDiagnostics.Diagnostics.Length} diagnostics.", processedDiagnostics.Diagnostics.Length);
                 diagnosticReport.Diagnostics = processedDiagnostics.Diagnostics;
 
                 mappedDiagnosticReports.Add(diagnosticReport);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -96,11 +96,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            _logger.LogInformation("Requesting references for {projectionResult.Uri}.", projectionResult.Uri);
+            _logger.LogInformation("Requesting references for {projectionResultUri}.", projectionResult.Uri);
 
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<SerializableReferenceParams, VSInternalReferenceItem[]>(
                 Methods.TextDocumentReferencesName,
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Results returned through Progress notification
             var remappedResults = await RemapReferenceItemsAsync(result, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("Returning {remappedResults.Length} results.", remappedResults.Length);
+            _logger.LogInformation("Returning {remappedResultsLength} results.", remappedResults.Length);
 
             return remappedResults;
 
@@ -202,10 +202,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return;
             }
 
-            _logger.LogInformation("Received {result.Length} references, remapping.", result.Length);
+            _logger.LogInformation("Received {resultLength} references, remapping.", result.Length);
             var remappedResults = await RemapReferenceItemsAsync(result, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("Reporting {remappedResults.Length} results.", remappedResults.Length);
+            _logger.LogInformation("Reporting {remappedResultsLength} results.", remappedResults.Length);
             progress.Report(remappedResults);
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/FindAllReferencesHandler.cs
@@ -96,11 +96,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            _logger.LogInformation($"Requesting references for {projectionResult.Uri}.");
+            _logger.LogInformation("Requesting references for {projectionResult.Uri}.", projectionResult.Uri);
 
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<SerializableReferenceParams, VSInternalReferenceItem[]>(
                 Methods.TextDocumentReferencesName,
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Results returned through Progress notification
             var remappedResults = await RemapReferenceItemsAsync(result, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation($"Returning {remappedResults.Length} results.");
+            _logger.LogInformation("Returning {remappedResults.Length} results.", remappedResults.Length);
 
             return remappedResults;
 
@@ -202,10 +202,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return;
             }
 
-            _logger.LogInformation($"Received {result.Length} references, remapping.");
+            _logger.LogInformation("Received {result.Length} references, remapping.", result.Length);
             var remappedResults = await RemapReferenceItemsAsync(result, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation($"Reporting {remappedResults.Length} results.");
+            _logger.LogInformation("Reporting {remappedResults.Length} results.", remappedResults.Length);
             progress.Report(remappedResults);
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 cancellationToken).ConfigureAwait(false);
             if (projectionResult is null)
             {
-                _logger.LogWarning($"Projection result was null");
+                _logger.LogWarning("Projection result was null");
                 return null;
             }
 
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation($"Requesting GoToDef for {projectionResult.Uri}.");
+            _logger.LogInformation("Requesting GoToDef for {projectionResult.Uri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var languageServerName = serverKind.ToLanguageServerName();
@@ -128,13 +128,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return locations;
             }
 
-            _logger.LogInformation($"Received {locations.Length} results, remapping.");
+            _logger.LogInformation("Received {locations.Length} results, remapping.", locations.Length);
 
             cancellationToken.ThrowIfCancellationRequested();
 
             var remappedLocations = await _documentMappingProvider.RemapLocationsAsync(locations, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation($"Returning {remappedLocations?.Length} definitions.");
+            _logger.LogInformation("Returning {remappedLocations?.Length} definitions.", remappedLocations?.Length);
             return remappedLocations;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToDefinitionHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation("Requesting GoToDef for {projectionResult.Uri}.", projectionResult.Uri);
+            _logger.LogInformation("Requesting GoToDef for {projectionResultUri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var languageServerName = serverKind.ToLanguageServerName();
@@ -128,13 +128,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return locations;
             }
 
-            _logger.LogInformation("Received {locations.Length} results, remapping.", locations.Length);
+            _logger.LogInformation("Received {locationsLength} results, remapping.", locations.Length);
 
             cancellationToken.ThrowIfCancellationRequested();
 
             var remappedLocations = await _documentMappingProvider.RemapLocationsAsync(locations, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("Returning {remappedLocations?.Length} definitions.", remappedLocations?.Length);
+            _logger.LogInformation("Returning {remappedLocationsLength} definitions.", remappedLocations?.Length);
             return remappedLocations;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToImplementationHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToImplementationHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return new();
             }
 
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var languageServerName = serverKind.ToLanguageServerName();
 
-            _logger.LogInformation("Requesting {languageServerName} implementation for {projectionResult.Uri}.", languageServerName, projectionResult.Uri);
+            _logger.LogInformation("Requesting {languageServerName} implementation for {projectionResultUri}.", languageServerName, projectionResult.Uri);
 
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, SumType<Location[]?, VSInternalReferenceItem[]?>>(
@@ -130,14 +130,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 var remappedLocations = await FindAllReferencesHandler.RemapReferenceItemsAsync(referenceItems, _documentMappingProvider, _documentManager, cancellationToken).ConfigureAwait(false);
 
-                _logger.LogInformation("Returning {remappedLocations?.Length} internal reference items.", remappedLocations?.Length);
+                _logger.LogInformation("Returning {remappedLocationsLength} internal reference items.", remappedLocations?.Length);
                 return remappedLocations;
             }
             else if (result.Value is Location[] locations)
             {
                 var remappedLocations = await _documentMappingProvider.RemapLocationsAsync(locations, cancellationToken).ConfigureAwait(false);
 
-                _logger.LogInformation("Returning {remappedLocations?.Length} locations.", remappedLocations?.Length);
+                _logger.LogInformation("Returning {remappedLocationsLength} locations.", remappedLocations?.Length);
 
                 return remappedLocations;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToImplementationHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/GoToImplementationHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return new();
             }
 
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var languageServerName = serverKind.ToLanguageServerName();
 
-            _logger.LogInformation($"Requesting {languageServerName} implementation for {projectionResult.Uri}.");
+            _logger.LogInformation("Requesting {languageServerName} implementation for {projectionResult.Uri}.", languageServerName, projectionResult.Uri);
 
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, SumType<Location[]?, VSInternalReferenceItem[]?>>(
@@ -130,14 +130,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 var remappedLocations = await FindAllReferencesHandler.RemapReferenceItemsAsync(referenceItems, _documentMappingProvider, _documentManager, cancellationToken).ConfigureAwait(false);
 
-                _logger.LogInformation($"Returning {remappedLocations?.Length} internal reference items.");
+                _logger.LogInformation("Returning {remappedLocations?.Length} internal reference items.", remappedLocations?.Length);
                 return remappedLocations;
             }
             else if (result.Value is Location[] locations)
             {
                 var remappedLocations = await _documentMappingProvider.RemapLocationsAsync(locations, cancellationToken).ConfigureAwait(false);
 
-                _logger.LogInformation($"Returning {remappedLocations?.Length} locations.");
+                _logger.LogInformation("Returning {remappedLocations?.Length} locations.", remappedLocations?.Length);
 
                 return remappedLocations;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation($"Requesting hovers for {projectionResult.Uri}.");
+            _logger.LogInformation("Requesting hovers for {projectionResult.Uri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);
@@ -147,7 +147,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
             else if (mappingResult.HostDocumentVersion != documentSnapshot.Version)
             {
-                _logger.LogInformation($"Discarding result, document has changed. {documentSnapshot.Version} -> {mappingResult.HostDocumentVersion}");
+                _logger.LogInformation("Discarding result, document has changed. {documentSnapshot.Version} -> {mappingResult.HostDocumentVersion}",
+                    documentSnapshot.Version, mappingResult.HostDocumentVersion);
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/HoverHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation("Requesting hovers for {projectionResult.Uri}.", projectionResult.Uri);
+            _logger.LogInformation("Requesting hovers for {projectionResultUri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
             else if (mappingResult.HostDocumentVersion != documentSnapshot.Version)
             {
-                _logger.LogInformation("Discarding result, document has changed. {documentSnapshot.Version} -> {mappingResult.HostDocumentVersion}",
+                _logger.LogInformation("Discarding result, document has changed. {documentSnapshotVersion} -> {mappingResultHostDocumentVersion}",
                     documentSnapshot.Version, mappingResult.HostDocumentVersion);
                 return null;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}, with trigger character {request.Character}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}, with trigger character {request.Character}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
             if (projectionResult is null)
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
             else if (projectionResult.LanguageKind == RazorLanguageKind.Razor)
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 TextDocument = new TextDocumentIdentifier() { Uri = projectionResult.Uri }
             };
 
-            _logger.LogInformation($"Requesting auto-insert for {projectionResult.Uri}.");
+            _logger.LogInformation("Requesting auto-insert for {projectionResult.Uri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 TextEditFormat = result.TextEditFormat,
             };
 
-            _logger.LogInformation($"Returning edit.");
+            _logger.LogInformation("Returning edit.");
             return remappedResponse;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/OnAutoInsertHandler.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 return null;
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}, with trigger character {request.Character}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}, with trigger character {character}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var projectionResult = await _projectionProvider.GetProjectionAsync(documentSnapshot, request.Position, cancellationToken).ConfigureAwait(false);
             if (projectionResult is null)
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
             else if (projectionResult.LanguageKind == RazorLanguageKind.Razor)
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 TextDocument = new TextDocumentIdentifier() { Uri = projectionResult.Uri }
             };
 
-            _logger.LogInformation("Requesting auto-insert for {projectionResult.Uri}.", projectionResult.Uri);
+            _logger.LogInformation("Requesting auto-insert for {projectionResultUri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RenameHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RenameHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation("Requesting rename for {projectionResult.Uri}.", projectionResult.Uri);
+            _logger.LogInformation("Requesting rename for {projectionResultUri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RenameHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RenameHandler.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 }
             };
 
-            _logger.LogInformation($"Requesting rename for {projectionResult.Uri}.");
+            _logger.LogInformation("Requesting rename for {projectionResult.Uri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var textBuffer = serverKind.GetTextBuffer(documentSnapshot);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/SignatureHelpHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/SignatureHelpHandler.cs
@@ -63,11 +63,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
+            _logger.LogInformation("Starting request for {textDocumentUri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                _logger.LogWarning("Failed to find document {textDocumentUri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 },
             };
 
-            _logger.LogInformation("Requesting signature help for {projectionResult.Uri}.", projectionResult.Uri);
+            _logger.LogInformation("Requesting signature help for {projectionResultUri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var languageServerName = serverKind.ToLanguageServerName();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/SignatureHelpHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/SignatureHelpHandler.cs
@@ -63,11 +63,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 throw new ArgumentNullException(nameof(clientCapabilities));
             }
 
-            _logger.LogInformation($"Starting request for {request.TextDocument.Uri}.");
+            _logger.LogInformation("Starting request for {request.TextDocument.Uri}.", request.TextDocument.Uri);
 
             if (!_documentManager.TryGetDocument(request.TextDocument.Uri, out var documentSnapshot))
             {
-                _logger.LogWarning($"Failed to find document {request.TextDocument.Uri}.");
+                _logger.LogWarning("Failed to find document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 },
             };
 
-            _logger.LogInformation($"Requesting signature help for {projectionResult.Uri}.");
+            _logger.LogInformation("Requesting signature help for {projectionResult.Uri}.", projectionResult.Uri);
 
             var serverKind = projectionResult.LanguageKind.ToLanguageServerKind();
             var languageServerName = serverKind.ToLanguageServerName();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (processedDiagnostics is null)
             {
-                _logger?.LogWarning("Failed to semnd request to diagnostic translation server for {htmlDocumentUri}.", htmlDocumentUri);
+                _logger?.LogWarning("Failed to send request to diagnostic translation server for {htmlDocumentUri}.", htmlDocumentUri);
                 return CreateEmptyDiagnosticsResponse(diagnosticParams);
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -90,7 +90,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return CreateDefaultResponse(token);
             }
 
-            _logger?.LogInformation($"Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.");
+            _logger?.LogInformation("Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.",
+                diagnosticParams.Uri, diagnosticParams.Diagnostics.Length);
 
             var htmlDocumentUri = diagnosticParams.Uri;
             var razorDocumentUri = RazorLSPConventions.GetRazorDocumentUri(htmlDocumentUri);
@@ -103,14 +104,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (!_documentManager.TryGetDocument(razorDocumentUri, out var razorDocumentSnapshot))
             {
-                _logger?.LogInformation($"Failed to find document {razorDocumentUri}.");
+                _logger?.LogInformation("Failed to find document {razorDocumentUri}.", razorDocumentUri);
                 return CreateEmptyDiagnosticsResponse(diagnosticParams);
             }
 
             if (!razorDocumentSnapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var htmlDocumentSnapshot) ||
                 !htmlDocumentSnapshot.Uri.Equals(htmlDocumentUri))
             {
-                _logger?.LogInformation($"Failed to find virtual HTML document {htmlDocumentUri}.");
+                _logger?.LogInformation("Failed to find virtual HTML document {htmlDocumentUri}.", htmlDocumentUri);
                 return CreateEmptyDiagnosticsResponse(diagnosticParams);
             }
 
@@ -130,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             if (processedDiagnostics is null)
             {
-                _logger?.LogWarning($"Failed to semnd request to diagnostic translation server for {htmlDocumentUri}.");
+                _logger?.LogWarning("Failed to semnd request to diagnostic translation server for {htmlDocumentUri}.", htmlDocumentUri);
                 return CreateEmptyDiagnosticsResponse(diagnosticParams);
             }
 
@@ -140,7 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             //
             // This'll need to be revisited based on preferences with flickering vs lingering.
 
-            _logger?.LogInformation($"Returning {processedDiagnostics.Diagnostics.Length} diagnostics.");
+            _logger?.LogInformation("Returning {processedDiagnostics.Diagnostics.Length} diagnostics.", processedDiagnostics.Diagnostics.Length);
             diagnosticParams.Diagnostics = processedDiagnostics.Diagnostics;
 
             return CreateResponse(diagnosticParams);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorHtmlPublishDiagnosticsInterceptor.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return CreateDefaultResponse(token);
             }
 
-            _logger?.LogInformation("Received HTML Publish diagnostic request for {diagnosticParams.Uri} with {diagnosticParams.Diagnostics.Length} diagnostics.",
+            _logger?.LogInformation("Received HTML Publish diagnostic request for {diagnosticParamsUri} with {diagnosticsLength} diagnostics.",
                 diagnosticParams.Uri, diagnosticParams.Diagnostics.Length);
 
             var htmlDocumentUri = diagnosticParams.Uri;
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             //
             // This'll need to be revisited based on preferences with flickering vs lingering.
 
-            _logger?.LogInformation("Returning {processedDiagnostics.Diagnostics.Length} diagnostics.", processedDiagnostics.Diagnostics.Length);
+            _logger?.LogInformation("Returning {diagnosticsLength} diagnostics.", processedDiagnostics.Diagnostics.Length);
             diagnosticParams.Diagnostics = processedDiagnostics.Diagnostics;
 
             return CreateResponse(diagnosticParams);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -16,7 +16,6 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem;
 using ContentItem = Microsoft.CodeAnalysis.Razor.ProjectSystem.ManagedProjectSystemSchema.ContentItem;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLSPEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLSPEditorFeatureDetector.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
             if (!IsLSPEditorAvailable())
             {
-                _logger.LogVerbose($"Using Legacy editor because the option was set to true");
+                _logger.LogVerbose("Using Legacy editor because the option was set to true");
                 return false;
             }
 
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             if (!ProjectSupportsLSPEditor(documentMoniker, ivsHierarchy))
             {
                 // Current project hierarchy doesn't support the LSP Razor editor
-                _logger.LogVerbose($"Using Legacy editor because the current project does not support LSP Editor");
+                _logger.LogVerbose("Using Legacy editor because the current project does not support LSP Editor");
                 return false;
             }
 


### PR DESCRIPTION
### Summary of the changes

- By fixing all instances of [CA2254](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254) we ensure that we are able to take advantage of structured logging.
- I went ahead and made this a warning to make it more noticeable and prevent future instances since it's easy to miss this and in other contexts we prefer the `$"..."` method.
