### PR TITLE
Update rename tests to use C# LSP server

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -134,6 +134,7 @@
     <Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>7.0.0-preview1.22116.1</Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
     <Tooling_MicrosoftCodeAnalysisExternalAccessOmniSharpCSharpPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisExternalAccessOmniSharpCSharpPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
     <Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
     <Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisCSharpPackageVersion>
     <Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>$(RoslynPackageVersion)</Tooling_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPSpanMappingService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPSpanMappingService.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using System.Linq;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 {
@@ -82,13 +83,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var mappedSpanResults = GetMappedSpanResults(_documentSnapshot, sourceTextRazor, mappedResult);
+            var mappedSpanResults = GetMappedSpanResults(_documentSnapshot.Uri.LocalPath, sourceTextRazor, mappedResult);
             return mappedSpanResults;
         }
 
         // Internal for testing
         internal static ImmutableArray<RazorMappedSpanResult> GetMappedSpanResults(
-            LSPDocumentSnapshot documentSnapshot,
+            string localFilePath,
             SourceText sourceTextRazor,
             RazorMapToDocumentRangesResponse mappedResult)
         {
@@ -101,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             foreach (var mappedRange in mappedResult.Ranges)
             {
-                if (Extensions.RangeExtensions.IsUndefined(mappedRange))
+                if (RangeExtensions.IsUndefined(mappedRange))
                 {
                     // Couldn't remap the range correctly. Add default placeholder to indicate to C# that there were issues.
                     results.Add(new RazorMappedSpanResult());
@@ -110,8 +111,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
                 var mappedSpan = mappedRange.AsTextSpan(sourceTextRazor);
                 var linePositionSpan = sourceTextRazor.Lines.GetLinePositionSpan(mappedSpan);
-                var filePath = documentSnapshot.Uri.LocalPath;
-                results.Add(new RazorMappedSpanResult(filePath, linePositionSpan, mappedSpan));
+                results.Add(new RazorMappedSpanResult(localFilePath, linePositionSpan, mappedSpan));
             }
 
             return results.ToImmutable();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -6,8 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -39,7 +41,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
             IEnumerable<CSharpFile> files,
             ExportProvider exportProvider)
         {
-            var workspace = TestWorkspace.Create() as AdhocWorkspace;
+            var hostServices = MefHostServices.Create(exportProvider.AsCompositionContext());
+            var workspace = TestWorkspace.Create(hostServices);
 
             // Add project and solution to workspace
             var projectInfo = ProjectInfo.Create(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Extensions/ExportProviderExtensions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Extensions/ExportProviderExtensions.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition.Hosting.Core;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.VisualStudio.Composition;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.Extensions
+{
+    internal static class ExportProviderExtensions
+    {
+        public static CompositionContext AsCompositionContext(this ExportProvider exportProvider)
+        {
+            return new CompositionContextShim(exportProvider);
+        }
+
+        private class CompositionContextShim : CompositionContext
+        {
+            private readonly ExportProvider _exportProvider;
+
+            public CompositionContextShim(ExportProvider exportProvider)
+            {
+                _exportProvider = exportProvider;
+            }
+
+            public override bool TryGetExport(CompositionContract contract, [NotNullWhen(true)] out object? export)
+            {
+                var importMany = contract.MetadataConstraints.Contains(new KeyValuePair<string, object>("IsImportMany", true));
+                var (contractType, metadataType) = GetContractType(contract.ContractType, importMany);
+
+                if (metadataType != null)
+                {
+                    var methodInfo = (from method in _exportProvider.GetType().GetTypeInfo().GetMethods()
+                                      where method.Name == nameof(ExportProvider.GetExports)
+                                      where method.IsGenericMethod && method.GetGenericArguments().Length == 2
+                                      where method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(string)
+                                      select method).Single();
+                    var parameterizedMethod = methodInfo.MakeGenericMethod(contractType, metadataType);
+                    export = parameterizedMethod.Invoke(_exportProvider, new[] { contract.ContractName });
+                    Assumes.NotNull(export);
+                }
+                else
+                {
+                    var methodInfo = (from method in _exportProvider.GetType().GetTypeInfo().GetMethods()
+                                      where method.Name == nameof(ExportProvider.GetExports)
+                                      where method.IsGenericMethod && method.GetGenericArguments().Length == 1
+                                      where method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(string)
+                                      select method).Single();
+                    var parameterizedMethod = methodInfo.MakeGenericMethod(contractType);
+                    export = parameterizedMethod.Invoke(_exportProvider, new[] { contract.ContractName });
+                    Assumes.NotNull(export);
+                }
+
+                return true;
+            }
+
+            private static (Type exportType, Type? metadataType) GetContractType(Type contractType, bool importMany)
+            {
+                if (importMany && contractType.IsConstructedGenericType)
+                {
+                    if (contractType.GetGenericTypeDefinition() == typeof(IList<>)
+                        || contractType.GetGenericTypeDefinition() == typeof(ICollection<>)
+                        || contractType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    {
+                        contractType = contractType.GenericTypeArguments[0];
+                    }
+                }
+
+                if (contractType.IsConstructedGenericType)
+                {
+                    if (contractType.GetGenericTypeDefinition() == typeof(Lazy<>))
+                    {
+                        return (contractType.GenericTypeArguments[0], null);
+                    }
+                    else if (contractType.GetGenericTypeDefinition() == typeof(Lazy<,>))
+                    {
+                        return (contractType.GenericTypeArguments[0], contractType.GenericTypeArguments[1]);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException();
+                    }
+                }
+
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,8 +12,11 @@ using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
@@ -27,6 +31,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
             LegacyDispatcher = new TestProjectSnapshotManagerDispatcher();
 #pragma warning restore CS0618 // Type or member is obsolete
             FilePathNormalizer = new FilePathNormalizer();
+            SpanMappingService = new ThrowingRazorSpanMappingService();
             var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
             Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>())).Verifiable();
             Mock.Get(logger).Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(false);
@@ -46,6 +51,8 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
         internal readonly ProjectSnapshotManagerDispatcher Dispatcher = new LSPProjectSnapshotManagerDispatcher(TestLoggerFactory.Instance);
 
         internal FilePathNormalizer FilePathNormalizer { get; }
+
+        internal IRazorSpanMappingService SpanMappingService { get; }
 
         protected LspSerializer Serializer { get; }
 
@@ -112,6 +119,14 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
             }
 
             protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class ThrowingRazorSpanMappingService : IRazorSpanMappingService
+        {
+            public Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="$(Tooling_MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="$(Tooling_MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/RoslynTestCompositions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/RoslynTestCompositions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
         public static readonly TestComposition Roslyn = TestComposition.Empty
             .AddAssemblies(MefHostServices.DefaultAssemblies)
             .AddAssemblies(Assembly.LoadFrom("Microsoft.CodeAnalysis.dll"))
+            .AddAssemblies(Assembly.LoadFrom("Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll"))
             .AddAssemblies(Assembly.LoadFrom("Microsoft.CodeAnalysis.EditorFeatures.dll"))
             .AddAssemblies(Assembly.LoadFrom("Microsoft.CodeAnalysis.ExternalAccess.Razor.dll"))
             .AddAssemblies(Assembly.LoadFrom("Microsoft.CodeAnalysis.LanguageServer.Protocol.dll"))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestRazorDocumentServiceProvider.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestRazorDocumentServiceProvider.cs
@@ -4,19 +4,18 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
 {
-    public class TestRazorDocumentServiceProvider : IRazorDocumentServiceProvider
+    internal class TestRazorDocumentServiceProvider : IRazorDocumentServiceProvider
     {
-        public static readonly TestRazorDocumentServiceProvider Instance = new();
+        private readonly IRazorSpanMappingService _razorSpanMappingService;
+
+        public TestRazorDocumentServiceProvider(IRazorSpanMappingService razorSpanMappingService)
+        {
+            _razorSpanMappingService = razorSpanMappingService;
+        }
 
         public bool CanApplyChange => throw new NotImplementedException();
 
@@ -28,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
 
             if (serviceType == typeof(IRazorSpanMappingService))
             {
-                return (TService)(IRazorSpanMappingService)new TestRazorSpanMappingService();
+                return (TService)_razorSpanMappingService;
             }
 
             if (serviceType == typeof(IRazorDocumentPropertiesService))
@@ -37,17 +36,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
             }
 
             return this as TService;
-        }
-
-        private class TestRazorSpanMappingService : IRazorSpanMappingService
-        {
-            public Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(
-                Document document,
-                IEnumerable<TextSpan> spans,
-                CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
         }
 
         private class TestRazorDocumentPropertiesService : IRazorDocumentPropertiesService

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokenTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokenTestBase.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
                 var csharpSourceText = codeDocument.GetCSharpSourceText();
 
                 await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                    csharpSourceText, csharpDocumentUri, SemanticTokensServerCapabilities).ConfigureAwait(false);
+                    csharpSourceText, csharpDocumentUri, SemanticTokensServerCapabilities, SpanMappingService).ConfigureAwait(false);
                 var result = await csharpServer.ExecuteRequestAsync<SemanticTokensRangeParamsBridge, SemanticTokens>(
                     Methods.TextDocumentSemanticTokensRangeName,
                     CreateVSSemanticTokensRangeParams(csharpRange, csharpDocumentUri),

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
@@ -124,18 +124,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 snapshotContent: codeDocument.GetSourceText().ToString(),
                 csharpDocumentSnapshot);
 
-            await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                csharpSourceText, csharpDocumentUri, HoverServerCapabilities).ConfigureAwait(false);
-
-            var requestInvoker = new TestLSPRequestInvoker(csharpServer);
-            var documentManager = new TestDocumentManager();
-            documentManager.AddDocument(documentUri, documentSnapshot);
-
             var uriToCodeDocumentMap = new Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)>
             {
                 { documentUri, (hostDocumentVersion: 1, codeDocument) }
             };
             var mappingProvider = new TestLSPDocumentMappingProvider(uriToCodeDocumentMap);
+            var razorSpanMappingService = new TestRazorLSPSpanMappingService(mappingProvider, documentUri, razorSourceText: codeDocument.GetSourceText(), csharpSourceText);
+
+            await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
+                csharpSourceText, csharpDocumentUri, HoverServerCapabilities, razorSpanMappingService).ConfigureAwait(false);
+
+            var requestInvoker = new TestLSPRequestInvoker(csharpServer);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(documentUri, documentSnapshot);
 
             var hoverHandler = new HoverHandler(requestInvoker, documentManager, TestLSPProjectionProvider.Instance, mappingProvider, LoggerProvider);
             var hoverRequest = new TextDocumentPositionParams()
@@ -268,18 +269,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 snapshotContent: codeDocument.GetSourceText().ToString(),
                 csharpDocumentSnapshot);
 
-            await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                csharpSourceText, csharpDocumentUri, HoverServerCapabilities).ConfigureAwait(false);
-
-            var requestInvoker = new TestLSPRequestInvoker(csharpServer);
-            var documentManager = new TestDocumentManager();
-            documentManager.AddDocument(documentUri, documentSnapshot);
-
             var uriToCodeDocumentMap = new Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)>
             {
                 { documentUri, (hostDocumentVersion: 1, codeDocument) }
             };
             var mappingProvider = new TestLSPDocumentMappingProvider(uriToCodeDocumentMap);
