### PR TITLE
Fix `FormatSnippetAsync` to properly format C# snippets.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -36,6 +36,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public const string RazorCompletionEndpointName = "razor/completion";
 
         public const string RazorCompletionResolveEndpointName = "razor/completionItem/resolve";
+        
+        public const string RazorGetFormattingOptionsEndpointName = "razor/formatting/options";
 
         // RZLS Custom Message Targets
         public const string RazorUpdateCSharpBufferEndpoint = "razor/updateCSharpBuffer";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -96,13 +96,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             {
                 return resolvedCompletionItem;
             }
-            
-            // TODO: Pull active formatting options from client.
-            var formattingOptions = new FormattingOptions()
+
+            var delegatedRequest = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorGetFormattingOptionsEndpointName, documentContext.Identifier).ConfigureAwait(false);
+            var formattingOptions = await delegatedRequest.Returning<FormattingOptions?>(cancellationToken).ConfigureAwait(false);
+            if (formattingOptions is null)
             {
-                InsertSpaces = true,
-                TabSize = 4,
-            };
+                return resolvedCompletionItem;
+            }
 
             if (resolvedCompletionItem.TextEdit is not null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             Uri uri,
             DocumentSnapshot documentSnapshot,
             RazorLanguageKind kind,
-            TextEdit[] formattedEdits,
+            TextEdit[] edits,
             FormattingOptions options,
             CancellationToken cancellationToken);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageEndpoint.cs
