### PR TITLE
Cache generated output as long as CodeDocument is referenced.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    internal class CodeDocumentReferenceHolder : DocumentProcessedListener
+    {
+        private Dictionary<string, RazorCodeDocument> _codeDocumentCache;
+        private ProjectSnapshotManager? _projectManager;
+
+        public CodeDocumentReferenceHolder()
+        {
+            _codeDocumentCache = new(FilePathComparer.Instance);
+        }
+
+        public override void DocumentProcessed(RazorCodeDocument codeDocument, DocumentSnapshot documentSnapshot)
+        {
+            // We capture a reference to the code document after a document has been processed in order to ensure that
+            // latest document state information is readily available without re-computation. The DocumentState type
+            // (brains of DocumentSnapshot) will garbage collect its generated output aggressively and due to the
+            // nature of LSP being heavily asynchronous (multiple requests for single keystrokes) we don't want to cause
+            // multiple parses/regenerations across LSP requests that are all for the same document version.
+            _codeDocumentCache[documentSnapshot.FilePath] = codeDocument;
+        }
+
+        public override void Initialize(ProjectSnapshotManager projectManager)
+        {
+            _projectManager = projectManager;
+            _projectManager.Changed += ProjectManager_Changed;
+        }
+
+        private void ProjectManager_Changed(object sender, ProjectChangeEventArgs args)
+        {
+            // Goal here is to evict cache entries (really just references to code documents) of known documents when
+            // related information changes for them
+
+            switch (args.Kind)
+            {
+                case ProjectChangeKind.ProjectChanged:
+                    foreach (var documentFilePath in args.Newer!.DocumentFilePaths)
+                    {
+                        _codeDocumentCache.Remove(documentFilePath);
+                    }
+
+                    break;
+                case ProjectChangeKind.ProjectRemoved:
+                    foreach (var documentFilePath in args.Older!.DocumentFilePaths)
+                    {
+                        _codeDocumentCache.Remove(documentFilePath);
+                    }
+
+                    break;
+                case ProjectChangeKind.DocumentChanged:
+                case ProjectChangeKind.DocumentRemoved:
+                    _codeDocumentCache.Remove(args.DocumentFilePath!);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -228,6 +228,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         // Document processed listeners
                         services.AddSingleton<DocumentProcessedListener, RazorDiagnosticsPublisher>();
                         services.AddSingleton<DocumentProcessedListener, GeneratedDocumentSynchronizer>();
+                        services.AddSingleton<DocumentProcessedListener, CodeDocumentReferenceHolder>();
 
                         services.AddSingleton<ProjectSnapshotManagerAccessor, DefaultProjectSnapshotManagerAccessor>();
                         services.AddSingleton<TagHelperFactsService, DefaultTagHelperFactsService>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class CodeDocumentReferenceHolderTest : LanguageServerTestBase
+    {
+        public CodeDocumentReferenceHolderTest()
+        {
+            ProjectManager = TestProjectSnapshotManager.Create(Dispatcher);
+            ProjectManager.AllowNotifyListeners = true;
+            ReferenceHolder = new CodeDocumentReferenceHolder();
+            ReferenceHolder.Initialize(ProjectManager);
+
+            HostProject = new HostProject("C:/path/to/project.csproj", RazorConfiguration.Default, rootNamespace: "TestNamespace");
+            HostDocument = new HostDocument("C:/path/to/file.razor", "file.razor");
+        }
+
+        private TestProjectSnapshotManager ProjectManager { get; }
+
+        private CodeDocumentReferenceHolder ReferenceHolder { get; }
+
+        private HostProject HostProject { get; }
+
+        private HostDocument HostDocument { get; }
+
+        [Fact]
+        public async Task DocumentProcessed_ReferencesGeneratedCodeDocument()
+        {
+            // Arrange
+            var documentSnapshot = await CreateDocumentSnapshotAsync(CancellationToken.None).ConfigureAwait(false);
+            var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            // Act
+            GC.Collect();
+
+            // Assert
+            Assert.True(codeDocumentReference.TryGetTarget(out _));
+        }
+
+        [Fact]
+        public async Task UnrelatedDocumentChanged_ReferencesGeneratedCodeDocument()
+        {
+            // Arrange
+            var documentSnapshot = await CreateDocumentSnapshotAsync(CancellationToken.None).ConfigureAwait(false);
+            var unrelatedHostDocument = new HostDocument("C:/path/to/otherfile.razor", "otherfile.razor");
+            var unrelatedDocumentSnapshot = await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                var unrelatedTextLoader = new SourceTextLoader("<p>Unrelated</p>", unrelatedHostDocument.FilePath);
+                ProjectManager.DocumentAdded(HostProject, unrelatedHostDocument, unrelatedTextLoader);
+                var project = ProjectManager.GetLoadedProject(HostProject.FilePath);
+                var document = project.GetDocument(unrelatedHostDocument.FilePath);
+                return document;
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            var mainCodeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, CancellationToken.None).ConfigureAwait(false);
+            var unrelatedCodeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(unrelatedDocumentSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            // Act
+            await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                ProjectManager.DocumentChanged(HostProject.FilePath, unrelatedHostDocument.FilePath, SourceText.From(string.Empty));
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            GC.Collect();
+
+            // Assert
+            Assert.True(mainCodeDocumentReference.TryGetTarget(out _));
+            Assert.False(unrelatedCodeDocumentReference.TryGetTarget(out _));
+        }
+
+        [Fact]
+        public async Task DocumentChanged_DereferencesGeneratedCodeDocument()
+        {
+            // Arrange
+            var documentSnapshot = await CreateDocumentSnapshotAsync(CancellationToken.None).ConfigureAwait(false);
+            var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            // Act
+            await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                ProjectManager.DocumentChanged(HostProject.FilePath, HostDocument.FilePath, SourceText.From(string.Empty));
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            GC.Collect();
+
+            // Assert
+            Assert.False(codeDocumentReference.TryGetTarget(out _));
+        }
+
+        [Fact]
+        public async Task DocumentRemoved_DereferencesGeneratedCodeDocument()
+        {
+            // Arrange
+            var documentSnapshot = await CreateDocumentSnapshotAsync(CancellationToken.None).ConfigureAwait(false);
+            var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            // Act
+            await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                ProjectManager.DocumentRemoved(HostProject, HostDocument);
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            GC.Collect();
+
+            // Assert
+            Assert.False(codeDocumentReference.TryGetTarget(out _));
+        }
+
+        [Fact]
+        public async Task ProjectChanged_DereferencesGeneratedCodeDocument()
+        {
+            // Arrange
+            var documentSnapshot = await CreateDocumentSnapshotAsync(CancellationToken.None).ConfigureAwait(false);
+            var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            // Act
+            await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                ProjectManager.ProjectConfigurationChanged(new HostProject(HostProject.FilePath, RazorConfiguration.Default, rootNamespace: "NewRootNamespace"));
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            GC.Collect();
+
+            // Assert
+            Assert.False(codeDocumentReference.TryGetTarget(out _));
+        }
+
+        [Fact]
+        public async Task ProjectRemoved_DereferencesGeneratedCodeDocument()
+        {
+            // Arrange
+            var documentSnapshot = await CreateDocumentSnapshotAsync(CancellationToken.None).ConfigureAwait(false);
+            var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            // Act
+            await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                ProjectManager.ProjectRemoved(HostProject);
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            GC.Collect();
+
+            // Assert
+            Assert.False(codeDocumentReference.TryGetTarget(out _));
+        }
+
+        private Task<DocumentSnapshot> CreateDocumentSnapshotAsync(CancellationToken cancellationToken)
+        {
+            return Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                ProjectManager.ProjectAdded(HostProject);
+                var textLoader = new SourceTextLoader("<p>Hello World</p>", HostDocument.FilePath);
+                ProjectManager.DocumentAdded(HostProject, HostDocument, textLoader);
+                var project = ProjectManager.GetLoadedProject(HostProject.FilePath);
+                var document = project.GetDocument(HostDocument.FilePath);
+                return document;
+            }, cancellationToken);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private async Task<WeakReference<RazorCodeDocument>> ProcessDocumentAndRetrieveOutputAsync(DocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
+        {
+            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+            await Dispatcher.RunOnDispatcherThreadAsync(() =>
+            {
+                ReferenceHolder.DocumentProcessed(codeDocument, documentSnapshot);
+            }, cancellationToken).ConfigureAwait(false);
+            var codeDocumentReference = new WeakReference<RazorCodeDocument>(codeDocument);
+
+            return codeDocumentReference;
+        }
+
+        private sealed class SourceTextLoader : TextLoader
+        {
+            private readonly SourceText _sourceText;
+            private readonly string _filePath;
+
+            public SourceTextLoader(string content, string filePath)
+            {
+                _sourceText = SourceText.From(content);
+                _filePath = filePath;
+            }
+
+            public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(TextAndVersion.Create(_sourceText, VersionStamp.Default, _filePath));
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public async Task GCCollect_OutputIsNoLongerCached()
         {
             // Arrange
-            await LegacyDocument.GetGeneratedOutputAsync();
+            await Task.Run(async () => { await LegacyDocument.GetGeneratedOutputAsync(); });
 
             // Act
 


### PR DESCRIPTION
- This changeset changes how our `DocumentSnapshot` system caches its output. Previous it relied on a secondary system to dig deep into a `DocumentSnapshot`, extract its "generate output task" and then hold onto a reference of that. In this change I expand `DocumentState` to be "code document reference aware"; meaning, if someone is referencing the generated output then the output is maintained so we don't need to re-parse / compute data. Ultimately this ends up bringing our new system back into par with our existing perf and even surpassing it in quick typing scenarios (multiple document states flowing simultaneously).
- With this changeset and some rudimentary testing I saw a 10% reduction in overall cache misses compared to what exists today while also maintaining simplicity.
- Added tests to validate we do the right thing at referene / cache time.

Final part of #6043