+            var razorSpanMappingService = new TestRazorLSPSpanMappingService(mappingProvider, documentUri, razorSourceText: codeDocument.GetSourceText(), csharpSourceText);
+
+            await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
+                csharpSourceText, csharpDocumentUri, HoverServerCapabilities, razorSpanMappingService).ConfigureAwait(false);
+
+            var requestInvoker = new TestLSPRequestInvoker(csharpServer);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(documentUri, documentSnapshot);
 
             var hoverHandler = new HoverHandler(requestInvoker, documentManager, TestLSPProjectionProvider.Instance, mappingProvider, LoggerProvider);
             var hoverRequest = new TextDocumentPositionParams()
@@ -321,15 +323,16 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 snapshotContent: codeDocument.GetSourceText().ToString(),
                 csharpDocumentSnapshot);
 
+            var uriToVersionAndCodeDocumentMap = new Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)>();
+            var mappingProvider = new TestLSPDocumentMappingProvider(uriToVersionAndCodeDocumentMap);
+            var razorSpanMappingService = new TestRazorLSPSpanMappingService(mappingProvider, documentUri, razorSourceText: codeDocument.GetSourceText(), csharpSourceText);
+
             await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                csharpSourceText, csharpDocumentUri, HoverServerCapabilities).ConfigureAwait(false);
