### PR TITLE
Update restore-internal-tools.yml path 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,7 +173,7 @@ stages:
             command: custom
             arguments: 'locals all -clear'
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - template: /eng/common/restore-internal-tools.yml
+          - template: /eng/restore-internal-tools.yml
 
         - powershell: ./eng/scripts/InstallProcDump.ps1
           displayName: Install ProcDump

--- a/eng/restore-internal-tools.yml
+++ b/eng/restore-internal-tools.yml
@@ -1,0 +1,15 @@
+steps:
+  - task: NuGetAuthenticate@0
+    inputs:
+      nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling'
+      forceReinstallCredentialProvider: true
+
+  - script: $(Build.SourcesDirectory)\build.cmd
+            -ci
+            -restore
+            -projects $(Build.SourcesDirectory)/eng/common/internal/Tools.csproj
+            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/RestoreInternal.binlog
+            /v:normal
+    displayName: Restore internal tools
+    condition: and(succeeded(), ne(variables['_skipRestoreInternalTools'], 'true'))
+


### PR DESCRIPTION
### Summary of the changes

-
restore-internal-tools.yml should not be under eng/common it should be under eng folder, as eng/common folder gets overwritten everytime the repo gets an arcade update

Fixes:
