### PR TITLE
Remove C# and Html output versioning.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultDocumentSnapshot.cs
@@ -59,20 +59,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public override async Task<RazorCodeDocument> GetGeneratedOutputAsync()
         {
-            var (output, _, _, _) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
+            var (output, _) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
             return output;
-        }
-
-        public override async Task<VersionStamp> GetGeneratedCSharpOutputVersionAsync()
-        {
-            var (_, _, version, _) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
-            return version;
-        }
-
-        public override async Task<VersionStamp> GetGeneratedHtmlOutputVersionAsync()
-        {
-            var (_, _, _, version) = await State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).ConfigureAwait(false);
-            return version;
         }
 
         public override bool TryGetText(out SourceText result)
@@ -96,34 +84,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
 
             result = null;
-            return false;
-        }
-
-        public override bool TryGetGeneratedCSharpOutputVersion(out VersionStamp result)
-        {
-            if (State.IsGeneratedOutputResultAvailable)
-            {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-                result = State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).Result.outputCSharpVersion;
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-                return true;
-            }
-
-            result = default;
-            return false;
-        }
-
-        public override bool TryGetGeneratedHtmlOutputVersion(out VersionStamp result)
-        {
-            if (State.IsGeneratedOutputResultAvailable)
-            {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-                result = State.GetGeneratedOutputAndVersionAsync(ProjectInternal, this).Result.outputHtmlVersion;
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-                return true;
-            }
-
-            result = default;
             return false;
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultImportDocumentSnapshot.cs
@@ -41,16 +41,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             throw new NotSupportedException();
         }
 
-        public override Task<VersionStamp> GetGeneratedCSharpOutputVersionAsync()
-        {
-            throw new NotSupportedException();
-        }
-
-        public override Task<VersionStamp> GetGeneratedHtmlOutputVersionAsync()
-        {
-            throw new NotSupportedException();
-        }
-
         public override IReadOnlyList<DocumentSnapshot> GetImports()
         {
             return Array.Empty<DocumentSnapshot>();
@@ -92,16 +82,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         public override bool TryGetGeneratedOutput(out RazorCodeDocument result)
-        {
-            throw new NotSupportedException();
-        }
-
-        public override bool TryGetGeneratedCSharpOutputVersion(out VersionStamp result)
-        {
-            throw new NotSupportedException();
-        }
-
-        public override bool TryGetGeneratedHtmlOutputVersion(out VersionStamp result)
         {
             throw new NotSupportedException();
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -30,18 +30,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public abstract Task<RazorCodeDocument> GetGeneratedOutputAsync();
 
-        public abstract Task<VersionStamp> GetGeneratedCSharpOutputVersionAsync();
-
-        public abstract Task<VersionStamp> GetGeneratedHtmlOutputVersionAsync();
-
         public abstract bool TryGetText(out SourceText result);
 
         public abstract bool TryGetTextVersion(out VersionStamp result);
 
         public abstract bool TryGetGeneratedOutput(out RazorCodeDocument result);
-
-        public abstract bool TryGetGeneratedCSharpOutputVersion(out VersionStamp result);
-
-        public abstract bool TryGetGeneratedHtmlOutputVersion(out VersionStamp result);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,17 +24,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private readonly object _lock;
 
-        private ComputedStateTracker _computedState;
+        private ComputedStateTracker? _computedState;
 
         private readonly Func<Task<TextAndVersion>> _loader;
-        private Task<TextAndVersion> _loaderTask;
-        private SourceText _sourceText;
+        private Task<TextAndVersion>? _loaderTask;
+        private SourceText? _sourceText;
         private VersionStamp? _version;
 
         public static DocumentState Create(
             HostWorkspaceServices services,
             HostDocument hostDocument,
-            Func<Task<TextAndVersion>> loader)
+            Func<Task<TextAndVersion>>? loader)
         {
             if (services is null)
             {
@@ -47,7 +46,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 throw new ArgumentNullException(nameof(hostDocument));
             }
 
-            loader ??= EmptyLoader;
             return new DocumentState(services, hostDocument, null, null, loader);
         }
 
@@ -55,15 +53,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         internal DocumentState(
             HostWorkspaceServices services,
             HostDocument hostDocument,
-            SourceText text,
+            SourceText? text,
             VersionStamp? version,
-            Func<Task<TextAndVersion>> loader)
+            Func<Task<TextAndVersion>>? loader)
         {
             Services = services;
             HostDocument = hostDocument;
             _sourceText = text;
             _version = version;
-            _loader = loader;
+            _loader = loader ?? EmptyLoader;
             _lock = new object();
         }
 
@@ -92,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
         }
 
