### PR TITLE
Add support for remapping TextEdits & AdditionalTextEdits at resolve time.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.CodeAnalysis;
@@ -35,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
             var logger = new Mock<ILogger>(MockBehavior.Strict).Object;
             Mock.Get(logger).Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>())).Verifiable();
             Mock.Get(logger).Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(false);
-            LoggerFactory = Mock.Of<ILoggerFactory>(factory => factory.CreateLogger(It.IsAny<string>()) == logger, MockBehavior.Strict);
+            LoggerFactory = TestLoggerFactory.Instance;
             Serializer = new LspSerializer();
             Serializer.RegisterRazorConverters();
             Serializer.RegisterVSInternalExtensionConverters();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 
         public override IReadOnlyList<DocumentSnapshot> GetImports()
         {
-            throw new NotImplementedException();
+            return Array.Empty<DocumentSnapshot>();
         }
 
         public override bool TryGetGeneratedOutput(out RazorCodeDocument result)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 
         public override RazorProjectEngine GetProjectEngine()
         {
-            throw new NotImplementedException();
+            return RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Create("C:/"));
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             return monitor.Object;
         }
 
-        internal class TestRazorFormattingService : RazorFormattingService
+        internal class DummyRazorFormattingService : RazorFormattingService
         {
             public bool Called { get; private set; }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 InsertSpaces = insertSpaces,
             };
 
-            var formattingService = TestRazorFormattingService.CreateWithHtmlSupport(codeDocument);
+            var formattingService = TestRazorFormattingService.CreateWithFullSupport(codeDocument);
 
             // Act
             var edits = await formattingService.FormatAsync(uri, documentSnapshot, range, options, CancellationToken.None);
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var languageKind = mappingService.GetLanguageKind(codeDocument, positionAfterTrigger, rightAssociative: false);
 
-            var formattingService = TestRazorFormattingService.CreateWithHtmlSupport(codeDocument);
+            var formattingService = TestRazorFormattingService.CreateWithFullSupport(codeDocument);
             var options = new FormattingOptions()
             {
                 TabSize = tabSize,
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new InvalidOperationException("Could not map from Razor document to generated document");
             }
 
-            var formattingService = TestRazorFormattingService.CreateWithHtmlSupport(codeDocument);
+            var formattingService = TestRazorFormattingService.CreateWithFullSupport(codeDocument);
             var options = new FormattingOptions()
             {
                 TabSize = tabSize,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -94,7 +93,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 InsertSpaces = insertSpaces,
             };
 
-            var formattingService = CreateFormattingService(codeDocument);
+            var formattingService = TestRazorFormattingService.CreateWithHtmlSupport(codeDocument);
 
             // Act
             var edits = await formattingService.FormatAsync(uri, documentSnapshot, range, options, CancellationToken.None);
@@ -133,7 +132,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var languageKind = mappingService.GetLanguageKind(codeDocument, positionAfterTrigger, rightAssociative: false);
 
-            var formattingService = CreateFormattingService(codeDocument);
+            var formattingService = TestRazorFormattingService.CreateWithHtmlSupport(codeDocument);
             var options = new FormattingOptions()
             {
                 TabSize = tabSize,
@@ -200,7 +199,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new InvalidOperationException("Could not map from Razor document to generated document");
             }
 
-            var formattingService = CreateFormattingService(codeDocument);
+            var formattingService = TestRazorFormattingService.CreateWithHtmlSupport(codeDocument);
             var options = new FormattingOptions()
             {
                 TabSize = tabSize,
@@ -227,28 +226,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 },
                 NewText = newText,
             };
