### PR TITLE
Don't spin up 2 threads for every text edit

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ReferenceOutputCapturingContainer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ReferenceOutputCapturingContainer.cs
@@ -26,11 +26,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             var generatedOutputTask = document.State.GetGeneratedOutputAndVersionAsync(document.ProjectInternal, document);
-            var (codeDocument, inputVersion, outputCSharpVersion, outputHtmlVersion) = await generatedOutputTask;
+            var (codeDocument, inputVersion, _, _) = await generatedOutputTask;
 
             lock (_outputTaskLock)
             {
-                if (TrySetOutput(document, codeDocument, inputVersion, outputCSharpVersion, outputHtmlVersion))
+                if (TrySetOutput(document, codeDocument, inputVersion))
                 {
                     _outputTask = generatedOutputTask;
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -532,9 +532,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     defaultDocument.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(
                         defaultDocument,
                         codeDocument,
-                        inputVersion,
-                        outputCSharpVersion,
-                        outputHtmlVersion);
+                        inputVersion);
                 }
 
                 return (codeDocument, inputVersion, outputCSharpVersion, outputHtmlVersion);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/GeneratedDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/GeneratedDocumentContainer.cs
@@ -16,12 +16,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public event EventHandler<TextChangeEventArgs> GeneratedCSharpChanged;
         public event EventHandler<TextChangeEventArgs> GeneratedHtmlChanged;
 
-        private SourceText _source;
         private VersionStamp? _inputVersion;
-        private VersionStamp? _outputCSharpVersion;
-        private VersionStamp? _outputHtmlVersion;
-        private RazorCSharpDocument _outputCSharp;
-        private RazorHtmlDocument _outputHtml;
         private DocumentSnapshot _latestDocument;
 
         private readonly object _setOutputLock = new object();
@@ -35,72 +30,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             _htmlTextContainer = new TextContainer(_setOutputLock);
             _htmlTextContainer.TextChanged += HtmlTextContainer_TextChanged;
-        }
-
-        public SourceText Source
-        {
-            get
-            {
-                lock (_setOutputLock)
-                {
-                    return _source;
-                }
-            }
-        }
-
-        public VersionStamp InputVersion
-        {
-            get
-            {
-                lock (_setOutputLock)
-                {
-                    return _inputVersion.Value;
-                }
-            }
-        }
-
-        public VersionStamp OutputCSharpVersion
-        {
-            get
-            {
-                lock (_setOutputLock)
-                {
-                    return _outputCSharpVersion.Value;
-                }
-            }
-        }
-
-        public VersionStamp OutputHtmlVersion
-        {
-            get
-            {
-                lock (_setOutputLock)
-                {
-                    return _outputHtmlVersion.Value;
-                }
-            }
-        }
-
-        public RazorCSharpDocument OutputCSharp
-        {
-            get
-            {
-                lock (_setOutputLock)
-                {
-                    return _outputCSharp;
-                }
-            }
-        }
-
-        public RazorHtmlDocument OutputHtml
-        {
-            get
-            {
-                lock (_setOutputLock)
-                {
-                    return _outputHtml;
-                }
-            }
         }
 
         public DocumentSnapshot LatestDocument
@@ -139,9 +68,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public bool TrySetOutput(
             DefaultDocumentSnapshot document,
             RazorCodeDocument codeDocument,
-            VersionStamp inputVersion,
-            VersionStamp outputCSharpVersion,
-            VersionStamp outputHtmlVersion)
+            VersionStamp inputVersion)
         {
             lock (_setOutputLock)
             {
@@ -159,12 +86,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     return false;
                 }
 
-                _source = source;
                 _inputVersion = inputVersion;
-                _outputCSharpVersion = outputCSharpVersion;
-                _outputHtmlVersion = outputHtmlVersion;
-                _outputCSharp = codeDocument.GetCSharpDocument();
-                _outputHtml = codeDocument.GetHtmlDocument();
                 _latestDocument = document;
                 var csharpSourceText = codeDocument.GetCSharpSourceText();
                 _csharpTextContainer.SetText(csharpSourceText);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultHostDocumentFactoryTest.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor;
 using Moq;
 using Xunit;
 
@@ -18,7 +19,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 LegacyDispatcher,
                 Mock.Of<DocumentVersionCache>(MockBehavior.Strict),
                 Mock.Of<GeneratedDocumentPublisher>(MockBehavior.Strict));