-        public Task<(RazorCodeDocument output, VersionStamp inputVersion, VersionStamp outputCSharpVersion, VersionStamp outputHtmlVersion)> GetGeneratedOutputAndVersionAsync(DefaultProjectSnapshot project, DefaultDocumentSnapshot document)
+        public Task<(RazorCodeDocument output, VersionStamp inputVersion)> GetGeneratedOutputAndVersionAsync(DefaultProjectSnapshot project, DefaultDocumentSnapshot document)
         {
             return ComputedState.GetGeneratedOutputAndVersionAsync(project, document);
         }
@@ -132,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return (await _loaderTask.ConfigureAwait(false)).Version;
         }
 
-        public bool TryGetText(out SourceText result)
+        public bool TryGetText([NotNullWhen(true)] out SourceText? result)
         {
             if (_sourceText != null)
             {
@@ -284,13 +282,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             private readonly object _lock;
 
-            private ComputedStateTracker _older;
+            private ComputedStateTracker? _older;
 
             // We utilize a WeakReference here to avoid bloating committed memory. If pieces request document output inbetween GC collections
             // then we will provide the weak referenced task; otherwise we require any state requests to be re-computed.
-            private WeakReference<Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)>> _taskUnsafeReference;
+            private WeakReference<Task<(RazorCodeDocument, VersionStamp)>>? _taskUnsafeReference;
 
-            public ComputedStateTracker(DocumentState state, ComputedStateTracker older = null)
+            public ComputedStateTracker(DocumentState state, ComputedStateTracker? older = null)
             {
                 _lock = state._lock;
                 _older = older;
@@ -314,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 }
             }
 
-            public Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetGeneratedOutputAndVersionAsync(DefaultProjectSnapshot project, DocumentSnapshot document)
+            public Task<(RazorCodeDocument, VersionStamp)> GetGeneratedOutputAndVersionAsync(DefaultProjectSnapshot project, DocumentSnapshot document)
             {
                 if (project is null)
                 {
@@ -329,7 +327,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 if (_taskUnsafeReference is null ||
                     !_taskUnsafeReference.TryGetTarget(out var taskUnsafe))
                 {
-                    TaskCompletionSource<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> tcs = null;
+                    TaskCompletionSource<(RazorCodeDocument, VersionStamp)>? tcs = null;
 
                     lock (_lock)
                     {
@@ -343,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
                             tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
                             taskUnsafe = tcs.Task;
-                            _taskUnsafeReference = new WeakReference<Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)>>(taskUnsafe);
+                            _taskUnsafeReference = new WeakReference<Task<(RazorCodeDocument, VersionStamp)>>(taskUnsafe);
                         }
                     }
 
@@ -367,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                         _ = outputTask.ContinueWith(
                             static (task, state) =>
                             {
-                                var tcs = (TaskCompletionSource<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)>)state;
+                                var tcs = (TaskCompletionSource<(RazorCodeDocument, VersionStamp)>)state;
 
                                 PropagateToTaskCompletionSource(task, tcs);
                             },
@@ -381,8 +379,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 return taskUnsafe;
 
                 static void PropagateToTaskCompletionSource(
-                    Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> targetTask,
-                    TaskCompletionSource<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> tcs)
+                    Task<(RazorCodeDocument, VersionStamp)> targetTask,
+                    TaskCompletionSource<(RazorCodeDocument, VersionStamp)> tcs)
                 {
                     if (targetTask.Status == TaskStatus.RanToCompletion)
                     {
@@ -403,7 +401,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 }
             }
 
-            private async Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetGeneratedOutputAndVersionCoreAsync(DefaultProjectSnapshot project, DocumentSnapshot document)
+            private async Task<(RazorCodeDocument, VersionStamp)> GetGeneratedOutputAndVersionCoreAsync(DefaultProjectSnapshot project, DocumentSnapshot document)
             {
                 // We only need to produce the generated code if any of our inputs is newer than the
                 // previously cached output.
@@ -447,14 +445,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     }
                 }
 
-                RazorCodeDocument olderOutput = null;
-                var olderCSharpOutputVersion = default(VersionStamp);
-                var olderHtmlOutputVersion = default(VersionStamp);
+                RazorCodeDocument? olderOutput = null;
                 if (_older?._taskUnsafeReference != null &&
                     _older._taskUnsafeReference.TryGetTarget(out var taskUnsafe))
                 {
                     VersionStamp olderInputVersion;
-                    (olderOutput, olderInputVersion, olderCSharpOutputVersion, olderHtmlOutputVersion) = await taskUnsafe.ConfigureAwait(false);
+                    (olderOutput, olderInputVersion) = await taskUnsafe.ConfigureAwait(false);
                     if (inputVersion.GetNewerVersion(olderInputVersion) == olderInputVersion)
                     {
                         // Nothing has changed, we can use the cached result.
@@ -462,7 +458,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                         {
                             _taskUnsafeReference = _older._taskUnsafeReference;
                             _older = null;
-                            return (olderOutput, olderInputVersion, olderCSharpOutputVersion, olderHtmlOutputVersion);
+                            return (olderOutput, olderInputVersion);
                         }
                     }
                 }
