### PR TITLE
Yet another attempt at fixing RpcContract errors.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Microsoft.VisualStudio.LiveShare.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Microsoft.VisualStudio.LiveShare.Razor.csproj
@@ -23,10 +23,11 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
 
     <!--
-      Microsoft.VisualStudio.LanguageServices brings in a transitive dependency to StreamJsonRpc of 2.7.X and Nerdbank.Streams 2.6.81. We found that in practice this would flakily break our
+      Pinning packages to avoid misaligned reference CI failures.
       CI builds here: https://github.com/dotnet/razor-tooling/issues/4327
-      Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin StreamJsonRpc and Nerdbank.Streams.
+      Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin the following packages to workaround the issue.
     -->
+    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" Version="$(MicrosoftVisualStudioRpcContractsPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcPackageVersion)" />
     <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsPackageVersion)" />


### PR DESCRIPTION
- In the latest binlog failure it was complaining about our LiveShare project. Turns out my last attempt to fix this I actually had locally the LiveShare csproj edited locally but never saved. This makes more sense. Gotta fix em all!