+                csharpSourceText, csharpDocumentUri, HoverServerCapabilities, razorSpanMappingService).ConfigureAwait(false);
 
             var requestInvoker = new TestLSPRequestInvoker(csharpServer);
             var documentManager = new TestDocumentManager();
             documentManager.AddDocument(documentUri, documentSnapshot);
-
-            var uriToVersionAndCodeDocumentMap = new Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)>();
-            var mappingProvider = new TestLSPDocumentMappingProvider(uriToVersionAndCodeDocumentMap);
 
             var hoverHandler = new HoverHandler(requestInvoker, documentManager, TestLSPProjectionProvider.Instance, mappingProvider, LoggerProvider);
             var hoverRequest = new TextDocumentPositionParams()
@@ -377,18 +380,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 snapshotContent: codeDocument.GetSourceText().ToString(),
                 csharpDocumentSnapshot);
 
-            await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                csharpSourceText, csharpDocumentUri, HoverServerCapabilities).ConfigureAwait(false);
-
-            var requestInvoker = new TestLSPRequestInvoker(csharpServer);
-            var documentManager = new TestDocumentManager();
-            documentManager.AddDocument(documentUri, documentSnapshot);
-
             var uriToVersionAndCodeDocumentMap = new Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)>
             {
                 { documentUri, (hostDocumentVersion: 2, codeDocument) }
             };
             var mappingProvider = new TestLSPDocumentMappingProvider(uriToVersionAndCodeDocumentMap);
