### PR TITLE
Add package source mapping for internal tools

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -25,6 +25,9 @@
   </packageSources>
   <packageSourceMapping>
     <clear />
+    <packageSource key="dotnet-core-internal-tooling">
+      <package pattern="microsoft.*" />
+    </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="microbuild.plugins.swixbuild" />
       <package pattern="microsoft.*" />


### PR DESCRIPTION
Fixes the CI build

FYI @epananth though it's worth noting that package source mapping wasn't enabled when you added the internal tools stuff, so not a problem that this broke, but thought you might like to know. Is it possible to add a package source mapping to the `nuget.config` file that is in `eng/common` to prevent this affecting other teams, if they adopt package source mapping?