### PR TITLE
Revert "Enable test" for TypeScript test.

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnTypeFormattingTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnTypeFormattingTests.cs
@@ -11,6 +11,12 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
         [IdeFact]
         public async Task TypeScript_Semicolon()
         {
+            var version = await TestServices.Shell.GetVersionAsync(HangMitigatingCancellationToken);
+            if (version < new System.Version(42, 42, 42, 42))
+            {
+                return;
+            }
+
             // Open the file
             await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
 


### PR DESCRIPTION
This reverts commit b0300dbd51418e522462ac976c4896d8ac7d0ee5.

- Unfortunately looks like this test still fails 😢 /cc @davidwengier 