### PR TITLE
Add support for delegated completion item resolutions.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -35,6 +35,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public const string RazorCompletionEndpointName = "razor/completion";
 
+        public const string RazorCompletionResolveEndpointName = "razor/completionItem/resolve";
+
         // RZLS Custom Message Targets
         public const string RazorUpdateCSharpBufferEndpoint = "razor/updateCSharpBuffer";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionItemResolveParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionItemResolveParams.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Protocol
+{
+    internal record DelegatedCompletionItemResolveParams(
+        TextDocumentIdentifier HostDocument,
+        VSInternalCompletionItem CompletionItem,
+        RazorLanguageKind OriginatingKind);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionResolutionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedCompletionResolutionContext.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Protocol
+{
+    internal record DelegatedCompletionResolutionContext(DelegatedCompletionParams OriginalRequestParams, object? OriginalCompletionListData);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    internal class DelegatedCompletionItemResolver : CompletionItemResolver
+    {
+        private readonly ClientNotifierServiceBase _languageServer;
+
+        public DelegatedCompletionItemResolver(ClientNotifierServiceBase languageServer)
+        {
+            _languageServer = languageServer;
+        }
+
+        public override async Task<VSInternalCompletionItem?> ResolveAsync(
+            VSInternalCompletionItem item,
+            VSInternalCompletionList containingCompletionlist,
+            object? originalRequestContext,
+            VSInternalClientCapabilities? clientCapabilities,
+            CancellationToken cancellationToken)
+        {
+            if (originalRequestContext is not DelegatedCompletionResolutionContext resolutionContext)
+            {
+                // Can't recognize the original request context, bail.
+                return null;
+            }
+
+            var labelQuery = item.Label;
+            var associatedDelegatedCompletion = containingCompletionlist.Items.FirstOrDefault(completion => string.Equals(labelQuery, completion.Label, StringComparison.Ordinal));
+            if (associatedDelegatedCompletion is null)
+            {
+                return null;
+            }
+
+            item.Data = associatedDelegatedCompletion.Data ?? resolutionContext.OriginalCompletionListData;
+
+            var delegatedParams = resolutionContext.OriginalRequestParams;
+            var delegatedResolveParams = new DelegatedCompletionItemResolveParams(
+                delegatedParams.HostDocument,
+                item,
+                delegatedParams.ProjectedKind);
+            var delegatedRequest = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorCompletionResolveEndpointName, delegatedResolveParams).ConfigureAwait(false);
+            var resolvedCompletionItem = await delegatedRequest.Returning<VSInternalCompletionItem?>(cancellationToken).ConfigureAwait(false);
+            return resolvedCompletionItem;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -248,6 +248,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                         services.AddSingleton<AggregateCompletionItemResolver>();
                         services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();
+                        services.AddSingleton<CompletionItemResolver, DelegatedCompletionItemResolver>();
                         services.AddSingleton<TagHelperCompletionService, LanguageServerTagHelperCompletionService>();
                         services.AddSingleton<RazorCompletionFactsService, DefaultRazorCompletionFactsService>();
                         services.AddSingleton<RazorCompletionItemProvider, DirectiveCompletionItemProvider>();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -87,5 +87,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [JsonRpcMethod(LanguageServerConstants.RazorCompletionEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<JToken?> ProvideCompletionsAsync(DelegatedCompletionParams completionParams, CancellationToken cancellationToken);
+
+        [JsonRpcMethod(LanguageServerConstants.RazorCompletionResolveEndpointName, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<JToken?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams completionResolveParams, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
+{
+    public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
+    {
+        public DelegatedCompletionItemResolverTest()
+        {
+            ClientCapabilities = new VSInternalClientCapabilities();
+            var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml");
+            CSharpCompletionParams = new DelegatedCompletionParams(documentContext.Identifier, new Position(10, 6), RazorLanguageKind.CSharp, new VSInternalCompletionContext(), ProvisionalTextEdit: null);
+            HtmlCompletionParams = new DelegatedCompletionParams(documentContext.Identifier, new Position(0, 0), RazorLanguageKind.Html, new VSInternalCompletionContext(), ProvisionalTextEdit: null);
+        }
+
+        private VSInternalClientCapabilities ClientCapabilities { get; }
+
+        private DelegatedCompletionParams CSharpCompletionParams { get; }
+
+        internal DelegatedCompletionParams HtmlCompletionParams { get; }
+
+        [Fact]
+        public async Task ResolveAsync_CanNotFindCompletionItem_Noops()
+        {
+            // Arrange
+            var server = TestItemResolverServer.Create();
+            var resolver = new DelegatedCompletionItemResolver(server);
+            var item = new VSInternalCompletionItem();
+            var notContainingCompletionList = new VSInternalCompletionList();
+            var originalRequestContext = new object();
+
+            // Act
+            var resolvedItem = await resolver.ResolveAsync(item, notContainingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            Assert.Null(resolvedItem);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_UnknownRequestContext_Noops()
+        {
+            // Arrange
+            var server = TestItemResolverServer.Create();
+            var resolver = new DelegatedCompletionItemResolver(server);
+            var item = new VSInternalCompletionItem();
+            var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, } };
+            var originalRequestContext = new object();
+
+            // Act
+            var resolvedItem = await resolver.ResolveAsync(item, containingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            Assert.Null(resolvedItem);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_UsesItemsData()
+        {
+            // Arrange
+            var server = TestItemResolverServer.Create();
+            var resolver = new DelegatedCompletionItemResolver(server);
+            var expectedData = new object();
+            var item = new VSInternalCompletionItem()
+            {
+                Data = expectedData,
+            };
+            var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, }, Data = new object() };
+            var originalRequestContext = new DelegatedCompletionResolutionContext(CSharpCompletionParams, new object());
+
+            // Act
+            await resolver.ResolveAsync(item, containingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedData, server.DelegatedParams.CompletionItem.Data);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_InheritsOriginalCompletionListData()
+        {
+            // Arrange
+            var server = TestItemResolverServer.Create();
+            var resolver = new DelegatedCompletionItemResolver(server);
+            var item = new VSInternalCompletionItem();
+            var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, }, Data = new object() };
+            var expectedData = new object();
+            var originalRequestContext = new DelegatedCompletionResolutionContext(CSharpCompletionParams, expectedData);
+
+            // Act
+            await resolver.ResolveAsync(item, containingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedData, server.DelegatedParams.CompletionItem.Data);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_CSharp_Resolves()
+        {
+            // Arrange
+            var expectedResolvedItem = new VSInternalCompletionItem();
+            var server = TestItemResolverServer.Create(expectedResolvedItem);
+            var resolver = new DelegatedCompletionItemResolver(server);
+            var item = new VSInternalCompletionItem();
+            var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, } };
+            var originalRequestContext = new DelegatedCompletionResolutionContext(CSharpCompletionParams, new object());
+
+            // Act
+            var resolvedItem = await resolver.ResolveAsync(item, containingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            Assert.Same(CSharpCompletionParams.HostDocument, server.DelegatedParams.HostDocument);
+            Assert.Equal(RazorLanguageKind.CSharp, server.DelegatedParams.OriginatingKind);
+            Assert.Same(expectedResolvedItem, resolvedItem);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_Html_Resolves()
+        {
+            // Arrange
+            var expectedResolvedItem = new VSInternalCompletionItem();
+            var server = TestItemResolverServer.Create(expectedResolvedItem);
+            var resolver = new DelegatedCompletionItemResolver(server);
+            var item = new VSInternalCompletionItem();
+            var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, } };
+            var originalRequestContext = new DelegatedCompletionResolutionContext(HtmlCompletionParams, new object());
+
+            // Act
+            var resolvedItem = await resolver.ResolveAsync(item, containingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            Assert.Same(HtmlCompletionParams.HostDocument, server.DelegatedParams.HostDocument);
+            Assert.Equal(RazorLanguageKind.Html, server.DelegatedParams.OriginatingKind);
+            Assert.Same(expectedResolvedItem, resolvedItem);
+        }
+
+        internal class TestItemResolverServer : TestOmnisharpLanguageServer
+        {
+            private readonly DelegatedCompletionResolveRequestHandler _requestHandler;
+
+            private TestItemResolverServer(DelegatedCompletionResolveRequestHandler requestHandler) : base(new Dictionary<string, Func<object, object>>()
+            {
+                [LanguageServerConstants.RazorCompletionResolveEndpointName] = requestHandler.OnDelegation,
+            })
+            {
+                _requestHandler = requestHandler;
+            }
+
+            public DelegatedCompletionItemResolveParams DelegatedParams => _requestHandler.DelegatedParams;
+
+            public static TestItemResolverServer Create(VSInternalCompletionItem resolveResponse = null)
+            {
+                resolveResponse ??= new VSInternalCompletionItem();
+                var requestResponseFactory = new DelegatedCompletionResolveRequestHandler(resolveResponse);
+                var provider = new TestItemResolverServer(requestResponseFactory);
+                return provider;
+            }
+
+            private class DelegatedCompletionResolveRequestHandler
+            {
+                private readonly VSInternalCompletionItem _resolveResponse;
+
+                public DelegatedCompletionResolveRequestHandler(VSInternalCompletionItem resolveResponse)
+                {
+                    _resolveResponse = resolveResponse;
+                }
+
+                public DelegatedCompletionItemResolveParams DelegatedParams { get; private set; }
+
+                public object OnDelegation(object parameters)
+                {
+                    DelegatedParams = (DelegatedCompletionItemResolveParams)parameters;
+
+                    return _resolveResponse;
+                }
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
@@ -24,7 +24,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
                 new TestOmnisharpLanguageServer(new Dictionary<string, Func<object, object>>()
                 {
                     [LanguageServerConstants.RazorCompletionEndpointName] = completionFactory.OnDelegation,
-                }))
+                }),
+                new CompletionListCache())
         {
             _completionFactory = completionFactory;
         }


### PR DESCRIPTION
- Added a`DelegatedCompletionItemResolver` that understands how to resolve items producted from the `DelegatedCompletionListProvider`.
- Added a new `DelegatedCompletionResolutionContext` that's cached along side the delegated completion lists. This is what's used by the resolve to properly delegated item resolutions.
- Added tests for new delegated completion item resolution.

### Before

![before gif](https://i.imgur.com/G16Ltnp.gif)

### After

![after gif](https://i.imgur.com/vuqsrBJ.gif)

Fixes #6449