+            var razorSpanMappingService = new TestRazorLSPSpanMappingService(mappingProvider, documentUri, razorSourceText: codeDocument.GetSourceText(), csharpSourceText);
+
+            await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
+                csharpSourceText, csharpDocumentUri, HoverServerCapabilities, razorSpanMappingService).ConfigureAwait(false);
+
+            var requestInvoker = new TestLSPRequestInvoker(csharpServer);
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(documentUri, documentSnapshot);
 
             var hoverHandler = new HoverHandler(requestInvoker, documentManager, TestLSPProjectionProvider.Instance, mappingProvider, LoggerProvider);
             var hoverRequest = new TextDocumentPositionParams()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/SignatureHelpHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/SignatureHelpHandlerTest.cs
@@ -4,9 +4,11 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -169,8 +171,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 snapshotContent: codeDocument.GetSourceText().ToString(),
                 csharpDocumentSnapshot);
 
+            var uriToCodeDocumentMap = new Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)>
+            {
+                { documentUri, (hostDocumentVersion: 1, codeDocument) }
+            };
+            var mappingProvider = new TestLSPDocumentMappingProvider(uriToCodeDocumentMap);
+            var razorSpanMappingService = new TestRazorLSPSpanMappingService(mappingProvider, documentUri, razorSourceText: codeDocument.GetSourceText(), csharpSourceText);
+
             await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                csharpSourceText, csharpDocumentUri, SignatureHelpServerCapabilities).ConfigureAwait(false);
+                csharpSourceText, csharpDocumentUri, SignatureHelpServerCapabilities, razorSpanMappingService).ConfigureAwait(false);
 
             var requestInvoker = new TestLSPRequestInvoker(csharpServer);
             var documentManager = new TestDocumentManager();
@@ -218,8 +227,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 snapshotContent: codeDocument.GetSourceText().ToString(),
                 csharpDocumentSnapshot);
 
+            var uriToCodeDocumentMap = new Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)>
+            {
+                { documentUri, (hostDocumentVersion: 1, codeDocument) }
+            };
+            var mappingProvider = new TestLSPDocumentMappingProvider(uriToCodeDocumentMap);
+            var razorSpanMappingService = new TestRazorLSPSpanMappingService(mappingProvider, documentUri, razorSourceText: codeDocument.GetSourceText(), csharpSourceText);
+
             await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                csharpSourceText, csharpDocumentUri, SignatureHelpServerCapabilities).ConfigureAwait(false);
+                csharpSourceText, csharpDocumentUri, SignatureHelpServerCapabilities, razorSpanMappingService).ConfigureAwait(false);
 
             var requestInvoker = new TestLSPRequestInvoker(csharpServer);
             var documentManager = new TestDocumentManager();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPSpanMappingServiceTest.cs