-
-        private RazorFormattingService CreateFormattingService(RazorCodeDocument codeDocument)
-        {
-            var mappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
-
-            var dispatcher = new LSPProjectSnapshotManagerDispatcher(LoggerFactory);
-            var versionCache = new DefaultDocumentVersionCache(dispatcher);
-
-            var client = new FormattingLanguageServerClient();
-            client.AddCodeDocument(codeDocument);
-            var passes = new List<IFormattingPass>()
-            {
-                new HtmlFormattingPass(mappingService, FilePathNormalizer, client, versionCache, LoggerFactory),
-                new CSharpFormattingPass(mappingService, FilePathNormalizer, client, LoggerFactory),
-                new CSharpOnTypeFormattingPass(mappingService, FilePathNormalizer, client, LoggerFactory),
-                new RazorFormattingPass(mappingService, FilePathNormalizer, client, LoggerFactory),
-                new FormattingDiagnosticValidationPass(mappingService, FilePathNormalizer, client, LoggerFactory),
-                new FormattingContentValidationPass(mappingService, FilePathNormalizer, client, LoggerFactory),
-            };
-
-            return new DefaultRazorFormattingService(passes, LoggerFactory, TestAdhocWorkspaceFactory.Instance);
-        }
 
         private static SourceText ApplyEdits(SourceText source, TextEdit[] edits)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var uri = new Uri("file://path/test.razor");
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(new Uri("file://path/testDifferentFile.razor"), codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
             documentMappingService.Setup(s => s.GetLanguageKind(codeDocument, 17, false)).Returns(RazorLanguageKind.Html);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
             documentMappingService.Setup(s => s.GetLanguageKind(codeDocument, 17, false)).Returns(RazorLanguageKind.Razor);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = CreateCodeDocument(content, sourceMappings);
             var uri = new Uri("file://path/test.razor");
             var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var codeDocument = TestRazorCodeDocument.CreateEmpty();
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 documentContextFactory, formattingService, optionsMonitor);
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_DocumentNotFound_ReturnsNull()
         {
             // Arrange
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 EmptyDocumentContextFactory, formattingService, optionsMonitor);
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             codeDocument.SetUnsupported();
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 documentContextFactory, formattingService, optionsMonitor);
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         public async Task Handle_FormattingDisabled_ReturnsNull()
         {
             // Arrange
-            var formattingService = new TestRazorFormattingService();
+            var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 EmptyDocumentContextFactory, formattingService, optionsMonitor);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
@@ -11,13 +11,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal class TestRazorFormattingService
     {
-        public static readonly RazorFormattingService Instance = CreateWithHtmlSupport(TestRazorCodeDocument.CreateEmpty());
+        public static readonly RazorFormattingService Instance = CreateWithFullSupport(TestRazorCodeDocument.CreateEmpty());
 
         private TestRazorFormattingService()
         {
         }
 
-        public static RazorFormattingService CreateWithHtmlSupport(RazorCodeDocument codeDocument)
+        public static RazorFormattingService CreateWithFullSupport(RazorCodeDocument codeDocument)
         {
             var mappingService = new DefaultRazorDocumentMappingService(TestLoggerFactory.Instance);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.AspNetCore.Razor.Test.Common;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
+{
+    internal class TestRazorFormattingService
+    {
+        public static readonly RazorFormattingService Instance = CreateWithHtmlSupport(TestRazorCodeDocument.CreateEmpty());
+
+        private TestRazorFormattingService()
+        {
+        }
+
+        public static RazorFormattingService CreateWithHtmlSupport(RazorCodeDocument codeDocument)
+        {
+            var mappingService = new DefaultRazorDocumentMappingService(TestLoggerFactory.Instance);
+
+            var dispatcher = new LSPProjectSnapshotManagerDispatcher(TestLoggerFactory.Instance);
+            var versionCache = new DefaultDocumentVersionCache(dispatcher);
+
+            var client = new FormattingLanguageServerClient();
+            client.AddCodeDocument(codeDocument);
+
+            var passes = new List<IFormattingPass>()
+            {
+                new HtmlFormattingPass(mappingService, FilePathNormalizer.Instance, client, versionCache, TestLoggerFactory.Instance),
+                new CSharpFormattingPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new CSharpOnTypeFormattingPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new RazorFormattingPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new FormattingDiagnosticValidationPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+                new FormattingContentValidationPass(mappingService, FilePathNormalizer.Instance, client, TestLoggerFactory.Instance),
+            };
+
+            return new DefaultRazorFormattingService(passes, TestLoggerFactory.Instance, TestAdhocWorkspaceFactory.Instance);
+        }
+    }
+}


### PR DESCRIPTION
- Migrated our old `CompletionResolutionHandler` logic for post-processing C# completion items to our new single server completion system.
    - One current gap is that the old system used to lookup active formatting options on the client to understand if snippets should be formatted with/without tabs etc. For now I'm using defaults but in a follow up PR i'll light up the real formatting options acquisition logic.
- As part of this PR there were several pieces of code that could be re-used so I refactored them out. The `TestRazorFormattingService` is a prime example (especially now that completion resolve depends on it).
    - Did a few updates to the API so it was clear what type of formatting service you'd be getting (aka should it be HTML enabled?).
- Added a test that validates that we get and remap text edit completions properly (I use `await`). I couldn't find a corresponding C# completion item that utilizes `AdditionalTextEdit`s.

## Enables

![gif of await and override completion working](https://i.imgur.com/EAwqM3j.gif)

Most of #6618