### PR TITLE
Update Razor addin version to 17.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,7 +36,7 @@
   -->
   <PropertyGroup>
     <VsixVersionPrefix>17.0.0</VsixVersionPrefix>
-    <AddinMajorVersion>17.0</AddinMajorVersion>
+    <AddinMajorVersion>17.3</AddinMajorVersion>
     <AddinVersion>$(AddinMajorVersion)</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' != ''">$(AddinVersion).$(OfficialBuildId)</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' == ''">$(AddinVersion).42424242.42</AddinVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -41,8 +41,8 @@
     -->
   </Runtime>
   <Dependencies>
-    <Addin id="::MonoDevelop.Core" version="17.0" />
-    <Addin id="::MonoDevelop.Ide" version="17.0" />
+    <Addin id="::MonoDevelop.Core" version="17.3" />
+    <Addin id="::MonoDevelop.Ide" version="17.3" />
   </Dependencies>
 
   <!-- MEF catalog -->

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
@@ -1,4 +1,4 @@
-<Addin id="RazorAddin" namespace="Microsoft.VisualStudio.Mac" version="17.0" name="Razor Language Services" author="Microsoft" description="Language services for ASP.NET Core Razor" category="Web Development">
+<Addin id="RazorAddin" namespace="Microsoft.VisualStudio.Mac" version="17.3" name="Razor Language Services" author="Microsoft" description="Language services for ASP.NET Core Razor" category="Web Development">
   <Runtime>
     <Import assembly="Microsoft.VisualStudio.Editor.Razor.dll" />
     <Import assembly="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
@@ -41,7 +41,7 @@
     -->
   </Runtime>
   <Dependencies>
-    <Addin id="::MonoDevelop.Core" version="17.0" />
-    <Addin id="::MonoDevelop.Ide" version="17.0" />
+    <Addin id="::MonoDevelop.Core" version="17.3" />
+    <Addin id="::MonoDevelop.Ide" version="17.3" />
   </Dependencies>
 </Addin>


### PR DESCRIPTION
VS Mac 17.3 has breaking API changes which require its app compat
being changed to 17.3.
