### PR TITLE
Import metadata references to C# test workspace

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -5,12 +5,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -31,7 +33,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
             };
 
             var exportProvider = RoslynTestCompositions.Roslyn.ExportProviderFactory.CreateExportProvider();
-            var workspace = CreateCSharpTestWorkspace(files, exportProvider, razorSpanMappingService);
+            var metadataReferences = await ReferenceAssemblies.Default.ResolveAsync(language: "CSharp", CancellationToken.None).ConfigureAwait(false);
+            var workspace = CreateCSharpTestWorkspace(files, exportProvider, metadataReferences, razorSpanMappingService);
             var clientCapabilities = new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true };
 
             var testLspServer = await CSharpTestLspServer.CreateAsync(
@@ -42,6 +45,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
         private static AdhocWorkspace CreateCSharpTestWorkspace(
             IEnumerable<CSharpFile> files,
             ExportProvider exportProvider,
+            ImmutableArray<MetadataReference> metadataReferences,
             IRazorSpanMappingService razorSpanMappingService)
         {
             var hostServices = MefHostServices.Create(exportProvider.AsCompositionContext());
@@ -54,7 +58,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
                 name: "TestProject",
                 assemblyName: "TestProject",
                 language: LanguageNames.CSharp,
-                filePath: "C:\\TestSolution\\TestProject.csproj");
+                filePath: "C:\\TestSolution\\TestProject.csproj",
+                metadataReferences: metadataReferences);
 
             var solutionInfo = SolutionInfo.Create(
                 id: SolutionId.CreateNewId("TestSolution"),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
             };
 
             var exportProvider = RoslynTestCompositions.Roslyn.ExportProviderFactory.CreateExportProvider();
-            var metadataReferences = await ReferenceAssemblies.Default.ResolveAsync(language: "CSharp", CancellationToken.None).ConfigureAwait(false);
+            var metadataReferences = await ReferenceAssemblies.Default.ResolveAsync(language: LanguageNames.CSharp, CancellationToken.None).ConfigureAwait(false);
             var workspace = CreateCSharpTestWorkspace(files, exportProvider, metadataReferences, razorSpanMappingService);
             var clientCapabilities = new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true };
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -28,15 +28,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_RazorIfNotReady()
         {
-            var documentText = @"<p></p>@{
-    var d = ""t"";
-}
-";
+            var documentText =
+                """
+                <p></p>@{
+                    var d = "t";
+                }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 3, Character = 0 }
+                End = new Position { Line = 2, Character = 1 }
             };
 
             var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: 1);
@@ -46,16 +48,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharpBlock_HTML()
         {
-            var documentText = @"@{
-    var d = ""t"";
-    <p>HTML @d</p>
-}
-";
+            var documentText =
+                """
+                @{
+                    var d = "t";
+                    <p>HTML @d</p>
+                }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 4, Character = 0 }
+                End = new Position { Line = 3, Character = 1 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -65,14 +69,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_Nested_HTML()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<!--@{var d = ""string"";@<a></a>}-->
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <!--@{var d = "string";@<a></a>}-->
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 37 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -82,14 +88,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_VSCodeWorks()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-@{ var d = }
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                @{ var d = }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 12 }
             };
 
             var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: null);
