### PR TITLE
Re-enable integration tests on PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -240,8 +240,8 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             -test
-            # -integrationTest
-            # /p:BuildProjectReferences=false
+            -integrationTest
+            /p:BuildProjectReferences=false
           name: Run_Tests
           displayName: Run Unit and Integration tests
           condition: succeeded()
@@ -276,14 +276,14 @@ stages:
             artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
             artifactType: Container
             parallel: true
-        # - task: PublishTestResults@2
-        #   displayName: Publish VSCode Test Results
-        #   inputs:
-        #     testResultsFormat: 'JUnit'
-        #     testResultsFiles: '*.xml'
-        #     searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        #   continueOnError: true
-        #   condition: always()
+        - task: PublishTestResults@2
+          displayName: Publish VSCode Test Results
+          inputs:
+            testResultsFormat: 'JUnit'
+            testResultsFiles: '*.xml'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          continueOnError: true
+          condition: always()
         - task: PublishBuildArtifacts@1
           displayName: Publish VSIX Artifacts
           inputs:


### PR DESCRIPTION
- This attempts to re-enable integration tests on PRs that were disabled [here](https://github.com/dotnet/razor-tooling/pull/6325).

Fixes #6575