@@ -123,13 +123,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public void MapSpans_GetMappedSpanResults_MappingErrorReturnsDefaultMappedSpan()
         {
             // Arrange
-            var documentSnapshot = new Mock<LSPDocumentSnapshot>(MockBehavior.Strict);
-            documentSnapshot.SetupGet(doc => doc.Uri).Returns(_mockDocumentUri);
             var sourceTextRazor = SourceText.From("");
             var response = new RazorMapToDocumentRangesResponse { Ranges = new Range[] { Extensions.RangeExtensions.UndefinedRange } };
 
             // Act
-            var results = RazorLSPSpanMappingService.GetMappedSpanResults(documentSnapshot.Object, sourceTextRazor, response);
+            var results = RazorLSPSpanMappingService.GetMappedSpanResults(_mockDocumentUri.LocalPath, sourceTextRazor, response);
 
             // Assert
             Assert.True(results.Single().IsDefault);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPRequestInvoker.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPRequestInvoker.cs
@@ -111,6 +111,18 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             TIn parameters,
             CancellationToken cancellationToken)
         {
+            /*if (method is LanguageServerConstants.RazorMapToDocumentEditsEndpoint)
+            {
+                var mappingParams = new RazorMapToDocumentEditsParams
+                {
+                    
+                };
+
+                var razorLanguageEndpoint = new RazorLanguageEndpoint(
+                    documentContextFactory, new TestLSPDocumentMappingProvider(), razorFormattingService: null, TestLoggerFactory.Instance);
+                var response = await razorLanguageEndpoint.Handle(request, cancellationToken).ConfigureAwait(false);
+            }*/
+
             throw new NotImplementedException();
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPRequestInvoker.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPRequestInvoker.cs
@@ -111,18 +111,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             TIn parameters,
             CancellationToken cancellationToken)
         {
-            /*if (method is LanguageServerConstants.RazorMapToDocumentEditsEndpoint)
-            {
-                var mappingParams = new RazorMapToDocumentEditsParams
-                {
-                    
-                };
-
-                var razorLanguageEndpoint = new RazorLanguageEndpoint(
-                    documentContextFactory, new TestLSPDocumentMappingProvider(), razorFormattingService: null, TestLoggerFactory.Instance);
-                var response = await razorLanguageEndpoint.Handle(request, cancellationToken).ConfigureAwait(false);
-            }*/
-
             throw new NotImplementedException();
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestRazorLSPSpanMappingService.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestRazorLSPSpanMappingService.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
+{
+    internal class TestRazorLSPSpanMappingService : IRazorSpanMappingService
+    {
+        private readonly LSPDocumentMappingProvider _mappingProvider;
+        private readonly Uri _razorUri;
+        private readonly SourceText _razorSourceText;
+        private readonly SourceText _csharpSourceText;
+
+        public TestRazorLSPSpanMappingService(LSPDocumentMappingProvider mappingProvider, Uri razorUri, SourceText razorSourceText, SourceText csharpSourceText)
+        {
+            _mappingProvider = mappingProvider;
+            _razorUri = razorUri;
+            _razorSourceText = razorSourceText;
+            _csharpSourceText = csharpSourceText;
+        }
+
+        public async Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
+        {
+            var projectedRanges = spans.Select(span => span.AsRange(_csharpSourceText)).ToArray();
+            var mappedResult = await _mappingProvider.MapToDocumentRangesAsync(
+                RazorLanguageKind.CSharp, _razorUri, projectedRanges, CancellationToken.None).ConfigureAwait(false);
+
+            var mappedSpanResults = RazorLSPSpanMappingService.GetMappedSpanResults(_razorUri.LocalPath, _razorSourceText, mappedResult);
+            return mappedSpanResults;
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes
- Un-mocks all but one rename test to use the C# LSP server. The one remaining mocked test is testing the HTML language server.
- Rename tests were a bit more complicated to move over since we had to update the test workspace to take in the correct HostServices. This is because `IEditorInlineRenameService` (which Roslyn rename utilizes) lives in the Roslyn EditorFeatures layer and is not a default workspace language service.

Part of https://github.com/dotnet/razor-tooling/issues/6263
