### PR TITLE
Use the complete branch name in DartLab yml

### DIFF
--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -20,7 +20,7 @@ resources:
     endpoint: dnceng/internal dotnet-razor-tooling
     type: git
     name: internal/dotnet-razor-tooling
-    ref: $(Build.SourceBranchName)
+    ref: $(Build.SourceBranch)
     trigger:
     - main
 


### PR DESCRIPTION
When branch names contain `/` the Build.SourceBranchName variable only includes the last part of the branch name. Build.SourceBranch includes the entire branch name.

Port of this Roslyn change https://github.com/dotnet/roslyn/pull/61821