@@ -205,17 +205,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
             else if (request.TextEditKind == TextEditKind.Snippet)
             {
-                if (request.Kind == RazorLanguageKind.CSharp)
-                {
-                    WrapCSharpSnippets(request.ProjectedTextEdits);
-                }
-
                 var mappedEdits = await _razorFormattingService.FormatSnippetAsync(request.RazorDocumentUri, documentContext.Snapshot, request.Kind, request.ProjectedTextEdits, request.FormattingOptions, cancellationToken);
-
-                if (request.Kind == RazorLanguageKind.CSharp)
-                {
-                    UnwrapCSharpSnippets(mappedEdits);
-                }
 
                 return new RazorMapToDocumentEditsResponse()
                 {
@@ -258,31 +248,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 TextEdits = edits.ToArray(),
                 HostDocumentVersion = documentContext.Version,
             };
-
-            static void WrapCSharpSnippets(TextEdit[] snippetEdits)
-            {
-                for (var i = 0; i < snippetEdits.Length; i++)
-                {
-                    var snippetEdit = snippetEdits[i];
-
-                    // Formatting doesn't work with syntax errors caused by the cursor marker ($0).
-                    // So, let's avoid the error by wrapping the cursor marker in a comment.
-                    var wrappedText = snippetEdit.NewText.Replace("$0", "/*$0*/");
-                    snippetEdit.NewText = wrappedText;
-                }
-            }
-
-            static void UnwrapCSharpSnippets(TextEdit[] snippetEdits)
-            {
-                for (var i = 0; i < snippetEdits.Length; i++)
-                {
-                    var snippetEdit = snippetEdits[i];
-
-                    // Unwrap the cursor marker.
-                    var unwrappedText = snippetEdit.NewText.Replace("/*$0*/", "$0");
-                    snippetEdit.NewText = unwrappedText;
-                }
-            }
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FormattingOptionsProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FormattingOptionsProvider.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 {
     public abstract class FormattingOptionsProvider
     {
-        public abstract FormattingOptions GetOptions(LSPDocumentSnapshot documentSnapshot);
+        public abstract FormattingOptions? GetOptions(Uri uri);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -320,7 +320,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             TextExtent wordExtent,
             CompletionList completionList)
         {
-            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot);
+            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot.Uri);
+            if (formattingOptions is null)
+            {
+                return completionList;
+            }
 
             if (IsSimpleImplicitExpression(request, documentSnapshot, wordExtent))
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -148,7 +148,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             _logger.LogInformation("Start formatting text edit.");
 
-            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot);
+            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot.Uri);
+            if (formattingOptions is null)
+            {
+                return resolvedCompletionItem;
+            }
+
             if (resolvedCompletionItem.TextEdit != null)
             {
                 var containsSnippet = resolvedCompletionItem.InsertTextFormat == InsertTextFormat.Snippet;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -90,5 +91,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [JsonRpcMethod(LanguageServerConstants.RazorCompletionResolveEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<JToken?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams completionResolveParams, CancellationToken cancellationToken);
+
+        [JsonRpcMethod(LanguageServerConstants.RazorGetFormattingOptionsEndpointName, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<FormattingOptions?> GetFormattingOptionsAsync(TextDocumentIdentifier document, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.CodeAnalysis;
@@ -35,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
             var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
             Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>())).Verifiable();
             Mock.Get(logger).Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(false);
-            LoggerFactory = Mock.Of<ILoggerFactory>(factory => factory.CreateLogger(It.IsAny<string>()) == logger, MockBehavior.Strict);
+            LoggerFactory = TestLoggerFactory.Instance;
             Serializer = new LspSerializer();
             Serializer.RegisterRazorConverters();
             Serializer.RegisterVSInternalExtensionConverters();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 
         public override IReadOnlyList<DocumentSnapshot> GetImports()
         {
-            throw new NotImplementedException();
+            return Array.Empty<DocumentSnapshot>();
         }
 
         public override bool TryGetGeneratedOutput(out RazorCodeDocument result)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 
         public override RazorProjectEngine GetProjectEngine()
         {
-            throw new NotImplementedException();
+            return RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Create("C:/"));
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -263,6 +263,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             private TestDelegatedCompletionItemResolverServer(CompletionResolveRequestResponseFactory requestHandler) : base(new Dictionary<string, Func<object, Task<object>>>()
             {
                 [LanguageServerConstants.RazorCompletionResolveEndpointName] = requestHandler.OnCompletionResolveDelegationAsync,
+                [LanguageServerConstants.RazorGetFormattingOptionsEndpointName] = requestHandler.OnGetFormattingOptionsAsync,
             })
             {
                 _requestHandler = requestHandler;
@@ -337,6 +338,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
                 public abstract DelegatedCompletionItemResolveParams DelegatedParams { get; }
 
                 public abstract Task<object> OnCompletionResolveDelegationAsync(object parameters);
+
+                public Task<object> OnGetFormattingOptionsAsync(object parameters)
+                {
+                    var formattingOptions = new FormattingOptions()
+                    {
+                        InsertSpaces = true,
+                        TabSize = 4,
+                    };
+                    return Task.FromResult<object>(formattingOptions);
+                }
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             return monitor.Object;
         }
 
-        internal class TestRazorFormattingService : RazorFormattingService
+        internal class DummyRazorFormattingService : RazorFormattingService
         {
             public bool Called { get; private set; }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var uri = new Uri("file://path/test.razor");
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(new Uri("file://path/testDifferentFile.razor"), codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
             documentMappingService.Setup(s => s.GetLanguageKind(codeDocument, 17, false)).Returns(RazorLanguageKind.Html);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
             documentMappingService.Setup(s => s.GetLanguageKind(codeDocument, 17, false)).Returns(RazorLanguageKind.Razor);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = TestRazorCodeDocument.CreateEmpty();
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 documentContextFactory, formattingService, optionsMonitor);
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_DocumentNotFound_ReturnsNull()
         {
             // Arrange
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 EmptyDocumentContextFactory, formattingService, optionsMonitor);
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             codeDocument.SetUnsupported();
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 documentContextFactory, formattingService, optionsMonitor);
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_FormattingDisabled_ReturnsNull()
         {
             // Arrange
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 EmptyDocumentContextFactory, formattingService, optionsMonitor);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.AspNetCore.Razor.Test.Common;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class TestRazorFormattingService
+    {
+        public static readonly RazorFormattingService Instance = CreateWithFullSupport(TestRazorCodeDocument.CreateEmpty());
+
+        private TestRazorFormattingService()
+        {
+        }
+
+        public static RazorFormattingService CreateWithFullSupport(RazorCodeDocument codeDocument)
+        {
+            var mappingService = new DefaultRazorDocumentMappingService(TestLoggerFactory.Instance);
+
+            var dispatcher = new LSPProjectSnapshotManagerDispatcher(TestLoggerFactory.Instance);
+            var versionCache = new DefaultDocumentVersionCache(dispatcher);
+
+            var client = new FormattingLanguageServerClient();
+            client.AddCodeDocument(codeDocument);
+
+            var passes = new List<IFormattingPass>()
+            {
+                new HtmlFormattingPass(mappingService, FilePathNormalizer.Instance, client, versionCache, TestLoggerFactory.Instance),
+                new CSharpFormattingPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new CSharpOnTypeFormattingPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new RazorFormattingPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new FormattingDiagnosticValidationPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new FormattingContentValidationPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+            };
+
+            return new DefaultRazorFormattingService(passes, TestLoggerFactory.Instance, TestAdhocWorkspaceFactory.Instance);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
             var request = new CodeActionParams()
             {
                 TextDocument = new LanguageServer.Protocol.TextDocumentIdentifier()
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
             var codeAction = new VSInternalCodeAction()
             {
                 Title = "Something",
@@ -463,7 +463,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
             var request = new ProvideSemanticTokensRangeParams(
                 textDocument: new TextDocumentIdentifier()
                 {
@@ -518,7 +518,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             // Act
             await target.RazorServerReadyAsync(CancellationToken.None);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -1307,23 +1307,5 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await completionHandler.HandleRequestAsync(completionParams, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
             return result;
         }
-
-        private class TestFormattingOptionsProvider : FormattingOptionsProvider
-        {
-            public static readonly TestFormattingOptionsProvider Default = new(
-                new FormattingOptions()
-                {
-                    InsertSpaces = true,
-                    TabSize = 4,
-                });
-            private readonly FormattingOptions _options;
-
-            public TestFormattingOptionsProvider(FormattingOptions options)
-            {
-                _options = options;
-            }
-
-            public override FormattingOptions GetOptions(LSPDocumentSnapshot documentSnapshot) => _options;
-        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -26,7 +26,6 @@ using CompletionItem = Microsoft.VisualStudio.LanguageServer.Protocol.Completion
 using CompletionOptions = Microsoft.VisualStudio.LanguageServer.Protocol.CompletionOptions;
 using CompletionParams = Microsoft.VisualStudio.LanguageServer.Protocol.CompletionParams;
 using CompletionTriggerKind = Microsoft.VisualStudio.LanguageServer.Protocol.CompletionTriggerKind;
-using FormattingOptions = Microsoft.VisualStudio.LanguageServer.Protocol.FormattingOptions;
 using Position = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
 using TextDocumentIdentifier = Microsoft.VisualStudio.LanguageServer.Protocol.TextDocumentIdentifier;
 
@@ -61,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         private TestLSPDocumentMappingProvider DocumentMappingProvider { get; } = new();
 
-        private TestFormattingOptionsProvider FormattingOptionsProvider { get; } = new();
+        private FormattingOptionsProvider FormattingOptionsProvider { get; } = TestFormattingOptionsProvider.Default;
 
         private CompletionRequestContextCache CompletionRequestContextCache { get; } = new();
 
@@ -316,11 +315,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 OriginalData = originalData,
             };
             item.Data = data;
-        }
-
-        private class TestFormattingOptionsProvider : FormattingOptionsProvider
-        {
-            public override FormattingOptions GetOptions(LSPDocumentSnapshot documentSnapshot) => new FormattingOptions();
         }
 
         private record CompletionResolveResponse(VSInternalCompletionItem UnresolvedItem, VSInternalCompletionItem ResolvedItem, int TextEditRemapCount);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestFormattingOptionsProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestFormattingOptionsProvider.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
+{
+    internal class TestFormattingOptionsProvider : FormattingOptionsProvider
+    {
+        public static readonly TestFormattingOptionsProvider Default = new(
+            new FormattingOptions()
+            {
+                InsertSpaces = true,
+                TabSize = 4,
+            });
+        private readonly FormattingOptions _options;
+
+        public TestFormattingOptionsProvider(FormattingOptions options)
+        {
+            _options = options;
+        }
+
+        public override FormattingOptions? GetOptions(Uri uri) => _options;
+    }
+}


### PR DESCRIPTION
- Prior to this C# snippets were wrapped/unwrapped at the endpoint layer. This means anyone trying to format a snippet would need to manually wrap/unwrap their own snippets. The logic fit well into the existing formatting service so I migrated the logic there.
- Another aspect of this that's a little disconnected is that when applying formatted snippet edits I found that edits wouldn't get "minimialized" prior to collapsing which would result in unminified edits returning to the client. At completion time (what I will eventually be doing as part of #6618) this was highly troublesome because completion is sensitive to the "end of the edit" area. Meaning if you complete `await` and the await has a complex text edit that gets formatted the `t` in `await` needs to be the absolute last thing in the edit to not obstruct the cursor; however, without the minimal edit change that doesn't actually work properly. I imagine this was just an unintentional oversight and wasn't quite sure how to test this (although I do test it in the completion resolve tests that are coming latere) so I included it here.
- Currently there's no direct tests of this method it looks like. Although in a follow up PR for #6618 I'll be formatting resolved completion items.

Part of #6618