### PR TITLE
Allow TagHelper completions to show up when typing space.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             _logger = loggerFactory.CreateLogger<RazorCompletionListProvider>();
         }
 
-        public override ImmutableHashSet<string> TriggerCharacters => new[] { "@", "<", ":" }.ToImmutableHashSet();
+        public override ImmutableHashSet<string> TriggerCharacters => new[] { "@", "<", ":", " " }.ToImmutableHashSet();
 
         public override async Task<VSInternalCompletionList?> GetCompletionListAsync(
             int absoluteIndex,


### PR DESCRIPTION
- Expanded trigger characters to include a space for TagHelper completion
- Missed this originally when enabling single server completion!

Fixes #6601