### PR TITLE
Fixed explicit completions invocation for tag helper attributes

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -124,7 +124,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     // When we are in the middle of writing an attribute it is treated as a minimilized one, e.g.:
                     // <form asp$$ - 'asp' is parsed as MarkupMinimizedTagHelperAttributeSyntax (tag helper)
                     // <SurveyPromt Tit$$ - 'Tit' is parsed as MarkupMinimizedTagHelperAttributeSyntax as well (razor component)
-                    if (attributeSyntax is MarkupMinimizedTagHelperAttributeSyntax)
+                    // Need to check for MarkupMinimizedAttributeBlockSyntax in order to handle cases when html tag becomes a tag helper only with certain attributes
+                    if (attributeSyntax is MarkupMinimizedTagHelperAttributeSyntax or MarkupMinimizedAttributeBlockSyntax)
                     {
                         return attributeSyntax.Span.End == absoluteIndex;
                     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -71,10 +71,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
             {
                 if ((containingTagNameToken.FullWidth > 1 || containingTagNameToken.Content == "-") &&
-                    containingTagNameToken.Span.Start != context.AbsoluteIndex)
+                    containingTagNameToken.Span.Start != context.AbsoluteIndex &&
+                    containingTagNameToken.Span.End != context.AbsoluteIndex)
                 {
                     // To align with HTML completion behavior we only want to provide completion items if we're trying to resolve completion at the
-                    // beginning of an HTML element name.
+                    // beginning/ending of an HTML element name.
                     return Array.Empty<RazorCompletionItem>();
                 }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -141,7 +141,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public void GetCompletionAt_AtHtmlElementNameEdge_ReturnsNoCompletions()
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/6134")]
+        public void GetCompletionAt_AtHtmlElementNameEdge_ReturnsCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -151,11 +152,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Empty(completions);
+            // Both "test1" and "test2" technically should not be here, but in real-world scenarios they will be filtered by the IDE
+            AssertTest1Test2Completions(completions);
         }
 
         [Fact]
-        public void GetCompletionAt_AtTagHelperElementNameEdge_ReturnsNoCompletions()
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/6134")]
+        public void GetCompletionAt_AtTagHelperElementNameEdge_ReturnsCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -165,7 +168,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Empty(completions);
+            // "test2" technically should not be here, but in real-world scenarios it will be filtered by the IDE
+            AssertTest1Test2Completions(completions);
         }
 
         [Fact]
@@ -539,6 +543,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     Assert.Equal("int-val", completion.InsertText);
                     Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                }
+            );
+        }
+
+        private static void AssertTest1Test2Completions(IReadOnlyList<RazorCompletionItem> completions)
+        {
+            Assert.Collection(completions,
+                completion =>
+                {
+                    Assert.Equal("test1", completion.InsertText);
+                },
+                completion =>
+                {
+                    Assert.Equal("test2", completion.InsertText);
                 }
             );
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/razor-tooling/issues/6134

![0CKs4U5Oky](https://user-images.githubusercontent.com/70431552/178514536-e68e86ca-0972-495a-be71-2e801af0c443.png)

![i68dCeHhPH](https://user-images.githubusercontent.com/70431552/178535777-6d9efce4-379e-4997-b7c5-2c4470434984.png)