@@ -99,14 +107,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_Explicit()
         {
-            var documentText = @$"@addTagHelper *, TestAssembly
-@(DateTime.Now)
-";
+            var documentText =
+                """
+                @using System
+                @addTagHelper *, TestAssembly
+                @(DateTime.Now)
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 2, Character = 15 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -116,15 +127,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_Implicit()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-@{ var d = ""txt"";}
-@d
-";
+            var documentText = 
+                """
+                @addTagHelper *, TestAssembly
+                @{ var d = "txt";}
+                @d
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 3, Character = 0 }
+                End = new Position { Line = 2, Character = 2 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -134,14 +147,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_VersionMismatch()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-@{ var d = }
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                @{ var d = }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 12 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -151,14 +166,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_FunctionAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-@{ var d = }
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                @{ var d = }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 12 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -168,16 +185,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_CSharp_StaticModifier()
         {
-            var documentText = @"@code
-{
-    static int x = 1;
-}
-";
+            var documentText =
+                """
+                @code
+                {
+                    static int x = 1;
+                }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 4, Character = 0 }
+                End = new Position { Line = 3, Character = 1 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -189,16 +208,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
         [Fact]
         public async Task GetSemanticTokens_MultipleBlankLines()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
 
-<p>first
-second</p>
-";
+                <p>first
+                second</p>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 4, Character = 0 }
+                End = new Position { Line = 3, Character = 10 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -208,13 +229,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_IncompleteTag()
         {
-            var documentText = @"<str class='
-";
+            var documentText =
+                """
+                <str class='
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 0 }
+                End = new Position { Line = 0, Character = 12 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -224,13 +247,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_MinimizedHTMLAttribute()
         {
-            var documentText = @"<p attr />
-";
+            var documentText =
+                """
+                <p attr />
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 0 }
+                End = new Position { Line = 0, Character = 10 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -240,14 +265,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_MinimizedHTMLAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<input/>
-";
+            var documentText = """
+                @addTagHelper *, TestAssembly
+                <input/>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 8 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -257,14 +283,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_HTMLCommentAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<!-- comment with comma's -->
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <!-- comment with comma's -->
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 29 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -274,14 +302,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_PartialHTMLCommentAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<!-- comment
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <!-- comment
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 12 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -291,14 +321,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_HTMLIncludesBang()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<!input/>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <!input/>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 9 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -310,14 +342,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_HalfOfCommentAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-@* comment
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                @* comment
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 10 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -327,14 +361,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_NoAttributesAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<test1></test1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <test1></test1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 15 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -344,14 +380,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_WithAttributeAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<test1 bool-val='true'></test1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <test1 bool-val='true'></test1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 31 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -361,14 +399,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_MinimizedAttribute_BoundAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<test1 bool-val></test1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <test1 bool-val></test1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 24 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -378,14 +418,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_MinimizedAttribute_NotBoundAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<test1 notbound></test1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <test1 notbound></test1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 24 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -395,14 +437,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_IgnoresNonTagHelperAttributesAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<test1 bool-val='true' class='display:none'></test1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <test1 bool-val='true' class='display:none'></test1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 52 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -412,14 +456,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_TagHelpersNotAvailableInRazorAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<test1 bool-val='true' class='display:none'></test1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <test1 bool-val='true' class='display:none'></test1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 52 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -429,14 +475,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_DoesNotApplyOnNonTagHelpersAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<p bool-val='true'></p>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <p bool-val='true'></p>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 23 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -449,14 +497,16 @@ second</p>
         public async Task GetSemanticTokens_Razor_MinimizedDirectiveAttributeParameters()
         {
             // Capitalized, non-well-known-HTML elements should not be marked as TagHelpers
-            var documentText = @"@addTagHelper *, TestAssembly
-}<NotATagHelp @minimized:something />
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                }<NotATagHelp @minimized:something />
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 37 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -466,14 +516,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_ComponentAttributeAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<Component1 bool-val=""true""></Component1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <Component1 bool-val=""true""></Component1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 43 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -483,14 +535,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_DirectiveAttributesParametersAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<Component1 @test:something='Function'></Component1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <Component1 @test:something='Function'></Component1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 52 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -500,14 +554,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_NonComponentsDoNotShowInRazorAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<test1 bool-val='true'></test1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <test1 bool-val='true'></test1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 31 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -517,14 +573,16 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_DirectivesAsync()
         {
-            var documentText = @"@addTagHelper *, TestAssembly
-<Component1 @test='Function'></Component1>
-";
+            var documentText =
+                """
+                @addTagHelper *, TestAssembly
+                <Component1 @test='Function'></Component1>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 42 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -534,13 +592,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_HandleTransitionEscape()
         {
-            var documentText = @"@@text
-";
+            var documentText =
+                """
+                @@text
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 0 }
+                End = new Position { Line = 0, Character = 6 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -550,14 +610,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_DoNotColorNonTagHelpersAsync()
         {
-            var documentText = @"
-<p @test='Function'></p>
-";
+            var documentText =
+                """
+                <p @test='Function'></p>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 0, Character = 24 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -567,14 +628,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_DoesNotApplyOnNonTagHelpersAsync()
         {
-            var documentText = @"@addTagHelpers *, TestAssembly
-<p></p>
-";
+            var documentText = """
+                @addTagHelpers *, TestAssembly
+                <p></p>
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 7 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -586,13 +648,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_CodeDirectiveAsync()
         {
-            var documentText = @"@code {}
-";
+            var documentText =
+                """
+                @code {}
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 0 }
+                End = new Position { Line = 0, Character = 8 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -602,18 +666,20 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_CodeDirectiveBodyAsync()
         {
-            var documentText = @"@code {
-    public void SomeMethod()
-    {
-@DateTime.Now
-    }
-}
-";
+            var documentText = """
+                @using System
+                @code {
+                    public void SomeMethod()
+                    {
+                        @DateTime.Now
+                    }
+                }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 6, Character = 0 }
+                End = new Position { Line = 6, Character = 1 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -623,13 +689,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_UsingDirective()
         {
-            var documentText = @"@using Microsoft.AspNetCore.Razor
-";
+            var documentText =
+                """
+                @using System.Threading
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 0 }
+                End = new Position { Line = 0, Character = 23 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -639,13 +707,15 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_FunctionsDirectiveAsync()
         {
-            var documentText = @"@functions {}
-";
+            var documentText =
+                """
+                @functions {}
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 0 }
+                End = new Position { Line = 0, Character = 13 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -655,26 +725,29 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_NestedTextDirectives()
         {
-            var documentText = @"@functions {
-                private void BidsByShipment(string generatedId, int bids)
-                {
-                    if (bids > 0)
+            var documentText =
+                """
+                @using System
+                @functions {
+                    private void BidsByShipment(string generatedId, int bids)
                     {
-                        <a class=""Thing"">
-                            @if(bids > 0)
-                            {
-                                <text>@DateTime.Now</text>
-                            }
-                        </a>
+                        if (bids > 0)
+                        {
+                            <a class=""Thing"">
+                                @if(bids > 0)
+                                {
+                                    <text>@DateTime.Now</text>
+                                }
+                            </a>
+                        }
                     }
                 }
-            }
-";
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 14, Character = 0 }
+                End = new Position { Line = 14, Character = 1 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -684,15 +757,18 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_NestedTransitions()
         {
-            var documentText = @"@functions {
-                Action<object> abc = @<span></span>;
-            }
-";
+            var documentText =
+                """
+                @using System
+                @functions {
+                    Action<object> abc = @<span></span>;
+                }
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 3, Character = 0 }
+                End = new Position { Line = 3, Character = 1 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -703,13 +779,14 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_CommentAsync()
         {
-            var documentText = @"@* A comment *@
-";
+            var documentText = """
+                @* A comment *@
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 0 }
+                End = new Position { Line = 0, Character = 15 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
@@ -719,15 +796,17 @@ second</p>
         [Fact]
         public async Task GetSemanticTokens_Razor_MultiLineCommentMidlineAsync()
         {
-            var documentText = @"<a />@* kdl
-   skd
-slf*@
-";
+            var documentText =
+                """
+                <a />@* kdl
+                skd
+                slf*@
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 2, Character = 5 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
@@ -737,14 +816,16 @@ slf*@
         [Fact]
         public async Task GetSemanticTokens_Razor_MultiLineCommentAsync()
         {
-            var documentText = @$"@*stuff
-things *@
-";
+            var documentText =
+                """
+                @*stuff
+                things *@
+                """;
 
             var razorRange = new Range
             {
                 Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 0 }
+                End = new Position { Line = 1, Character = 9 }
             };
 
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -35,12 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 1 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: 1);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 1);
         }
@@ -56,12 +51,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 3, Character = 1 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -75,12 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <!--@{var d = "string";@<a></a>}-->
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 37 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -94,12 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @{ var d = }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 12 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: null);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 1);
         }
@@ -114,12 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @(DateTime.Now)
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 15 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -134,12 +109,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @d
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 2 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -153,12 +123,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @{ var d = }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 12 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 21);
         }
@@ -172,12 +137,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @{ var d = }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 12 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -193,12 +153,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 3, Character = 1 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -216,12 +171,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 second</p>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 3, Character = 10 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -234,12 +184,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <str class='
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 12 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -252,12 +197,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <p attr />
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 10 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -270,12 +210,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <input/>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 8 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -289,12 +224,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <!-- comment with comma's -->
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 29 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -308,12 +238,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <!-- comment
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 12 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -327,12 +252,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <!input/>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 9 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -348,12 +268,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @* comment
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 10 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -367,12 +282,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <test1></test1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 15 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -386,12 +296,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <test1 bool-val='true'></test1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 31 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -405,12 +310,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <test1 bool-val></test1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 24 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -424,12 +324,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <test1 notbound></test1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 24 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -443,12 +338,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <test1 bool-val='true' class='display:none'></test1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 52 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -462,12 +352,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <test1 bool-val='true' class='display:none'></test1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 52 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -481,12 +366,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <p bool-val='true'></p>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 23 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -503,12 +383,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 }<NotATagHelp @minimized:something />
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 37 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -522,12 +397,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <Component1 bool-val=""true""></Component1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 43 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -541,12 +411,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <Component1 @test:something='Function'></Component1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 52 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -560,12 +425,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <test1 bool-val='true'></test1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 31 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -579,12 +439,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <Component1 @test='Function'></Component1>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 42 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -597,12 +452,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @@text
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 6 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -615,12 +465,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <p @test='Function'></p>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 24 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -633,12 +478,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 <p></p>
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 7 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -653,12 +493,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @code {}
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 8 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -676,12 +511,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 6, Character = 1 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -694,12 +524,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @using System.Threading
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 23 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -712,12 +537,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @functions {}
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 13 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -744,12 +564,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 14, Character = 1 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -765,12 +580,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 }
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 3, Character = 1 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -783,12 +593,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 @* A comment *@
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 0, Character = 15 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: true);
             await AssertSemanticTokensAsync(documentText, isRazorFile: true, razorRange, csharpTokens: csharpTokens);
         }
