### PR TITLE
Catch folding range exception

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 {
                     foldingRanges = await HandleCoreAsync(requestParams, documentContext, cancellationToken);
                 }
-                catch (Exception e) when (retries <= MaxRetries)
+                catch (Exception e)
                 {
                     _logger.LogWarning(e, "Try {retries} to get FoldingRange", retries);
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -125,8 +124,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
 
         private static IEnumerable<FoldingRange> FinalizeFoldingRanges(List<FoldingRange> mappedRanges, RazorCodeDocument codeDocument)
         {
-            var sourceText = codeDocument.GetSourceText();
-
             // Don't allow ranges to be reported if they aren't spanning at least one line
             var validRanges = mappedRanges.Where(r => r.StartLine < r.EndLine);
 
@@ -137,14 +134,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 .Select(ranges => ranges.OrderByDescending(r => r.EndLine).First());
 
             // Fix the starting range so the "..." is shown at the end
-            return reducedRanges.Select(r => FixFoldingRangeStart(r, sourceText));
+            return reducedRanges.Select(r => FixFoldingRangeStart(r, codeDocument));
         }
 
         /// <summary>
         /// Fixes the start of a range so that the offset of the first line is the last character on that line. This makes
         /// it so collapsing will still show the text instead of just "..."
         /// </summary>
-        private static FoldingRange FixFoldingRangeStart(FoldingRange range, SourceText sourceText)
+        private static FoldingRange FixFoldingRangeStart(FoldingRange range, RazorCodeDocument codeDocument)
         {
             Debug.Assert(range.StartLine < range.EndLine);
 
@@ -156,6 +153,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 return range;
             }
 
+            var sourceText = codeDocument.GetSourceText();
             var startLine = range.StartLine;
 
             Debug.Assert(range.StartLine < sourceText.Lines.Count);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
                 {
                     foldingRanges = await HandleCoreAsync(requestParams, documentContext, cancellationToken);
                 }
-                catch (Exception e) when (retries < MaxRetries)
+                catch (Exception e) when (retries <= MaxRetries)
                 {
                     _logger.LogWarning(e, "Try {retries} to get FoldingRange", retries);
                 }
@@ -127,8 +127,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
         {
             var sourceText = codeDocument.GetSourceText();
 
-            // Don't allow ranges to be reported if they aren't spanning at least one line or they exceed document length.
-            var validRanges = mappedRanges.Where(r => r.StartLine < r.EndLine && r.EndLine < sourceText.Lines.Count);
+            // Don't allow ranges to be reported if they aren't spanning at least one line
+            var validRanges = mappedRanges.Where(r => r.StartLine < r.EndLine);
 
             // Reduce ranges that have the same start line to be a single instance with the largest
             // range available, since only one button can be shown to collapse per line

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
             }
 
             List<FoldingRange> mappedRanges = new();
+
             foreach (var foldingRange in foldingResponse.CSharpRanges)
             {
                 var range = GetRange(foldingRange);


### PR DESCRIPTION
### Summary of the changes
- A formatting integration test [was being flaky](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6436101) and running into a `TaskCanceledException`.
- Turns out the problem was in our folding ranges logic. Essentially, we were receiving HTML responses for a more updated version of our Razor document. We were trying to compare these ranges with an older version of our Razor document and ended up throwing an exception. This subsequently would hang the integration test indefinitely until it timed out.
- This PR catches the exception (via re-try logic) which seems to have fixed the problem.