@@ -481,54 +477,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 var documentSource = await GetRazorSourceDocumentAsync(document, projectItem).ConfigureAwait(false);
 
                 var codeDocument = projectEngine.ProcessDesignTime(documentSource, fileKind: document.FileKind, importSources, project.TagHelpers);
-                var csharpDocument = codeDocument.GetCSharpDocument();
-                var htmlDocument = codeDocument.GetHtmlDocument();
-
-                // OK now we've generated the code. Let's check if the output is actually different. This is
-                // a valuable optimization for our use cases because lots of changes you could make require
-                // us to run code generation, but don't change the result.
-                //
-                // Note that we're talking about the effect on the generated C#/HTML here (not the other artifacts).
-                // This is the reason why we have three versions associated with the document.
-                //
-                // The INPUT version is related the .cshtml files and tag helpers
-                // The CSHARPOUTPUT version is related to the generated C#
-                // The HTMLOUTPUT version is related to the generated HTML
-                //
-                // Examples:
-                //
-                // A change to a tag helper not used by this document - updates the INPUT version, but not
-                // the OUTPUT version.
-                //
-                //
-                // Razor IDE features should always retrieve the output and party on it regardless. Depending
-                // on the use cases we may or may not need to synchronize the output.
-
-                var outputCSharpVersion = inputVersion;
-                var outputHtmlVersion = inputVersion;
-                if (olderOutput != null)
-                {
-                    if (string.Equals(
-                        olderOutput.GetCSharpDocument().GeneratedCode,
-                        csharpDocument.GeneratedCode,
-                        StringComparison.Ordinal))
-                    {
-                        outputCSharpVersion = olderCSharpOutputVersion;
-                    }
-
-                    if (string.Equals(
-                        olderOutput.GetHtmlDocument().GeneratedHtml,
-                        htmlDocument.GeneratedHtml,
-                        StringComparison.Ordinal))
-                    {
-                        outputHtmlVersion = olderHtmlOutputVersion;
-                    }
-                }
-
-                return (codeDocument, inputVersion, outputCSharpVersion, outputHtmlVersion);
+                return (codeDocument, inputVersion);
             }
 
-            private static async Task<RazorSourceDocument> GetRazorSourceDocumentAsync(DocumentSnapshot document, RazorProjectItem projectItem)
+            private static async Task<RazorSourceDocument> GetRazorSourceDocumentAsync(DocumentSnapshot document, RazorProjectItem? projectItem)
             {
                 var sourceText = await document.GetTextAsync();
                 return sourceText.GetRazorSourceDocument(document.FilePath, projectItem?.RelativePhysicalPath);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -82,26 +82,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert
             Assert.False(LegacyDocument.TryGetGeneratedOutput(out _));
-            Assert.False(LegacyDocument.TryGetGeneratedCSharpOutputVersion(out _));
-            Assert.False(LegacyDocument.TryGetGeneratedHtmlOutputVersion(out _));
-        }
-
-        [Fact]
-        public async Task GCCollect_OnRegenerationMaintainsOutputVersion()
-        {
-            // Arrange
-            var initialOutputVersion = await LegacyDocument.GetGeneratedCSharpOutputVersionAsync();
-
-            // Forces collection of the cached document output
-            GC.Collect();
-
-            // Act
-            var regeneratedCSharpOutputVersion = await LegacyDocument.GetGeneratedCSharpOutputVersionAsync();
-            var regeneratedHtmlOutputVersion = await LegacyDocument.GetGeneratedHtmlOutputVersionAsync();
-
-            // Assert
-            Assert.Equal(initialOutputVersion, regeneratedCSharpOutputVersion);
-            Assert.Equal(initialOutputVersion, regeneratedHtmlOutputVersion);
         }
 
         [Fact]
@@ -115,8 +95,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Act & Assert
             Assert.True(LegacyDocument.TryGetGeneratedOutput(out _));
-            Assert.True(LegacyDocument.TryGetGeneratedCSharpOutputVersion(out _));
-            Assert.True(LegacyDocument.TryGetGeneratedHtmlOutputVersion(out _));
         }
 
         // This is a sanity test that we invoke component codegen for components.It's a little fragile but

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -64,19 +64,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithAddedHostDocument(TestProjectData.AnotherProjectFile1, DocumentState.EmptyLoader);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.Same(originalOutput, actualOutput);
             Assert.Equal(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
-            Assert.NotEqual(state.ProjectWorkspaceStateVersion, actualCSharpOutputVersion);
-            Assert.NotEqual(state.ConfigurationVersion, actualCSharpOutputVersion);
         }
 
         [Fact]