-            Factory = new DefaultHostDocumentFactory(store);
+            var errorReporter = Mock.Of<ErrorReporter>(MockBehavior.Strict);
+            Factory = new DefaultHostDocumentFactory(store, errorReporter);
         }
 
         private DefaultHostDocumentFactory Factory { get; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/UnsynchronizableContentDocumentProcessedListenerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/UnsynchronizableContentDocumentProcessedListenerTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var codeDocument = CreateCodeDocument(csharpDocument, htmlDocument);
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(document, codeDocument, documentVersion.GetNewerVersion(), VersionStamp.Default, VersionStamp.Default);
+            document.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(document, codeDocument, documentVersion.GetNewerVersion());
 
             var listener = new UnsynchronizableContentDocumentProcessedListener(LegacyDispatcher, cache, generatedDocumentPublisher.Object);
             listener.Initialize(ProjectSnapshotManager);
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var codeDocument = CreateCodeDocument(csharpDocument, htmlDocument);
 
             // Force the state to already be up-to-date
-            oldDocument.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(lastDocument, codeDocument, lastVersion, VersionStamp.Default, VersionStamp.Default);
+            oldDocument.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(lastDocument, codeDocument, lastVersion);
 
             var listener = new UnsynchronizableContentDocumentProcessedListener(LegacyDispatcher, cache, generatedDocumentPublisher.Object);
             listener.Initialize(ProjectSnapshotManager);
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var codeDocument = CreateCodeDocument(csharpDocument, htmlDocument);
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(lastDocument, codeDocument, lastVersion, VersionStamp.Default, VersionStamp.Default);
+            document.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(lastDocument, codeDocument, lastVersion);
 
             var listener = new UnsynchronizableContentDocumentProcessedListener(LegacyDispatcher, cache, generatedDocumentPublisher.Object);
             listener.Initialize(ProjectSnapshotManager);
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var codeDocument = CreateCodeDocument(csharpDocument, htmlDocument);
 
             // Force the state to already be up-to-date
-            document.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(lastDocument, codeDocument, lastVersion, VersionStamp.Default, VersionStamp.Default);
+            document.State.HostDocument.GeneratedDocumentContainer.TrySetOutput(lastDocument, codeDocument, lastVersion);
 
             var listener = new UnsynchronizableContentDocumentProcessedListener(LegacyDispatcher, cache, generatedDocumentPublisher.Object);
             listener.Initialize(ProjectSnapshotManager);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -125,12 +125,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await LegacyDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
-            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputHtml);
-            Assert.Same(SourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
+            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.CSharpSourceTextContainer.CurrentText);
+            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.HtmlSourceTextContainer.CurrentText);
         }
 
-        // This is a sanity test that we invoke component codegen for components. It's a little fragile but
+        // This is a sanity test that we invoke component codegen for components.It's a little fragile but
         // necessary.
 
         [Fact]
@@ -140,9 +139,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await ComponentCshtmlDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(ComponentCshtmlHostDocument.GeneratedDocumentContainer.OutputCSharp);
-            Assert.Contains("using Microsoft.AspNetCore.Components", ComponentCshtmlHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode, StringComparison.Ordinal);
+            Assert.Contains("using Microsoft.AspNetCore.Components", ComponentCshtmlHostDocument.GeneratedDocumentContainer.CSharpSourceTextContainer.CurrentText.ToString(), StringComparison.Ordinal);
         }
+
         [Fact]
         public async Task GetGeneratedOutputAsync_Component()
         {
@@ -150,8 +149,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await ComponentDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(ComponentHostDocument.GeneratedDocumentContainer.OutputCSharp);
-            Assert.Contains("ComponentBase", ComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode, StringComparison.Ordinal);
+            Assert.Contains("ComponentBase", ComponentHostDocument.GeneratedDocumentContainer.CSharpSourceTextContainer.CurrentText.ToString(), StringComparison.Ordinal);
         }
 
         [Fact]
