### PR TITLE
Only return minimal text edits if we get back a tilde from the Html LSP server

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
@@ -2,14 +2,18 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.WrapWithTag;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
 {
@@ -98,7 +102,36 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
             var response = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorWrapWithTagEndpoint, parameter).ConfigureAwait(false);
             var htmlResponse = await response.Returning<WrapWithTagResponse>(cancellationToken).ConfigureAwait(false);
 
+            if (htmlResponse.TextEdits is not null)
+            {
+                htmlResponse.TextEdits = await CleanUpTextEditsAsync(documentContext, htmlResponse.TextEdits, cancellationToken).ConfigureAwait(false);
+            }
+
             return htmlResponse;
+        }
+
+        /// <summary>
+        /// Sometimes the Html language server will send back an edit that contains a tilde, because the generated
+        /// document we send them has lots of tildes. In those cases, we need to do some extra work to compute the
+        /// minimal text edits
+        /// </summary>
+        // Internal for testing
+        internal static async Task<TextEdit[]> CleanUpTextEditsAsync(DocumentContext documentContext, TextEdit[] edits, CancellationToken cancellationToken)
+        {
+            // Avoid computing a minimal diff if we don't need to
+            if (!edits.Any(e => e.NewText.IndexOf('~') != -1))
+                return edits;
+
+            // First we apply the edits that the Html language server wanted, to the Html document
+            var htmlSourceText = await documentContext.GetHtmlSourceTextAsync(cancellationToken).ConfigureAwait(false);
+            var textChanges = edits.Select(e => e.AsTextChange(htmlSourceText));
+            var changedText = htmlSourceText.WithChanges(textChanges);
+
+            // Now we use our minimal text differ algorithm to get the bare minimum of edits
+            var minimalChanges = SourceTextDiffer.GetMinimalTextChanges(htmlSourceText, changedText, lineDiffOnly: false);
+            var minimalEdits = minimalChanges.Select(f => f.AsTextEdit(htmlSourceText)).ToArray();
+
+            return minimalEdits;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +9,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.WrapWithTag;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -119,7 +117,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
         internal static async Task<TextEdit[]> CleanUpTextEditsAsync(DocumentContext documentContext, TextEdit[] edits, CancellationToken cancellationToken)
         {
             // Avoid computing a minimal diff if we don't need to
-            if (!edits.Any(e => e.NewText.IndexOf('~') != -1))
+            if (!edits.Any(e => e.NewText.Contains("~")))
                 return edits;
 
             // First we apply the edits that the Html language server wanted, to the Html document

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
@@ -2,14 +2,18 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.WrapWithTag;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using OmniSharp.Extensions.JsonRpc;
@@ -156,6 +160,156 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
 
             // Assert
             Assert.Null(result);
+
+            Func<int, int, int> x = (_, _) => { return 4; };
+        }
+
+        [Fact]
+        public async Task CleanUpTextEdits_NoTilde()
+        {
+            var input = """
+                @if (true)
+                {
+                }
+                """;
+            var expected = """
+                <div>
+                    @if (true)
+                    {
+                    }
+                </div>
+                """;
+
+            var uri = new Uri("file://path.razor");
+            var factory = CreateDocumentContextFactory(uri, input);
+            var context = await factory.TryCreateAsync(uri, CancellationToken.None);
+            Assert.NotNull(context);
+            var inputSourceText = await context!.GetSourceTextAsync(CancellationToken.None);
+
+            var computedEdits = new TextEdit[]
+            {
+                new TextEdit
+                {
+                    NewText="<div>\r\n    ",
+                    Range = new Range { Start= new Position(0, 0), End = new Position(0, 0) }
+                },
+                new TextEdit
+                {
+                    NewText="    ",
+                    Range = new Range { Start= new Position(1, 0), End = new Position(1, 0) }
+                },
+                new TextEdit
+                {
+                    NewText="    }\r\n</div>",
+                    Range = new Range { Start= new Position(2, 0), End = new Position(2, 1) }
+                }
+            };
+
+            var edits = await WrapWithTagEndpoint.CleanUpTextEditsAsync(context!, computedEdits, CancellationToken.None);
+            Assert.Same(computedEdits, edits);
+
+            var finalText = inputSourceText.WithChanges(edits.Select(e => e.AsTextChange(inputSourceText)));
+            Assert.Equal(expected, finalText.ToString());
+        }
+
+        [Fact]
+        public async Task CleanUpTextEdits_BadEditWithTilde()
+        {
+            var input = """
+                @if (true)
+                {
+                }
+                """;
+
+            var expected = """
+                <div>
+                    @if (true)
+                    {
+                    }
+                </div>
+                """;
+
+            var uri = new Uri("file://path.razor");
+            var factory = CreateDocumentContextFactory(uri, input);
+            var context = await factory.TryCreateAsync(uri, CancellationToken.None);
+            Assert.NotNull(context);
+            var inputSourceText = await context!.GetSourceTextAsync(CancellationToken.None);
+
+            var computedEdits = new TextEdit[]
+            {
+                new TextEdit
+                {
+                    NewText="<div>\r\n    ",
+                    Range = new Range { Start= new Position(0, 0), End = new Position(0, 0) }
+                },
+                new TextEdit
+                {
+                    NewText="    ",
+                    Range = new Range { Start= new Position(1, 0), End = new Position(1, 0) }
+                },
+                new TextEdit
+                {
+                    // This is the problematic edit.. the close brace has been replaced with a tilde
+                    NewText="    ~\r\n</div>",
+                    Range = new Range { Start= new Position(2, 0), End = new Position(2, 1) }
+                }
+            };
+
+            var edits = await WrapWithTagEndpoint.CleanUpTextEditsAsync(context!, computedEdits, CancellationToken.None);
+            Assert.NotSame(computedEdits, edits);
+
+            var finalText = inputSourceText.WithChanges(edits.Select(e => e.AsTextChange(inputSourceText)));
+            Assert.Equal(expected, finalText.ToString());
+        }
+
+        [Fact]
+        public async Task CleanUpTextEdits_GoodEditWithTilde()
+        {
+            var input = """
+                @if (true)
+                {
+                ~
+                """;
+
+            var expected = """
+                <div>
+                    @if (true)
+                    {
+                    ~
+                </div>
+                """;
+
+            var uri = new Uri("file://path.razor");
+            var factory = CreateDocumentContextFactory(uri, input);
+            var context = await factory.TryCreateAsync(uri, CancellationToken.None);
+            Assert.NotNull(context);
+            var inputSourceText = await context!.GetSourceTextAsync(CancellationToken.None);
+
+            var computedEdits = new TextEdit[]
+            {
+                new TextEdit
+                {
+                    NewText="<div>\r\n    ",
+                    Range = new Range { Start= new Position(0, 0), End = new Position(0, 0) }
+                },
+                new TextEdit
+                {
+                    NewText="    ",
+                    Range = new Range { Start= new Position(1, 0), End = new Position(1, 0) }
+                },
+                new TextEdit
+                {
+                    // This looks like a bad edit, but the original source document had a tilde
+                    NewText="    ~\r\n</div>",
+                    Range = new Range { Start= new Position(2, 0), End = new Position(2, 1) }
+                }
+            };
+
+            var edits = await WrapWithTagEndpoint.CleanUpTextEditsAsync(context!, computedEdits, CancellationToken.None);
+            Assert.NotSame(computedEdits, edits);
+
+            var finalText = inputSourceText.WithChanges(edits.Select(e => e.AsTextChange(inputSourceText)));
+            Assert.Equal(expected, finalText.ToString());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6596