### PR TITLE
Fix formatting tests that test markup after directive body.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Extensions;

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await EnsureExtensionInstalledAsync(ControlledHangMitigatingCancellationToken);
             EnsureMEFCompositionSuccessForRazor();
 
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, expectedClassification: RazorComponentElementClassification, count: 3);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
 
             // Close the file we opened, just in case, so the test can start with a clean slate
             await TestServices.Editor.CloseDocumentWindowAsync(ControlledHangMitigatingCancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/BreakpointSpanTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/BreakpointSpanTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
 
             // Wait for classifications to indicate Razor LSP is up and running
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken);
             await TestServices.Editor.SetTextAsync("<p>@{ var abc = 123; }</p>", ControlledHangMitigatingCancellationToken);
 
             // Act
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
 
             // Wait for classifications to indicate Razor LSP is up and running
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken);
             await TestServices.Editor.SetTextAsync(@"<p>@{
     var abc = 123;
 }</p>", ControlledHangMitigatingCancellationToken);
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
 
             // Wait for classifications to indicate Razor LSP is up and running
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken);
             await TestServices.Editor.SetTextAsync(@"<p>@{
     var abc = 123;
 }</p>", ControlledHangMitigatingCancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/FormatDocumentTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/FormatDocumentTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.Editor.SetTextAsync(input, ControlledHangMitigatingCancellationToken);
 
             // Wait for the document to settle
-            await TestServices.Editor.WaitForOutlineRegionsAsync(ControlledHangMitigatingCancellationToken);
+            await TestServices.Editor.WaitForSemanticClassificationAsync("RazorTransition", ControlledHangMitigatingCancellationToken);
 
             // Act
             await TestServices.Editor.InvokeFormatDocumentAsync(ControlledHangMitigatingCancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/TestFiles/Expected/FormatSelection.cshtml
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/TestFiles/Expected/FormatSelection.cshtml
@@ -5,21 +5,21 @@
     <div>
     </div>
 }
-    <html>
-    <body>
-        <div class="navbar navbar-inverse navbar-fixed-top">
-            <div class="container">
-                <div class="navbar-collapse collapse">
-                    <ul class="nav ">
-                        <li>@Html.ActionLink("Home", "Index", "Home")</li>
-                        <li>@Html.ActionLink( "About", "About", "Home")</li>
-                        <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
-                    </ul>
-                </div>
+<html>
+<body>
+    <div class="navbar navbar-inverse navbar-fixed-top">
+        <div class="container">
+            <div class="navbar-collapse collapse">
+                <ul class="nav ">
+                    <li>@Html.ActionLink("Home", "Index", "Home")</li>
+                    <li>@Html.ActionLink( "About", "About", "Home")</li>
+                    <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
+                </ul>
             </div>
         </div>
-        <div>
-            @{
+    </div>
+    <div>
+        @{
             <span>foo</span>
             <span>foo</span>
         }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Classification.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Classification.cs
@@ -16,6 +16,14 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
     internal partial class EditorInProcess
     {
         /// <summary>
+        /// Waits for the Razor component semantic classifications to be available on the active TextView
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <param name="count">The number of the given classification to expect.</param>
+        /// <returns>A <see cref="Task"/> which completes when classification is "ready".</returns>
+        public Task WaitForComponentClassificationAsync(CancellationToken cancellationToken, int count = 1) => WaitForSemanticClassificationAsync("RazorComponentElement", cancellationToken, count);
+
+        /// <summary>
         /// Waits for any semantic classifications to be available on the active TextView, and for at least one of the
         /// <paramref name="expectedClassification"/> if provided.
         /// </summary>
@@ -23,7 +31,7 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
         /// <param name="expectedClassification">The classification to wait for, if any.</param>
         /// <param name="count">The number of the given classification to expect.</param>
         /// <returns>A <see cref="Task"/> which completes when classification is "ready".</returns>
-        public async Task WaitForClassificationAsync(CancellationToken cancellationToken, string expectedClassification = "RazorComponentElement", int count = 1)
+        public async Task WaitForSemanticClassificationAsync(string expectedClassification, CancellationToken cancellationToken, int count = 1)
         {
             var textView = await TestServices.Editor.GetActiveTextViewAsync(cancellationToken);
             var classifier = await GetClassifierAsync(textView, cancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/RazorSemanticTokensTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/RazorSemanticTokensTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.Editor.SetTextAsync(RazorProjectConstants.MainLayoutContent, ControlledHangMitigatingCancellationToken);
 
             // Act
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", count: 3);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
 
             // Assert
             var expectedClassifications = await GetExpectedClassificationSpansAsync(nameof(Components_AreColored), ControlledHangMitigatingCancellationToken);
@@ -62,10 +62,10 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             await TestServices.Editor.SetTextAsync(RazorProjectConstants.MainLayoutContent, ControlledHangMitigatingCancellationToken);
 
             // Act
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", count: 3);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
 
             await TestServices.Editor.SetTextAsync(RazorProjectConstants.IndexPageContent, ControlledHangMitigatingCancellationToken);
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken, "RazorComponentElement", count: 3);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
 
             // Assert
             var expectedClassifications = await GetExpectedClassificationSpansAsync(nameof(Edits_UpdateColors), ControlledHangMitigatingCancellationToken);
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
         {
             // Arrange
             await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
-            await TestServices.Editor.WaitForClassificationAsync(ControlledHangMitigatingCancellationToken);
+            await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken);
 
             // Act and Assert
             var expectedClassifications = await GetExpectedClassificationSpansAsync(nameof(Directives_AreColored), ControlledHangMitigatingCancellationToken);


### PR DESCRIPTION
- Originally found in this Integration test CI failure: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6414782&view=results
- This ended up revealing a few issues:
    1. Prior to this changeset formatting tests would wait for folding ranges to be available before attempting to format anything. In the above CI failure those checks timed out and the screenshots included also showed that no folding ranges were available. This indicates there might be a secondary issue where folding ranges ar ea little flakey. I've filed [this](https://github.com/dotnet/razor-tooling/issues/6592) to track re-enabling code folding tests and moved our existing formatting tests off of folding ranges being available to waiting for semantic classifications
    2. With the introduction of [this](https://github.com/dotnet/razor-tooling/pull/6531) change we started accurately formatting content after directive bodies. Updated our baselines for formatting tests to capture this new requirement.
- As part of this work I also found that the existing `WaitForClassificationAsync` was a little misleading because it defaulted to waiting for Razor component classifications. I've gone ahead and renamed the existing method to `WaitForComponentClassificationAsync` to be extra clear what's being waited for. As an extra reaction I added a general `WaitForSemanticClassificationAsync` that's now used in Razor formatting tests so we can wait for semantic Razor transitions.