@@ -161,10 +159,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await NestedComponentDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp);
-            Assert.Contains("ComponentBase", NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode, StringComparison.Ordinal);
-            Assert.Contains("namespace SomeProject.Nested", NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode, StringComparison.Ordinal);
-            Assert.Contains("class File3", NestedComponentHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode, StringComparison.Ordinal);
+            Assert.Contains("ComponentBase", NestedComponentHostDocument.GeneratedDocumentContainer.CSharpSourceTextContainer.CurrentText.ToString(), StringComparison.Ordinal);
+            Assert.Contains("namespace SomeProject.Nested", NestedComponentHostDocument.GeneratedDocumentContainer.CSharpSourceTextContainer.CurrentText.ToString(), StringComparison.Ordinal);
+            Assert.Contains("class File3", NestedComponentHostDocument.GeneratedDocumentContainer.CSharpSourceTextContainer.CurrentText.ToString(), StringComparison.Ordinal);
         }
 
         // This is a sanity test that we invoke legacy codegen for .cshtml files. It's a little fragile but
@@ -176,8 +173,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await LegacyDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
-            Assert.Contains("Template", LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp.GeneratedCode, StringComparison.Ordinal);
+            Assert.Contains("Template", LegacyHostDocument.GeneratedDocumentContainer.CSharpSourceTextContainer.CurrentText.ToString(), StringComparison.Ordinal);
         }
 
         [Fact]
@@ -195,9 +191,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await newDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
-            Assert.Same(newSourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
-            Assert.Equal("NEW!", LegacyHostDocument.GeneratedDocumentContainer.OutputHtml.GeneratedHtml);
+            Assert.Equal("NEW!", LegacyHostDocument.GeneratedDocumentContainer.HtmlSourceTextContainer.CurrentText.ToString());
         }
 
         [Fact]
@@ -215,9 +209,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await LegacyDocument.GetGeneratedOutputAsync();
 
             // Assert
-            Assert.NotNull(LegacyHostDocument.GeneratedDocumentContainer.OutputCSharp);
-            Assert.Same(newSourceText, LegacyHostDocument.GeneratedDocumentContainer.Source);
-            Assert.Equal("NEW!", LegacyHostDocument.GeneratedDocumentContainer.OutputHtml.GeneratedHtml);
+            Assert.Equal("NEW!", LegacyHostDocument.GeneratedDocumentContainer.HtmlSourceTextContainer.CurrentText.ToString());
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentContainerTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentContainerTest.cs
@@ -39,10 +39,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             var version = VersionStamp.Create();
             var container = new GeneratedDocumentContainer();
-            var initialResult = container.TrySetOutput(document, codeDocument, version, version, version);
+            var initialResult = container.TrySetOutput(document, codeDocument, version);
 
             // Act
-            var result = container.TrySetOutput(newDocument, codeDocument, version, version, version);
+            var result = container.TrySetOutput(newDocument, codeDocument, version);
 
             // Assert
             Assert.Same(newDocument, container.LatestDocument);
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var container = new GeneratedDocumentContainer();
 
             // Act
-            var result = container.TrySetOutput(document, codeDocument, version, version, version);
+            var result = container.TrySetOutput(document, codeDocument, version);
 
             // Assert
             Assert.NotNull(container.LatestDocument);
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             container.GeneratedHtmlChanged += (o, a) => htmlChanged = true;
 
             // Act
-            var result = container.TrySetOutput(document, codeDocument, version, version, version);
+            var result = container.TrySetOutput(document, codeDocument, version);
 
             // Assert
             Assert.NotNull(container.LatestDocument);


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6349
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1533733

Reviewing each commit individually would be the best strategy. I'm not 100% sure there isn't some invisible horrible side effect from the second commit either, but I _think_ its okay.

Potentially this could go further, and remove this whole system, because it's not clear to me what its actually doing. I was very surprised there was so much info that was unused, and what is left seems to be pretty self referencial. eg, the `LatestDocument` property is basically only used in `DefaultGeneratedDocumentContainerStore`, which uses it in `Create`, which is only used from its own `Get` method, which is only used in the factory to get the container to store the document in, which means its about to overwrite the `LatestDocument` 🤷‍♂️

Figured I'd at least PR this as a start, in case someone sees something obvious I'm missing. If nothing else this should fix the issue at hand, because it isn't spinning up a bunch of tasks any more, and its not doing two per keypress, and in fact its not doing anything for fast key pressing at all.