### PR TITLE
Migrate completion list provider tests to utilize C# server where app…

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
 
         private DelegatedCompletionParams CSharpCompletionParams { get; }
 
-        internal DelegatedCompletionParams HtmlCompletionParams { get; }
+        private DelegatedCompletionParams HtmlCompletionParams { get; }
 
         [Fact]
         public async Task ResolveAsync_CanNotFindCompletionItem_Noops()
@@ -150,9 +150,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         {
             private readonly DelegatedCompletionResolveRequestHandler _requestHandler;
 
-            private TestItemResolverServer(DelegatedCompletionResolveRequestHandler requestHandler) : base(new Dictionary<string, Func<object, object>>()
+            private TestItemResolverServer(DelegatedCompletionResolveRequestHandler requestHandler) : base(new Dictionary<string, Func<object, Task<object>>>()
             {
-                [LanguageServerConstants.RazorCompletionResolveEndpointName] = requestHandler.OnDelegation,
+                [LanguageServerConstants.RazorCompletionResolveEndpointName] = requestHandler.OnDelegationAsync,
             })
             {
                 _requestHandler = requestHandler;
@@ -179,11 +179,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
 
                 public DelegatedCompletionItemResolveParams DelegatedParams { get; private set; }
 
-                public object OnDelegation(object parameters)
+                public Task<object> OnDelegationAsync(object parameters)
                 {
                     DelegatedParams = (DelegatedCompletionItemResolveParams)parameters;
 
-                    return _resolveResponse;
+                    return Task.FromResult<object>(_resolveResponse);
                 }
             }
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             var completionContext = new VSInternalCompletionContext();
             var codeDocument = CreateCodeDocument(documentContent);
             var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument);
-            var provider = TestDelegatedCompletionListProvider.Create(LoggerFactory, initialCompletionList, Rewriter);
+            var provider = TestDelegatedCompletionListProvider.Create(initialCompletionList, Rewriter);
             var clientCapabilities = new VSInternalClientCapabilities();
             var completionList = await provider.GetCompletionListAsync(absoluteIndex, completionContext, documentContext, clientCapabilities, CancellationToken.None);
             return completionList;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestOmnisharpLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestOmnisharpLanguageServer.cs
@@ -15,9 +15,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
 {
     internal class TestOmnisharpLanguageServer : ClientNotifierServiceBase
     {
-        private readonly IReadOnlyDictionary<string, Func<object, object>> _requestResponseFactory;
+        private readonly IReadOnlyDictionary<string, Func<object, Task<object>>> _requestResponseFactory;
 
-        public TestOmnisharpLanguageServer(Dictionary<string, Func<object, object>> requestResponseFactory)
+        public TestOmnisharpLanguageServer(Dictionary<string, Func<object, Task<object>>> requestResponseFactory)
         {
             _requestResponseFactory = requestResponseFactory;
         }
@@ -31,15 +31,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
             return SendRequestAsync(method, @params: (object)null);
         }
 
-        public override Task<IResponseRouterReturns> SendRequestAsync<TParams>(string method, TParams @params)
+        public override async Task<IResponseRouterReturns> SendRequestAsync<TParams>(string method, TParams @params)
         {
             if (!_requestResponseFactory.TryGetValue(method, out var factory))
             {
                 throw new InvalidOperationException($"No request factory setup for {method}");
             }
 
-            var result = factory(@params);
-            return Task.FromResult<IResponseRouterReturns>(new TestResponseRouterReturns(result));
+            var result = await factory(@params);
+            return new TestResponseRouterReturns(result);
         }
 
         private class TestResponseRouterReturns : IResponseRouterReturns


### PR DESCRIPTION
…licable.

- Found that for trigger character based tests completion results weren't being returned. Meaning, invoking completion at `@if (|)` wouldn't result in any completions. I tried this with a few different samples and all didn't work.
- Updated the delegated completion list provider to take in a CSharp server.
- Shamelessly stole 90% of this from @allisonchou