@@ -87,17 +83,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.DocumentCollectionVersion, actualInputVersion);
         }
 
@@ -110,18 +104,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var version = VersionStamp.Create();
             var state = original.WithChangedHostDocument(HostDocument, () => Task.FromResult(TextAndVersion.Create(SourceText.From("@using System"), version)));
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.NotEqual(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(version, actualInputVersion);
         }
 
@@ -134,18 +126,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var version = VersionStamp.Create();
             var state = original.WithChangedHostDocument(TestProjectData.SomeProjectImportFile, () => Task.FromResult(TextAndVersion.Create(SourceText.From("@using System"), version)));
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(version, actualInputVersion);
         }
 
@@ -158,17 +148,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithRemovedHostDocument(TestProjectData.SomeProjectImportFile);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.DocumentCollectionVersion, actualInputVersion);
         }
 
@@ -181,18 +169,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader)
                 .WithProjectWorkspaceState(ProjectWorkspaceState.Default);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
             var changed = new ProjectWorkspaceState(Array.Empty<TagHelperDescriptor>(), default);
 
             // Act
             var state = original.WithProjectWorkspaceState(changed);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.Same(originalOutput, actualOutput);
             Assert.Equal(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
@@ -205,18 +191,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
             var changed = new ProjectWorkspaceState(SomeTagHelpers, default);
 
             // Act
             var state = original.WithProjectWorkspaceState(changed);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.Equal(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
@@ -232,17 +216,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 .WithAddedHostDocument(HostDocument, () => Task.FromResult(TextAndVersion.Create(SourceText.From("@DateTime.Now"), VersionStamp.Default)));
             var changedWorkspaceState = new ProjectWorkspaceState(SomeTagHelpers, LanguageVersion.CSharp8);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithProjectWorkspaceState(changedWorkspaceState);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.Equal(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
@@ -254,27 +236,25 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 ProjectState.Create(Workspace.Services, HostProject)
                 .WithAddedHostDocument(HostDocument, DocumentState.EmptyLoader);
 
-            var (originalOutput, originalInputVersion, originalCSharpOutputVersion, originalHtmlOutputVersion) = await GetOutputAsync(original, HostDocument);
+            var (originalOutput, originalInputVersion) = await GetOutputAsync(original, HostDocument);
 
             // Act
             var state = original.WithHostProject(HostProjectWithConfigurationChange);
 
             // Assert
-            var (actualOutput, actualInputVersion, actualCSharpOutputVersion, actualHtmlOutputVersion) = await GetOutputAsync(state, HostDocument);
+            var (actualOutput, actualInputVersion) = await GetOutputAsync(state, HostDocument);
             Assert.NotSame(originalOutput, actualOutput);
             Assert.NotEqual(originalInputVersion, actualInputVersion);
-            Assert.NotEqual(originalCSharpOutputVersion, actualCSharpOutputVersion);
-            Assert.NotEqual(originalHtmlOutputVersion, actualHtmlOutputVersion);
             Assert.NotEqual(state.ProjectWorkspaceStateVersion, actualInputVersion);
         }
 
-        private static Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetOutputAsync(ProjectState project, HostDocument hostDocument)
+        private static Task<(RazorCodeDocument, VersionStamp)> GetOutputAsync(ProjectState project, HostDocument hostDocument)
         {
             var document = project.Documents[hostDocument.FilePath];
             return GetOutputAsync(project, document);
         }
 
-        private static Task<(RazorCodeDocument, VersionStamp, VersionStamp, VersionStamp)> GetOutputAsync(ProjectState project, DocumentState document)
+        private static Task<(RazorCodeDocument, VersionStamp)> GetOutputAsync(ProjectState project, DocumentState document)
         {
 
             var projectSnapshot = new DefaultProjectSnapshot(project);


### PR DESCRIPTION
- On its surface having a C#/HTML output version seems appealing; however, in practice we've never used it because the `SourceText` that stores the output already versions this information. Also, when digging through the code I found that every time we'd parse a file we'd aggressively be generating the C#/HTML docs (even when we don't need it) and simultaneously we'd also be doing massive string equals checks to try and understand versioning. This changeset removes all of that.
- Updated tests to remove the C#/HTML output checks because they no longer exist
- Made `DocumentState` nullable enabled.

Done as part of #6043 although it technically could stand on its own.