### PR TITLE
Migrate delegated completion list resolver tests to use C# server.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.Extensions;
@@ -22,6 +23,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
     internal class CSharpTestLspServerHelpers
     {
         private const string EditRangeSetting = "editRange";
+
+        public static Task<CSharpTestLspServer> CreateCSharpLspServerAsync(SourceText csharpSourceText, Uri csharpDocumentUri, ServerCapabilities serverCapabilities) =>
+            CreateCSharpLspServerAsync(csharpSourceText, csharpDocumentUri, serverCapabilities, new EmptyMappingService());
 
         public static async Task<CSharpTestLspServer> CreateCSharpLspServerAsync(
             SourceText csharpSourceText,
@@ -111,5 +115,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common
         }
 
         private record CSharpFile(Uri DocumentUri, SourceText CSharpSourceText);
+
+        private class EmptyMappingService : IRazorSpanMappingService
+        {
+            public Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
+            {
+                var result = Enumerable.Empty<RazorMappedSpanResult>().ToImmutableArray();
+                return Task.FromResult(result);
+            }
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -14,14 +14,33 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.AspNetCore.Razor.Language;
+using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
 {
+    [UseExportProvider]
     public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
     {
         public DelegatedCompletionItemResolverTest()
         {
-            ClientCapabilities = new VSInternalClientCapabilities();
+            ClientCapabilities = new VSInternalClientCapabilities()
+            {
+                TextDocument = new()
+                {
+                    Completion = new VSInternalCompletionSetting()
+                    {
+                        CompletionList = new()
+                        {
+                            Data = true,
+                        }
+                    }
+                }
+            };
             var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml");
             CSharpCompletionParams = new DelegatedCompletionParams(documentContext.Identifier, new Position(10, 6), RazorLanguageKind.CSharp, new VSInternalCompletionContext(), ProvisionalTextEdit: null);
             HtmlCompletionParams = new DelegatedCompletionParams(documentContext.Identifier, new Position(0, 0), RazorLanguageKind.Html, new VSInternalCompletionContext(), ProvisionalTextEdit: null);
@@ -37,7 +56,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         public async Task ResolveAsync_CanNotFindCompletionItem_Noops()
         {
             // Arrange
-            var server = TestItemResolverServer.Create();
+            var server = TestDelegatedCompletionItemResolverServer.Create();
             var resolver = new DelegatedCompletionItemResolver(server);
             var item = new VSInternalCompletionItem();
             var notContainingCompletionList = new VSInternalCompletionList();
@@ -54,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         public async Task ResolveAsync_UnknownRequestContext_Noops()
         {
             // Arrange
-            var server = TestItemResolverServer.Create();
+            var server = TestDelegatedCompletionItemResolverServer.Create();
             var resolver = new DelegatedCompletionItemResolver(server);
             var item = new VSInternalCompletionItem();
             var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, } };
@@ -71,7 +90,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         public async Task ResolveAsync_UsesItemsData()
         {
             // Arrange
-            var server = TestItemResolverServer.Create();
+            var server = TestDelegatedCompletionItemResolverServer.Create();
             var resolver = new DelegatedCompletionItemResolver(server);
             var expectedData = new object();
             var item = new VSInternalCompletionItem()
@@ -92,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         public async Task ResolveAsync_InheritsOriginalCompletionListData()
         {
             // Arrange
-            var server = TestItemResolverServer.Create();
+            var server = TestDelegatedCompletionItemResolverServer.Create();
             var resolver = new DelegatedCompletionItemResolver(server);
             var item = new VSInternalCompletionItem();
             var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, }, Data = new object() };
@@ -109,21 +128,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         [Fact]
         public async Task ResolveAsync_CSharp_Resolves()
         {
-            // Arrange
-            var expectedResolvedItem = new VSInternalCompletionItem();
-            var server = TestItemResolverServer.Create(expectedResolvedItem);
-            var resolver = new DelegatedCompletionItemResolver(server);
-            var item = new VSInternalCompletionItem();
-            var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, } };
-            var originalRequestContext = new DelegatedCompletionResolutionContext(CSharpCompletionParams, new object());
-
-            // Act
-            var resolvedItem = await resolver.ResolveAsync(item, containingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None);
+            // Arrange & Act
+            var resolvedItem = await ResolveCompletionItemAsync("@$$", itemToResolve: "typeof", CancellationToken.None).ConfigureAwait(false);
 
             // Assert
-            Assert.Same(CSharpCompletionParams.HostDocument, server.DelegatedParams.HostDocument);
-            Assert.Equal(RazorLanguageKind.CSharp, server.DelegatedParams.OriginatingKind);
-            Assert.Same(expectedResolvedItem, resolvedItem);
+            Assert.NotNull(resolvedItem.Description);
         }
 
         [Fact]
@@ -131,7 +140,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
         {
             // Arrange
             var expectedResolvedItem = new VSInternalCompletionItem();
-            var server = TestItemResolverServer.Create(expectedResolvedItem);
+            var server = TestDelegatedCompletionItemResolverServer.Create(expectedResolvedItem);
             var resolver = new DelegatedCompletionItemResolver(server);
             var item = new VSInternalCompletionItem();
             var containingCompletionList = new VSInternalCompletionList() { Items = new[] { item, } };
@@ -146,11 +155,66 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             Assert.Same(expectedResolvedItem, resolvedItem);
         }
 
-        internal class TestItemResolverServer : TestOmnisharpLanguageServer
+        private async Task<VSInternalCompletionItem> ResolveCompletionItemAsync(string content, string itemToResolve, CancellationToken none)
         {
-            private readonly DelegatedCompletionResolveRequestHandler _requestHandler;
+            TestFileMarkupParser.GetPosition(content, out var documentContent, out var cursorPosition);
+            var codeDocument = CreateCodeDocument(documentContent);
+            await using var csharpServer = await CreateCSharpServerAsync(codeDocument).ConfigureAwait(false);
 
-            private TestItemResolverServer(DelegatedCompletionResolveRequestHandler requestHandler) : base(new Dictionary<string, Func<object, Task<object>>>()
+            var server = TestDelegatedCompletionItemResolverServer.Create(csharpServer);
+            var resolver = new DelegatedCompletionItemResolver(server);
+            var (containingCompletionList, csharpCompletionParams) = await GetCompletionListAndOriginalParamsAsync(cursorPosition, codeDocument, csharpServer).ConfigureAwait(false);
+
+            var originalRequestContext = new DelegatedCompletionResolutionContext(csharpCompletionParams, containingCompletionList.Data);
+            var item = (VSInternalCompletionItem)containingCompletionList.Items.FirstOrDefault(item => item.Label == itemToResolve);
+
+            if (item is null)
+            {
+                throw new XunitException($"Could not locate completion item '{item.Label}' for completion resolve test");
+            }
+
+            var resolvedItem = await resolver.ResolveAsync(item, containingCompletionList, originalRequestContext, ClientCapabilities, CancellationToken.None).ConfigureAwait(false);
+            return resolvedItem;
+        }
+
+        private async Task<CSharpTestLspServer> CreateCSharpServerAsync(RazorCodeDocument codeDocument)
+        {
+            var csharpSourceText = codeDocument.GetCSharpSourceText();
+            var csharpDocumentUri = new Uri("C:/path/to/file.razor__virtual.g.cs");
+            var serverCapabilities = new ServerCapabilities()
+            {
+                CompletionProvider = new CompletionOptions
+                {
+                    ResolveProvider = true,
+                    TriggerCharacters = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", "~" }
+                }
+            };
+            var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(csharpSourceText, csharpDocumentUri, serverCapabilities).ConfigureAwait(false);
+
+            await csharpServer.OpenDocumentAsync(csharpDocumentUri, csharpSourceText.ToString()).ConfigureAwait(false);
+
+            return csharpServer;
+        }
+
+        private async Task<(VSInternalCompletionList, DelegatedCompletionParams)> GetCompletionListAndOriginalParamsAsync(
+            int cursorPosition,
+            RazorCodeDocument codeDocument,
+            CSharpTestLspServer csharpServer)
+        {
+            var completionContext = new VSInternalCompletionContext() { TriggerKind = CompletionTriggerKind.Invoked };
+            var documentContext = TestDocumentContext.From("C:/path/to/file.razor", codeDocument, hostDocumentVersion: 1337);
+            var provider = TestDelegatedCompletionListProvider.Create(csharpServer);
+
+            var completionList = await provider.GetCompletionListAsync(cursorPosition, completionContext, documentContext, ClientCapabilities, CancellationToken.None).ConfigureAwait(false);
+
+            return (completionList, provider.DelegatedParams);
+        }
+
+        internal class TestDelegatedCompletionItemResolverServer : TestOmnisharpLanguageServer
+        {
+            private readonly CompletionResolveRequestResponseFactory _requestHandler;
+
+            private TestDelegatedCompletionItemResolverServer(CompletionResolveRequestResponseFactory requestHandler) : base(new Dictionary<string, Func<object, Task<object>>>()
             {
                 [LanguageServerConstants.RazorCompletionResolveEndpointName] = requestHandler.OnDelegationAsync,
             })
@@ -160,31 +224,73 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
 
             public DelegatedCompletionItemResolveParams DelegatedParams => _requestHandler.DelegatedParams;
 
-            public static TestItemResolverServer Create(VSInternalCompletionItem resolveResponse = null)
+            public static TestDelegatedCompletionItemResolverServer Create(CSharpTestLspServer csharpServer)
             {
-                resolveResponse ??= new VSInternalCompletionItem();
-                var requestResponseFactory = new DelegatedCompletionResolveRequestHandler(resolveResponse);
-                var provider = new TestItemResolverServer(requestResponseFactory);
+                var requestHandler = new DelegatedCSharpCompletionRequestHandler(csharpServer);
+                var provider = new TestDelegatedCompletionItemResolverServer(requestHandler);
                 return provider;
             }
 
-            private class DelegatedCompletionResolveRequestHandler
+            public static TestDelegatedCompletionItemResolverServer Create(VSInternalCompletionItem resolveResponse = null)
+            {
+                resolveResponse ??= new VSInternalCompletionItem();
+                var requestResponseFactory = new StaticCompletionResolveRequestHandler(resolveResponse);
+                var provider = new TestDelegatedCompletionItemResolverServer(requestResponseFactory);
+                return provider;
+            }
+
+            private class StaticCompletionResolveRequestHandler : CompletionResolveRequestResponseFactory
             {
                 private readonly VSInternalCompletionItem _resolveResponse;
+                private DelegatedCompletionItemResolveParams _delegatedParams;
 
-                public DelegatedCompletionResolveRequestHandler(VSInternalCompletionItem resolveResponse)
+                public StaticCompletionResolveRequestHandler(VSInternalCompletionItem resolveResponse)
                 {
                     _resolveResponse = resolveResponse;
                 }
 
-                public DelegatedCompletionItemResolveParams DelegatedParams { get; private set; }
+                public override DelegatedCompletionItemResolveParams DelegatedParams => _delegatedParams;
 
-                public Task<object> OnDelegationAsync(object parameters)
+                public override Task<object> OnDelegationAsync(object parameters)
                 {
-                    DelegatedParams = (DelegatedCompletionItemResolveParams)parameters;
+                    var resolveParams = (DelegatedCompletionItemResolveParams)parameters;
+                    _delegatedParams = resolveParams;
 
                     return Task.FromResult<object>(_resolveResponse);
                 }
+            }
+
+            private class DelegatedCSharpCompletionRequestHandler : CompletionResolveRequestResponseFactory
+            {
+                private readonly CSharpTestLspServer _csharpServer;
+                private DelegatedCompletionItemResolveParams _delegatedParams;
+
+                public DelegatedCSharpCompletionRequestHandler(CSharpTestLspServer csharpServer)
+                {
+                    _csharpServer = csharpServer;
+                }
+
+                public override DelegatedCompletionItemResolveParams DelegatedParams => _delegatedParams;
+
+                public override async Task<object> OnDelegationAsync(object parameters)
+                {
+                    var resolveParams = (DelegatedCompletionItemResolveParams)parameters;
+                    _delegatedParams = resolveParams;
+                    
+                    var resolvedCompletionItem = await _csharpServer.ExecuteRequestAsync<VSInternalCompletionItem, VSInternalCompletionItem>(
+                        Methods.TextDocumentCompletionResolveName,
+                        _delegatedParams.CompletionItem,
+                        CancellationToken.None).ConfigureAwait(false);
+
+                    return resolvedCompletionItem;
+                }
+            }
+
+            private abstract class CompletionResolveRequestResponseFactory
+            {
+                public abstract DelegatedCompletionItemResolveParams DelegatedParams { get; }
+
+                public abstract Task<object> OnDelegationAsync(object parameters);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
                 }
             };
             await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-                csharpSourceText, csharpDocumentUri, serverCapabilities, new EmptyMappingService()).ConfigureAwait(false);
+                csharpSourceText, csharpDocumentUri, serverCapabilities).ConfigureAwait(false);
 
             await csharpServer.OpenDocumentAsync(csharpDocumentUri, csharpSourceText.ToString()).ConfigureAwait(false);
 
@@ -291,15 +291,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
 
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: cursorPosition, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
             return completionList;
-        }
-
-        private class EmptyMappingService : IRazorSpanMappingService
-        {
-            public Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
-            {
-                var result = Enumerable.Empty<RazorMappedSpanResult>().ToImmutableArray();
-                return Task.FromResult(result);
-            }
         }
     }
 }


### PR DESCRIPTION
- Updated C# portions of our delegated completion list provider tests to utilze the real C# server and simplified the testing model.
- Maintained a lot of pre-existing tests because we don't have similar capabilities for HTML
- These tests will be more widely used upon completion of #6618 where we'll want to resolve text edits (this is a leadup).

Part of #6618