### PR TITLE
Update completion resolve tests to use C# LSP server

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFormattingOptionsProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultFormattingOptionsProvider.cs
@@ -12,25 +12,16 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
     [Export(typeof(FormattingOptionsProvider))]
     internal class DefaultFormattingOptionsProvider : FormattingOptionsProvider
     {
-        private readonly LSPDocumentManager _documentManager;
         private readonly IIndentationManagerService _indentationManagerService;
 
         [ImportingConstructor]
-        public DefaultFormattingOptionsProvider(
-            LSPDocumentManager documentManager,
-            IIndentationManagerService indentationManagerService)
+        public DefaultFormattingOptionsProvider(IIndentationManagerService indentationManagerService)
         {
-            if (documentManager is null)
-            {
-                throw new ArgumentNullException(nameof(documentManager));
-            }
-
             if (indentationManagerService is null)
             {
                 throw new ArgumentNullException(nameof(indentationManagerService));
             }
 
-            _documentManager = documentManager;
             _indentationManagerService = indentationManagerService;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // This is a special contract between the Visual Studio LSP platform and language servers where if insert text and text edit's are not present
             // then the "resolve" endpoint is guaranteed to run prior to a completion item's content being comitted. This gives language servers the
             // opportunity to lazily evaluate text edits which in turn we need to remap. Given text edits generated through this mechanism tend to be
-            // more exntensive we do a full remapping gesture which includes formatting of said text-edits.
+            // more extensive we do a full remapping gesture which includes formatting of said text-edits.
             var shouldRemapTextEdits = preResolveCompletionItem.InsertText is null && preResolveCompletionItem.TextEdit is null;
             if (!shouldRemapTextEdits)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/HTMLCSharpLanguageServerLogHubLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/HTMLCSharpLanguageServerLogHubLoggerProvider.cs
@@ -17,6 +17,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
         private const string LogFileIdentifier = "Razor.HTMLCSharpLanguageServerClient";
 
         private LogHubLoggerProvider? _loggerProvider;
+        private readonly HTMLCSharpLanguageServerLogHubLoggerProviderFactory _loggerFactory;
+        private readonly SemaphoreSlim _initializationSemaphore;
 
         // Internal for testing / do not remove, used by Moq to construct
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -38,9 +40,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
             }
         }
 
-        private readonly HTMLCSharpLanguageServerLogHubLoggerProviderFactory _loggerFactory;
-        private readonly SemaphoreSlim _initializationSemaphore;
-
         [ImportingConstructor]
         public HTMLCSharpLanguageServerLogHubLoggerProvider(HTMLCSharpLanguageServerLogHubLoggerProviderFactory loggerFactory)
         {
@@ -50,7 +49,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging
             }
 
             _loggerFactory = loggerFactory;
