### PR TITLE
Fix Debug.Assert when delegated completions aren't C# or HTML.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
@@ -57,6 +56,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
             var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
             var projection = GetProjection(absoluteIndex, codeDocument, sourceText);
+
+            if (projection.LanguageKind == RazorLanguageKind.Razor)
+            {
+                // Nothing to delegate to.
+                return null;
+            }
+
             var provisionalCompletion = TryGetProvisionalCompletionInfo(completionContext, projection, codeDocument, sourceText);
             TextEdit? provisionalTextEdit = null;
             if (provisionalCompletion is not null)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -145,6 +145,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         }
 
         [Fact]
+        public async Task RazorDelegation_Noop()
+        {
+            // Arrange
+            var completionContext = new VSInternalCompletionContext() { TriggerKind = CompletionTriggerKind.Invoked };
+            var codeDocument = CreateCodeDocument("@functions ");
+            var documentContext = TestDocumentContext.From("C:/path/to/file.razor", codeDocument, hostDocumentVersion: 1337);
+
+            // Act
+            var completionList = await Provider.GetCompletionListAsync(absoluteIndex: 11, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+            Assert.Null(completionList);
+            var delegatedParameters = Provider.DelegatedParams;
+            Assert.Null(delegatedParameters);
+        }
+
+        [Fact]
         public async Task CSharpDelegation_TriggerCharacterAt_TranslatesToInvoked()
         {
             // Arrange


### PR DESCRIPTION
- When typing out directives like `@functions` the cursor would sit at the end of the identifier which would resolve the language as "Razor" resulting in a `Debug.Assert` failure in our middle layer [here](https://github.com/dotnet/razor-tooling/blob/6cc43d82033d2154b1dfe75f4729dcc7654287d3/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs#L1024). This ensures we actively no-op when we're in non-C#/HTML scenarios at completion time.
- Added a test  to validate

Fixes #6590