@@ -803,12 +608,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 slf*@
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 2, Character = 5 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -822,12 +622,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 things *@
                 """;
 
-            var razorRange = new Range
-            {
-                Start = new Position { Line = 0, Character = 0 },
-                End = new Position { Line = 1, Character = 9 }
-            };
-
+            var razorRange = GetRange(documentText);
             var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
             await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
         }
@@ -909,6 +704,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
                 documentMappingService,
                 documentContextFactory,
                 loggingFactory);
+        }
+
+        private static Range GetRange(string text)
+        {
+            var lines = text.Split(Environment.NewLine);
+            var lastLineIndex = lines.Length - 1;
+            var lastLineCharacterIndex = lines[lastLineIndex].Length;
+
+            var range = new Range
+            {
+                Start = new Position { Line = 0, Character = 0 },
+                End = new Position { Line = lastLineIndex, Character = lastLineCharacterIndex }
+            };
+
+            return range;
         }
 
         private class TestDocumentContextFactory : DocumentContextFactory

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_CSharp_Explicit.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_CSharp_Explicit.semantic.txt
@@ -1,9 +1,12 @@
 //line,characterPos,length,tokenType,modifier
 0 0 1 razorTransition 0
+0 1 5 keyword 0
+0 6 6 namespace name 0
+1 0 1 razorTransition 0
 0 1 12 razorDirective 0
 1 0 1 razorTransition 0
 0 1 1 razorTransition 0
-0 1 8 variable 0
+0 1 8 struct name 0
 0 8 1 operator 0
-0 1 3 variable 0
+0 1 3 property name 1
 0 3 1 razorTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_CodeDirectiveBodyAsync.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_CodeDirectiveBodyAsync.semantic.txt
@@ -1,5 +1,8 @@
 //line,characterPos,length,tokenType,modifier
 0 0 1 razorTransition 0
+0 1 5 keyword 0
+0 6 6 namespace name 0
+1 0 1 razorTransition 0
 0 1 4 razorDirective 0
 0 5 1 razorTransition 0
 1 4 6 keyword 0
@@ -8,9 +11,9 @@
 0 10 1 punctuation 0
 0 1 1 punctuation 0
 1 4 1 punctuation 0
-1 0 1 razorTransition 0
-0 1 8 variable 0
+1 8 1 razorTransition 0
+0 1 8 struct name 0
 0 8 1 operator 0
-0 1 3 variable 0
+0 1 3 property name 1
 1 4 1 punctuation 0
 1 0 1 razorTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_ComponentAttributeAsync.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_ComponentAttributeAsync.semantic.txt
@@ -1,14 +1,15 @@
 //line,characterPos,length,tokenType,modifier
 0 0 1 razorTransition 0
 0 1 12 razorDirective 0
+0 13 15 string 0
 1 0 1 markupTagDelimiter 0
 0 1 10 razorComponentElement 0
 0 11 8 RazorComponentAttribute 0
 0 8 1 markupOperator 0
 0 1 1 markupAttributeQuote 0
-0 1 4 keyword 0
-0 4 1 markupAttributeQuote 0
-0 1 1 markupTagDelimiter 0
+0 1 1 markupAttributeQuote 0
+0 1 6 markupAttribute 0
+0 6 1 markupTagDelimiter 0
 0 1 1 markupTagDelimiter 0
 0 1 1 markupTagDelimiter 0
 0 1 10 razorComponentElement 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_DoNotColorNonTagHelpersAsync.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_DoNotColorNonTagHelpersAsync.semantic.txt
@@ -1,5 +1,5 @@
 //line,characterPos,length,tokenType,modifier
-1 0 1 markupTagDelimiter 0
+0 0 1 markupTagDelimiter 0
 0 1 1 markupElement 0
 0 2 1 razorTransition 0
 0 1 4 razorDirectiveAttribute 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_MultiLineCommentMidlineAsync.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_MultiLineCommentMidlineAsync.semantic.txt
@@ -6,7 +6,7 @@
 0 1 1 razorCommentTransition 0
 0 1 1 razorCommentStar 0
 0 1 4 razorComment 0
-1 0 6 razorComment 0
+1 0 3 razorComment 0
 1 0 3 razorComment 0
 0 3 1 razorCommentStar 0
 0 1 1 razorCommentTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTextDirectives.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTextDirectives.semantic.txt
@@ -1,8 +1,12 @@
 //line,characterPos,length,tokenType,modifier
 0 0 1 razorTransition 0
+0 1 5 keyword 0
+0 6 6 namespace name 0
+0 6 1 punctuation 0
+1 0 1 razorTransition 0
 0 1 9 razorDirective 0
 0 10 1 razorTransition 0
-1 16 7 keyword 0
+1 4 7 keyword 0
 0 8 4 keyword 0
 0 5 14 method name 0
 0 14 1 punctuation 0
@@ -12,41 +16,41 @@
 0 2 3 keyword 0
 0 4 4 parameter name 0
 0 4 1 punctuation 0
-1 16 1 punctuation 0
-1 20 2 keyword - control 0
+1 4 1 punctuation 0
+1 8 2 keyword - control 0
 0 3 1 punctuation 0
 0 1 4 parameter name 0
 0 5 1 operator 0
 0 2 1 number 0
 0 1 1 punctuation 0
-1 20 1 punctuation 0
-1 24 1 markupTagDelimiter 0
+1 8 1 punctuation 0
+1 12 1 markupTagDelimiter 0
 0 1 1 markupElement 0
 0 2 5 markupAttribute 0
 0 5 1 markupOperator 0
 0 1 1 markupAttributeQuote 0
-0 1 5 markupAttributeQuote 0
-0 5 1 markupAttributeQuote 0
-0 1 1 markupTagDelimiter 0
-1 28 1 razorTransition 0
+0 1 1 markupAttributeQuote 0
+0 1 7 markupAttribute 0
+0 7 1 markupTagDelimiter 0
+1 16 1 razorTransition 0
 0 1 2 keyword - control 0
 0 2 1 punctuation 0
 0 1 4 parameter name 0
 0 5 1 operator 0
 0 2 1 number 0
 0 1 1 punctuation 0
-1 28 1 punctuation 0
-1 32 6 razorDirective 0
+1 16 1 punctuation 0
+1 20 6 razorDirective 0
 0 6 1 razorTransition 0
-0 1 8 variable 0
+0 1 8 struct name 0
 0 8 1 operator 0
-0 1 3 variable 0
+0 1 3 property name 1
 0 3 7 razorDirective 0
-1 28 1 punctuation 0
-1 24 1 markupTagDelimiter 0
+1 16 1 punctuation 0
+1 12 1 markupTagDelimiter 0
 0 1 1 markupTagDelimiter 0
 0 1 1 markupElement 0
 0 1 1 markupTagDelimiter 0
-1 20 1 punctuation 0
-1 16 1 punctuation 0
-1 12 1 razorTransition 0
+1 8 1 punctuation 0
+1 4 1 punctuation 0
+1 0 1 razorTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTextDirectives.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTextDirectives.semantic.txt
@@ -2,7 +2,6 @@
 0 0 1 razorTransition 0
 0 1 5 keyword 0
 0 6 6 namespace name 0
-0 6 1 punctuation 0
 1 0 1 razorTransition 0
 0 1 9 razorDirective 0
 0 10 1 razorTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTransitions.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTransitions.semantic.txt
@@ -1,8 +1,12 @@
 //line,characterPos,length,tokenType,modifier
 0 0 1 razorTransition 0
+0 1 5 keyword 0
+0 6 6 namespace name 0
+0 6 1 punctuation 0
+1 0 1 razorTransition 0
 0 1 9 razorDirective 0
 0 10 1 razorTransition 0
-1 16 6 variable 0
+1 4 6 delegate name 0
 0 6 1 punctuation 0
 0 1 6 keyword 0
 0 6 1 punctuation 0
@@ -17,4 +21,4 @@
 0 1 4 markupElement 0
 0 4 1 markupTagDelimiter 0
 0 1 1 punctuation 0
-1 12 1 razorTransition 0
+1 0 1 razorTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTransitions.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_NestedTransitions.semantic.txt
@@ -2,7 +2,6 @@
 0 0 1 razorTransition 0
 0 1 5 keyword 0
 0 6 6 namespace name 0
-0 6 1 punctuation 0
 1 0 1 razorTransition 0
 0 1 9 razorDirective 0
 0 10 1 razorTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_UsingDirective.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_UsingDirective.semantic.txt
@@ -1,8 +1,6 @@
 //line,characterPos,length,tokenType,modifier
 0 0 1 razorTransition 0
 0 1 5 keyword 0
-0 6 9 variable 0
-0 9 1 operator 0
-0 1 10 variable 0
-0 10 1 operator 0
-0 1 5 variable 0
+0 6 6 namespace name 0
+0 6 1 operator 0
+0 1 9 namespace name 0

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -148,8 +149,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.Equal(2, result.Length);
-            Assert.Equal(firstExpectedRange, result[0].Range);
-            Assert.Equal(secondExpectedRange, result[1].Range);
+
+            var actualRanges = result.Select(r => r.Range);
+            Assert.Contains(firstExpectedRange, actualRanges);
+            Assert.Contains(secondExpectedRange, actualRanges);
         }
 
         [Fact]


### PR DESCRIPTION
### Summary of the changes
- Previously, we weren't passing in any metadata references when creating our C# test workspace. That meant our workspace wouldn't have any of the default dlls, e.g. `System`.
- Now that we're properly passing in the metadata references, some of the existing semantic token test outputs had to be updated.
- While updating the semantic tokens tests, I went ahead and converted all the tests to use raw string literals. I also added a helper method to calculate the range so we don't need to do it manually every time. 

Part of https://github.com/dotnet/razor-tooling/issues/6263