-
             _initializationSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -44,9 +44,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
                 {
                     Completion = new VSInternalCompletionSetting
                     {
-                        CompletionListSetting = new CompletionListSetting
+                        CompletionListSetting = new()
                         {
                             ItemDefaults = new string[] { EditRangeSetting }
+                        },
+                        CompletionItem = new()
+                        {
+                            SnippetSupport = true
                         }
                     }
                 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultFormattingOptionsProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test/DefaultFormattingOptionsProviderTest.cs
@@ -16,10 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         public void GetOptions_UsesIndentationManagerInformation()
         {
             // Arrange
-            var documentManager = new TestDocumentManager();
             var documentUri = new Uri("C:/path/to/razorfile.razor");
             var documentSnapshot = new TestLSPDocumentSnapshot(documentUri, version: 0);
-            documentManager.AddDocument(documentSnapshot.Uri, documentSnapshot);
             var expectedInsertSpaces = true;
             var expectedTabSize = 1337;
             var unneededIndentSize = 123;
@@ -27,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             indentationManagerService
                 .Setup(service => service.GetIndentation(documentSnapshot.Snapshot.TextBuffer, false, out expectedInsertSpaces, out expectedTabSize, out unneededIndentSize))
                 .Verifiable();
-            var provider = new DefaultFormattingOptionsProvider(documentManager, indentationManagerService.Object);
+            var provider = new DefaultFormattingOptionsProvider(indentationManagerService.Object);
 
             // Act
             var options = provider.GetOptions(documentSnapshot);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Editor.Razor.Debugging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Moq;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Editor.Razor.Debugging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Moq;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -22,7 +22,6 @@ using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Xunit;
 using CompletionContext = Microsoft.VisualStudio.LanguageServer.Protocol.CompletionContext;
@@ -44,12 +43,9 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 #pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
 
             TextStructureNavigatorSelectorService = new TestTextStructureNavigatorSelectorService();
-
             Uri = new Uri("C:/path/to/file.razor");
-
             CompletionRequestContextCache = new CompletionRequestContextCache();
             FormattingOptionsProvider = TestFormattingOptionsProvider.Default;
-
             TextBuffer = new TestTextBuffer(new StringTextSnapshot(string.Empty));
             CSharpVirtualDocumentSnapshot = new CSharpVirtualDocumentSnapshot(new Uri("C:/path/to/file.razor.g.cs"), TextBuffer.CurrentSnapshot, 0);
             HtmlVirtualDocumentSnapshot = new HtmlVirtualDocumentSnapshot(new Uri("C:/path/to/file.razor__virtual.html"), TextBuffer.CurrentSnapshot, 0);
@@ -1328,31 +1324,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             }
 
             public override FormattingOptions GetOptions(LSPDocumentSnapshot documentSnapshot) => _options;
-        }
-
-        private class TestTextStructureNavigatorSelectorService : ITextStructureNavigatorSelectorService
-        {
-            private static readonly ITextStructureNavigator s_textStructureNavigator = new TestTextStructureNavigator();
-
-            public ITextStructureNavigator CreateTextStructureNavigator(ITextBuffer textBuffer, IContentType contentType) => s_textStructureNavigator;
-
-            public ITextStructureNavigator GetTextStructureNavigator(ITextBuffer textBuffer) => s_textStructureNavigator;
-        }
-
-        private class TestTextStructureNavigator : ITextStructureNavigator
-        {
-            public IContentType ContentType => throw new NotImplementedException();
-
-            public TextExtent GetExtentOfWord(SnapshotPoint currentPosition)
-                => new(new SnapshotSpan(new StringTextSnapshot("@{ }"), new Span(0, 0)), isSignificant: false);
-
-            public SnapshotSpan GetSpanOfEnclosing(SnapshotSpan activeSpan) => throw new NotImplementedException();
-
-            public SnapshotSpan GetSpanOfFirstChild(SnapshotSpan activeSpan) => throw new NotImplementedException();
-
-            public SnapshotSpan GetSpanOfNextSibling(SnapshotSpan activeSpan) => throw new NotImplementedException();
-
-            public SnapshotSpan GetSpanOfPreviousSibling(SnapshotSpan activeSpan) => throw new NotImplementedException();
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDiagnosticsTranslatorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDiagnosticsTranslatorTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Xunit;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DefaultLSPDocumentMappingProviderTest.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Newtonsoft.Json.Linq;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Arrange
             var requestInvoker = new TestLSPRequestInvoker();
             var projectionProvider = TestLSPProjectionProvider.Instance;
-            var documentMappingProvider = new TestLSPDocumentMappingProvider(new Dictionary<Uri, (int, RazorCodeDocument)>());
+            var documentMappingProvider = new TestLSPDocumentMappingProvider();
             var highlightHandler = new DocumentHighlightHandler(requestInvoker, new TestDocumentManager(), projectionProvider, documentMappingProvider, LoggerProvider);
             var highlightRequest = new DocumentHighlightParams()
             {
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Arrange
             var requestInvoker = new TestLSPRequestInvoker();
             var projectionProvider = TestLSPProjectionProvider.Instance;
-            var documentMappingProvider = new TestLSPDocumentMappingProvider(new Dictionary<Uri, (int, RazorCodeDocument)>());
+            var documentMappingProvider = new TestLSPDocumentMappingProvider();
             var highlightHandler = new DocumentHighlightHandler(requestInvoker, DocumentManager, projectionProvider, documentMappingProvider, LoggerProvider);
             var highlightRequest = new DocumentHighlightParams()
             {
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 snapshotContent: razorSourceText.ToString(),
                 csharpDocumentSnapshot);
 
-            var mappingProvider = new TestLSPDocumentMappingProvider(new Dictionary<Uri, (int, RazorCodeDocument)>());
+            var mappingProvider = new TestLSPDocumentMappingProvider();
             var razorSpanMappingService = new TestRazorLSPSpanMappingService(mappingProvider, documentUri, razorSourceText, csharpSourceText);
 
             await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentPullDiagnosticsHandlerTest.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Moq;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/FindAllReferencesHandlerTest.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Threading;
 using Moq;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToDefinitionHandlerTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToImplementationHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/GoToImplementationHandlerTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HandlerTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HandlerTestBase.cs
@@ -4,31 +4,16 @@
 #nullable disable
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
-using Moq;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     public abstract class HandlerTestBase
     {
-        public HandlerTestBase()
-        {
-            var logger = TestLogger.Instance;
-            LoggerProvider = Mock.Of<HTMLCSharpLanguageServerLogHubLoggerProvider>(l =>
-                l.CreateLogger(It.IsAny<string>()) == logger &&
-                l.InitializeLoggerAsync(It.IsAny<CancellationToken>()) == Task.CompletedTask &&
-                l.CreateLoggerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()) == Task.FromResult<ILogger>(logger),
-                MockBehavior.Strict);
-        }
-
-        internal HTMLCSharpLanguageServerLogHubLoggerProvider LoggerProvider { get; }
+        internal TestLoggerProvider LoggerProvider { get; } = new();
 
         internal static RazorCodeDocument CreateCodeDocument(
             string text,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentManager = new TestDocumentManager();
             var requestInvoker = new TestLSPRequestInvoker();
             var projectionProvider = TestLSPProjectionProvider.Instance;
-            var documentMappingProvider = new TestLSPDocumentMappingProvider(new Dictionary<Uri, (int, RazorCodeDocument)>());
+            var documentMappingProvider = new TestLSPDocumentMappingProvider();
             var hoverHandler = new HoverHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider, LoggerProvider);
             var hoverRequest = new TextDocumentPositionParams()
             {
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Arrange
             var requestInvoker = new TestLSPRequestInvoker();
             var projectionProvider = TestLSPProjectionProvider.Instance;
-            var documentMappingProvider = new TestLSPDocumentMappingProvider(new Dictionary<Uri, (int, RazorCodeDocument)>());
+            var documentMappingProvider = new TestLSPDocumentMappingProvider();
             var hoverHandler = new HoverHandler(requestInvoker, DocumentManager, projectionProvider, documentMappingProvider, LoggerProvider);
             var hoverRequest = new TextDocumentPositionParams()
             {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/RenameHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/RenameHandlerTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var documentManager = new TestDocumentManager();
             var requestInvoker = new TestLSPRequestInvoker();
             var projectionProvider = TestLSPProjectionProvider.Instance;
-            var documentMappingProvider = new TestLSPDocumentMappingProvider(new Dictionary<Uri, (int, RazorCodeDocument)>());
+            var documentMappingProvider = new TestLSPDocumentMappingProvider();
             var renameHandler = new RenameHandler(requestInvoker, documentManager, projectionProvider, documentMappingProvider, LoggerProvider);
             var renameRequest = new RenameParams()
             {
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             // Arrange
             var requestInvoker = new TestLSPRequestInvoker();
             var projectionProvider = TestLSPProjectionProvider.Instance;
-            var documentMappingProvider = new TestLSPDocumentMappingProvider(new Dictionary<Uri, (int, RazorCodeDocument)>());
+            var documentMappingProvider = new TestLSPDocumentMappingProvider();
             var renameHandler = new RenameHandler(requestInvoker, DocumentManager, projectionProvider, documentMappingProvider, LoggerProvider);
             var renameRequest = new RenameParams()
             {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/IsExternalInit.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/IsExternalInit.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace System.Runtime.CompilerServices
+{
+    // Used to compile against C# 9 in a net472 app.
+    internal class IsExternalInit
+    {
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\Microsoft.AspNetCore.Razor.LanguageServer.Common\Extensions\RazorCodeDocumentExtensions.cs" LinkBase="Shared" />
+    <Compile Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common\IsExternalInit.cs" Link="IsExternalInit.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\Microsoft.AspNetCore.Razor.LanguageServer.Common\Extensions\RazorCodeDocumentExtensions.cs" LinkBase="Shared" />
-    <Compile Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Test.Common\IsExternalInit.cs" Link="IsExternalInit.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorHtmlPublishDiagnosticsInterceptorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorHtmlPublishDiagnosticsInterceptorTest.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Test;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using Newtonsoft.Json.Linq;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
@@ -8,11 +8,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common.Extensions;
 using Microsoft.VisualStudio.Text;
 
-namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
 {
     internal class TestDocumentManager : TrackingLSPDocumentManager
     {
@@ -53,12 +53,12 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
                 return;
             }
 
-            if (!documentSnapshot.TryGetVirtualDocument<VirtualDocumentSnapshot>(out var virtualDocumentSnapshot))
+            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var virtualDocumentSnapshot))
             {
                 return;
             }
 
-            using var virtualDocument = new TestVirtualDocument(virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer);
+            using var virtualDocument = new CSharpVirtualDocument(virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer);
             virtualDocument.Update(changes, hostDocumentVersion, state);
             _documents[hostDocumentUri] = new TestLSPDocumentSnapshot(hostDocumentUri, documentSnapshot.Version, new[] { virtualDocument.CurrentSnapshot });
 
@@ -76,10 +76,10 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
             var rangesAndTexts = changes.Select(c =>
             {
                 virtualSourceText.GetLinesAndOffsets(c.OldSpan, out var startLine, out var startCharacter, out var endLine, out var endCharacter);
-                var range = new Protocol.Range
+                var range = new LanguageServer.Protocol.Range
                 {
-                    Start = new Protocol.Position { Line = startLine, Character = startCharacter },
-                    End = new Protocol.Position { Line = endLine, Character = endCharacter }
+                    Start = new LanguageServer.Protocol.Position { Line = startLine, Character = startCharacter },
+                    End = new LanguageServer.Protocol.Position { Line = endLine, Character = endCharacter }
                 };
 
                 return (range, c.NewText);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentMappingProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentMappingProvider.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
     {
         private readonly Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)> _uriToVersionAndCodeDocumentMap;
         private readonly DefaultRazorDocumentMappingService _documentMappingService;
-        private readonly Dictionary<TextEdit, TextEdit> _mappings = new();
 
         public TestLSPDocumentMappingProvider()
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentMappingProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLSPDocumentMappingProvider.cs
@@ -21,6 +21,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
     {
         private readonly Dictionary<Uri, (int hostDocumentVersion, RazorCodeDocument codeDocument)> _uriToVersionAndCodeDocumentMap;
         private readonly DefaultRazorDocumentMappingService _documentMappingService;
+        private readonly Dictionary<TextEdit, TextEdit> _mappings = new();
+
+        public TestLSPDocumentMappingProvider()
+        {
+            _uriToVersionAndCodeDocumentMap = new();
+            _documentMappingService = new DefaultRazorDocumentMappingService(TestLoggerFactory.Instance);
+        }
+
+        public int TextEditRemapCount { get; set; } = 0;
 
         public TestLSPDocumentMappingProvider(Dictionary<Uri, (int, RazorCodeDocument)> uriToVersionAndCodeDocumentMap)
         {
@@ -77,9 +86,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
             return Task.FromResult<RazorMapToDocumentRangesResponse?>(response);
         }
 
-        public override Task<TextEdit[]> RemapFormattedTextEditsAsync(Uri uri, TextEdit[] edits, FormattingOptions options, bool containsSnippet, CancellationToken cancellationToken)
+        public override Task<TextEdit[]> RemapFormattedTextEditsAsync(
+            Uri uri,
+            TextEdit[] edits,
+            FormattingOptions options,
+            bool containsSnippet,
+            CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            TextEditRemapCount++;
+            return Task.FromResult(edits);
         }
 
         public override Task<Location[]> RemapLocationsAsync(Location[] locations, CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLoggerProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLoggerProvider.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
+{
+    internal class TestLoggerProvider : HTMLCSharpLanguageServerLogHubLoggerProvider
+    {
+        public override ILogger CreateLogger(string categoryName) => TestLogger.Instance;
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLoggerProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestLoggerProvider.cs
@@ -1,13 +1,27 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
 {
     internal class TestLoggerProvider : HTMLCSharpLanguageServerLogHubLoggerProvider
     {
+        public TestLoggerProvider() : base(new HTMLCSharpLanguageServerLogHubLoggerProviderFactory(new TestRazorLogHubTraceProvider()))
+        {
+        }
+
         public override ILogger CreateLogger(string categoryName) => TestLogger.Instance;
+
+        private class TestRazorLogHubTraceProvider : RazorLogHubTraceProvider
+        {
+            public override Task<TraceSource?> InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken)
+                => Task.FromResult<TraceSource?>(new TraceSource("test"));
+        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestTextStructureNavigatorSelectorService.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestTextStructureNavigatorSelectorService.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
+{
+    internal class TestTextStructureNavigatorSelectorService : ITextStructureNavigatorSelectorService
+    {
+        private static readonly ITextStructureNavigator s_textStructureNavigator = new TestTextStructureNavigator();
+
+        public ITextStructureNavigator CreateTextStructureNavigator(ITextBuffer textBuffer, IContentType contentType) => s_textStructureNavigator;
+
+        public ITextStructureNavigator GetTextStructureNavigator(ITextBuffer textBuffer) => s_textStructureNavigator;
+
+        private class TestTextStructureNavigator : ITextStructureNavigator
+        {
+            public IContentType ContentType => throw new NotImplementedException();
+
+            public TextExtent GetExtentOfWord(SnapshotPoint currentPosition)
+                => new(new SnapshotSpan(new StringTextSnapshot("@{ }"), new Span(0, 0)), isSignificant: false);
+
+            public SnapshotSpan GetSpanOfEnclosing(SnapshotSpan activeSpan) => throw new NotImplementedException();
+
+            public SnapshotSpan GetSpanOfFirstChild(SnapshotSpan activeSpan) => throw new NotImplementedException();
+
+            public SnapshotSpan GetSpanOfNextSibling(SnapshotSpan activeSpan) => throw new NotImplementedException();
+
+            public SnapshotSpan GetSpanOfPreviousSibling(SnapshotSpan activeSpan) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes
- Moves the C# completion resolve tests from using Moq infrastructure to calling into a C# LSP test server
- Some of the tests were no longer relevant (each explained below), so those were removed. The C# server utilizes a cache on their side for completion items so we're only able to test realistic scenarios.

Part of https://github.com/dotnet/razor-tooling/issues/6263