### PR TITLE
Set default value for single sever completion to "true"

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -45,6 +45,6 @@
 
 [$RootKey$\FeatureFlags\Razor\LSP\SingleServerCompletion]
 "Description"="Enable single server completion when editing Razor (ASP.NET Core)."
-"Value"=dword:00000000
+"Value"=dword:00000001
 "Title"="Enable enhanced Razor completion (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"


### PR DESCRIPTION
- We're flighting "true" to all internal users in 17.3 builds; however, for 17.4 we're going to be on-by-default so we have an entire release to catch and address issues. If this ends up being a problem we can remotely  turn it off OR we can physically swap the switch.

Fixes #6421