### PR TITLE
fix issue with indentation of code/markup following directive blocks ...

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                         // Couldn't find the exact value. Find the index of the element to the left of the searched value.
                         index = (~index) - 1;
 
-                        // If that index comes from within a section directive that does not contain the line we are working with,
+                        // If that index comes from within a directive that does not contain the line we are working with,
                         // we don't want to use its desired C# indentation. In the following example, we would not want the indentation
                         // that applies to line 2 to also be applied to line 4:
                         //
@@ -193,7 +193,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                         {
                             var absoluteIndex = sourceMappingIndentationScopes[index];
                             var scopeOwner = syntaxTreeRoot.LocateOwner(new SourceChange(absoluteIndex, 0, string.Empty));
-                            if (scopeOwner.Parent.Parent?.Parent is not RazorDirectiveSyntax containingDirective || lineStart < containingDirective.EndPosition)
+                            var containingDirective = scopeOwner.FirstAncestorOrSelf<RazorDirectiveSyntax>();
+                            if (containingDirective is null || lineStart + 1 < containingDirective.EndPosition)
                             {
                                 break;
                             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -391,6 +391,40 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         }
 
         [Fact]
+        public async Task Format_SectionDirectiveBlock5()
+        {
+            await RunFormattingTestAsync(
+                input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
+
+                    @section Scripts {
+                    <script></script>
+                    }
+
+                    <p></p>
+                    """,
+                expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
+
+                    @section Scripts {
+                        <script></script>
+                    }
+
+                    <p></p>
+                    """,
+                fileKind: FileKinds.Legacy);
+        }
+
+        [Fact]
         public async Task Formats_CodeBlockDirectiveWithRazorComments()
         {
             await RunFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -401,6 +401,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                         }
                     }
 
+                    @section Foo {
+                        @{ var test = 1; }
+                    }
+
+                    <p></p>
+
                     @section Scripts {
                     <script></script>
                     }
@@ -414,6 +420,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                             void Method() { }
                         }
                     }
+
+                    @section Foo {
+                        @{
+                            var test = 1;
+                        }
+                    }
+
+                    <p></p>
 
                     @section Scripts {
                         <script></script>


### PR DESCRIPTION
… related to #4358

### Summary of the changes

added a test that demonstrates the problem scenario:
```
@section Foo {
    <p></p>
}
<p></p>
@section Bar {
    @{
        var test = 1;
    }
}
<p></p>
```
gets incorrectly formatted like
```
@section Foo {
    <p></p>
}
    <p></p>
    @section Bar {
    @{
        var test = 1;
    }
    }
    <p></p>
```

- added a block of code that fixes the problem
- removed a previously added block of code that only partially resolved the issue
