### PR TITLE
Allow minimized attribute completions anywhere in the attribute

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     selectedAttributeNameLocation.HasValue &&
                     selectedAttributeNameLocation.Value.Length > 1 &&
                     selectedAttributeNameLocation.Value.Start != context.AbsoluteIndex &&
-                    !IsPossiblePartiallyWrittenAttribute(parent, context.AbsoluteIndex))
+                    !InOrAtEndOfAttribute(parent, context.AbsoluteIndex))
                 {
                     // To align with HTML completion behavior we only want to provide completion items if we're trying to resolve completion at the
                     // beginning of an HTML attribute name or at the end of possible partially written attribute. We do extra checks on prefix locations here in order to rule out malformed cases when the Razor
@@ -119,20 +119,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 var attributeCompletions = GetAttributeCompletions(parent, containingTagNameToken.Content, selectedAttributeName, stringifiedAttributes, context.TagHelperDocumentContext, context.Options);
                 return attributeCompletions;
 
-                static bool IsPossiblePartiallyWrittenAttribute(SyntaxNode? attributeSyntax, int absoluteIndex)
+                static bool InOrAtEndOfAttribute(SyntaxNode attributeSyntax, int absoluteIndex)
                 {
                     // When we are in the middle of writing an attribute it is treated as a minimilized one, e.g.:
                     // <form asp$$ - 'asp' is parsed as MarkupMinimizedTagHelperAttributeSyntax (tag helper)
                     // <SurveyPrompt Tit$$ - 'Tit' is parsed as MarkupMinimizedTagHelperAttributeSyntax as well (razor component)
                     // Need to check for MarkupMinimizedAttributeBlockSyntax in order to handle cases when html tag becomes a tag helper only with certain attributes
-                    // We allow the absoluteIndex to be anywhere in the attribute, so that `<SurveyPrompt T$$it` doesn't return only
-                    // the html completions, because that has the effect of overwriting the casing of the attribute.
-                    if (attributeSyntax is MarkupMinimizedTagHelperAttributeSyntax or MarkupMinimizedAttributeBlockSyntax)
-                    {
-                        return attributeSyntax.Span.Start < absoluteIndex && attributeSyntax.Span.End >= absoluteIndex;
-                    }
-
-                    return false;
+                    // We allow the absoluteIndex to be anywhere in the attribute, and for non minimized attributes,
+                    // so that `<SurveyPrompt Title=""` doesn't return only the html completions, because that has the effect of overwriting the casing of the attribute.
+                    return attributeSyntax is MarkupMinimizedTagHelperAttributeSyntax or MarkupMinimizedAttributeBlockSyntax or MarkupTagHelperAttributeSyntax &&
+                        attributeSyntax.Span.Start < absoluteIndex && attributeSyntax.Span.End >= absoluteIndex;
                 }
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -123,11 +123,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 {
                     // When we are in the middle of writing an attribute it is treated as a minimilized one, e.g.:
                     // <form asp$$ - 'asp' is parsed as MarkupMinimizedTagHelperAttributeSyntax (tag helper)
-                    // <SurveyPromt Tit$$ - 'Tit' is parsed as MarkupMinimizedTagHelperAttributeSyntax as well (razor component)
+                    // <SurveyPrompt Tit$$ - 'Tit' is parsed as MarkupMinimizedTagHelperAttributeSyntax as well (razor component)
                     // Need to check for MarkupMinimizedAttributeBlockSyntax in order to handle cases when html tag becomes a tag helper only with certain attributes
+                    // We allow the absoluteIndex to be anywhere in the attribute, so that `<SurveyPrompt T$$it` doesn't return only
+                    // the html completions, because that has the effect of overwriting the casing of the attribute.
                     if (attributeSyntax is MarkupMinimizedTagHelperAttributeSyntax or MarkupMinimizedAttributeBlockSyntax)
                     {
-                        return attributeSyntax.Span.End == absoluteIndex;
+                        return attributeSyntax.Span.Start < absoluteIndex && attributeSyntax.Span.End >= absoluteIndex;
                     }
 
                     return false;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -402,7 +402,34 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
-        public void GetCompletionAt_MinimizedAttributeEdge_ReturnsNoCompletions()
+        public void GetCompletionAt_MinimizedAttributeMiddle_ReturnsCompletions()
+        {
+            // Arrange
+            var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
+            var context = CreateRazorCompletionContext(absoluteIndex: 38 + Environment.NewLine.Length, $"@addTagHelper *, TestAssembly{Environment.NewLine}<test2 boo />", isRazorFile: false, tagHelpers: DefaultTagHelpers);
+
+            // Act
+            var completions = service.GetCompletionItems(context);
+
+            // Assert
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("bool-val", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                },
+                completion =>
+                {
+                    Assert.Equal("int-val", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                });
+        }
+
+        [Fact]
+        public void GetCompletionAt_MinimizedAttributeEdge_ReturnsCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -412,11 +439,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Empty(completions);
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("bool-val", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                },
+                completion =>
+                {
+                    Assert.Equal("int-val", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                });
         }
 
         [Fact]
-        public void GetCompletionAt_MinimizedTagHelperAttributeEdge_ReturnsNoCompletions()
+        public void GetCompletionAt_MinimizedTagHelperAttributeEdge_ReturnsCompletions()
         {
             // Arrange
             var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, HtmlFactsService, TagHelperFactsService);
@@ -426,7 +466,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Empty(completions);
+            Assert.Collection(
+                completions,
+                completion =>
+                {
+                    Assert.Equal("bool-val", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                },
+                completion =>
+                {
+                    Assert.Equal("int-val", completion.InsertText);
+                    Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
+                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
+                });
         }
 
         [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -412,20 +412,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Collection(
-                completions,
-                completion =>
-                {
-                    Assert.Equal("bool-val", completion.InsertText);
-                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
-                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
-                },
-                completion =>
-                {
-                    Assert.Equal("int-val", completion.InsertText);
-                    Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
-                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
-                });
+            AssertBoolIntCompletions(completions);
         }
 
         [Fact]
@@ -439,20 +426,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Collection(
-                completions,
-                completion =>
-                {
-                    Assert.Equal("bool-val", completion.InsertText);
-                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
-                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
-                },
-                completion =>
-                {
-                    Assert.Equal("int-val", completion.InsertText);
-                    Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
-                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
-                });
+            AssertBoolIntCompletions(completions);
         }
 
         [Fact]
@@ -466,20 +440,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Collection(
-                completions,
-                completion =>
-                {
-                    Assert.Equal("bool-val", completion.InsertText);
-                    Assert.Equal(TagHelperCompletionProvider.MinimizedAttributeCommitCharacters, completion.CommitCharacters);
-                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
-                },
-                completion =>
-                {
-                    Assert.Equal("int-val", completion.InsertText);
-                    Assert.Equal(TagHelperCompletionProvider.AttributeCommitCharacters, completion.CommitCharacters);
-                    Assert.Equal(CompletionSortTextHelper.HighSortPriority, completion.SortText);
-                });
+            AssertBoolIntCompletions(completions);
         }
 
         [Fact]
@@ -493,7 +454,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Empty(completions);
+            AssertBoolIntCompletions(completions);
         }
 
         [Fact]
@@ -507,7 +468,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Empty(completions);
+            AssertBoolIntCompletions(completions);
         }
 
         [Fact]
@@ -538,7 +499,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completions = service.GetCompletionItems(context);
 
             // Assert
-            Assert.Empty(completions);
+            AssertBoolIntCompletions(completions);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6578