### PR TITLE
Add accessible name to syntax visualizer components

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml
@@ -1,23 +1,23 @@
 ﻿<UserControl x:Class="Microsoft.VisualStudio.RazorExtension.SyntaxVisualizer.SyntaxVisualizerControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Microsoft.VisualStudio.RazorExtension.SyntaxVisualizer"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
-             Loaded="SyntaxVisualizerControl_Loaded" 
+             Loaded="SyntaxVisualizerControl_Loaded"
              GotFocus="SyntaxVisualizerControl_GotFocus"
              LostFocus="SyntaxVisualizerControl_LostFocus"
              Unloaded="SyntaxVisualizerControl_Unloaded">
     <DockPanel>
         <ToolBarTray IsLocked="true" DockPanel.Dock="Top">
-            <ToolBar>
+            <ToolBar AutomationProperties.Name="Config">
                 <ToggleButton x:Name="showSourceMappingsButton" Content="Show C# Transitions" Click="ShowSourceMappingsButton_Click" />
                 <Button x:Name="showGeneratedCode" Content="Show Generated C#" Click="ShowGeneratedCode_Click" />
                 <Button x:Name="showGeneratedHtml" Content="Show Generated Html" Click="ShowGeneratedHtml_Click" />
             </ToolBar>
         </ToolBarTray>
-        <TreeView x:Name="treeView" />
+        <TreeView x:Name="treeView" AutomationProperties.Name="Nodes" />
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6512
Fixes AB#1531304