### PR TITLE
Use auto-indenting word wrap

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             var wordWrapStyle = WordWrapStyles.None;
             if (Convert.ToBoolean(langPrefs3[0].fWordWrap))
             {
-                wordWrapStyle |= WordWrapStyles.WordWrap;
+                wordWrapStyle |= WordWrapStyles.WordWrap | WordWrapStyles.AutoIndent;
                 if (Convert.ToBoolean(langPrefs3[0].fWordWrapGlyphs))
                 {
                     wordWrapStyle |= WordWrapStyles.VisibleGlyphs;


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6564

I was intrigued...

Before:
<img width="262" alt="image" src="https://user-images.githubusercontent.com/754264/178188586-0bcf0340-cfad-4fa2-aa18-9ef5129f9e67.png">

After:
<img width="168" alt="image" src="https://user-images.githubusercontent.com/754264/178188478-b5345c70-cadd-4782-9151-c70e2a7572dd.png">
