### PR TITLE
Don't bother fixing formatting edits if there aren't any

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -82,6 +82,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
                 _logger.LogTestOnly("After normalizedEdits:\r\n{changedText}", changedText);
             }
+            else if (context.IsFormatOnType)
+            {
+                // There are no HTML edits for us to apply. No op.
+                return new FormattingResult(htmlEdits);
+            }
 
             var indentationChanges = AdjustRazorIndentation(changedContext);
             if (indentationChanges.Count > 0)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveOnTypeFormattingTest.cs
@@ -841,5 +841,37 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     """,
                 triggerCharacter: '}');
         }
+
+        [Fact]
+        public async Task CloseCurly_UnrelatedEdit_DoesNothing()
+        {
+            await RunOnTypeFormattingTestAsync(
+                input: """
+                    <div>}$$</div>
+
+                    @{
+                    	void Test()
+                    	{
+                    		<span>
+                    			Test
+                    		</span>
+                    	}
+                    }
+                    """,
+                expected: """
+                    <div>}</div>
+                    
+                    @{
+                    	void Test()
+                    	{
+                    		<span>
+                    			Test
+                    		</span>
+                    	}
+                    }
+                    """,
+                triggerCharacter: '}',
+                insertSpaces: false);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6565

I missed this [bit of logic](https://github.com/dotnet/razor-tooling/blob/main/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs#L88-L92) from C# on type formatting when I implemented HTML on type formatting. If the HTML formatter doesn't want to format anything, then we shouldn't try to fix up the edits.