### PR TITLE
Update VS Mac addin version to 17.3 in Mono assembly attributes.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -29,11 +29,11 @@
     </AssemblyAttribute>
     <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
       <_Parameter1>::MonoDevelop.Core</_Parameter1>
-      <_Parameter2>17.0</_Parameter2>
+      <_Parameter2>17.3</_Parameter2>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
       <_Parameter1>::MonoDevelop.Ide</_Parameter1>
-      <_Parameter2>17.0</_Parameter2>
+      <_Parameter2>17.3</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 


### PR DESCRIPTION
This is also required to allow VS Mac to change its app compat version
to 17.3

