### PR TITLE
Add support for acquiring formatting options from client.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/LanguageServerConstants.cs
@@ -36,6 +36,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public const string RazorCompletionEndpointName = "razor/completion";
 
         public const string RazorCompletionResolveEndpointName = "razor/completionItem/resolve";
+        
+        public const string RazorGetFormattingOptionsEndpointName = "razor/formatting/options";
 
         // RZLS Custom Message Targets
         public const string RazorUpdateCSharpBufferEndpoint = "razor/updateCSharpBuffer";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -96,13 +96,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             {
                 return resolvedCompletionItem;
             }
-            
-            // TODO: Pull active formatting options from client.
-            var formattingOptions = new FormattingOptions()
+
+            var delegatedRequest = await _languageServer.SendRequestAsync(LanguageServerConstants.RazorGetFormattingOptionsEndpointName, documentContext.Identifier).ConfigureAwait(false);
+            var formattingOptions = await delegatedRequest.Returning<FormattingOptions?>(cancellationToken).ConfigureAwait(false);
+            if (formattingOptions is null)
             {
-                InsertSpaces = true,
-                TabSize = 4,
-            };
+                return resolvedCompletionItem;
+            }
 
             if (resolvedCompletionItem.TextEdit is not null)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FormattingOptionsProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/FormattingOptionsProvider.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
 {
     public abstract class FormattingOptionsProvider
     {
-        public abstract FormattingOptions GetOptions(LSPDocumentSnapshot documentSnapshot);
+        public abstract FormattingOptions? GetOptions(Uri uri);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionHandler.cs
@@ -320,7 +320,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             TextExtent wordExtent,
             CompletionList completionList)
         {
-            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot);
+            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot.Uri);
+            if (formattingOptions is null)
+            {
+                return completionList;
+            }
 
             if (IsSimpleImplicitExpression(request, documentSnapshot, wordExtent))
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/CompletionResolveHandler.cs
@@ -148,7 +148,12 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             _logger.LogInformation("Start formatting text edit.");
 
-            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot);
+            var formattingOptions = _formattingOptionsProvider.GetOptions(documentSnapshot.Uri);
+            if (formattingOptions is null)
+            {
+                return resolvedCompletionItem;
+            }
+
             if (resolvedCompletionItem.TextEdit != null)
             {
                 var containsSnippet = resolvedCompletionItem.InsertTextFormat == InsertTextFormat.Snippet;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -90,5 +91,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [JsonRpcMethod(LanguageServerConstants.RazorCompletionResolveEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<JToken?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams completionResolveParams, CancellationToken cancellationToken);
+
+        [JsonRpcMethod(LanguageServerConstants.RazorGetFormattingOptionsEndpointName, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<FormattingOptions?> GetFormattingOptionsAsync(TextDocumentIdentifier document, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -263,6 +263,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             private TestDelegatedCompletionItemResolverServer(CompletionResolveRequestResponseFactory requestHandler) : base(new Dictionary<string, Func<object, Task<object>>>()
             {
                 [LanguageServerConstants.RazorCompletionResolveEndpointName] = requestHandler.OnCompletionResolveDelegationAsync,
+                [LanguageServerConstants.RazorGetFormattingOptionsEndpointName] = requestHandler.OnGetFormattingOptionsAsync,
             })
             {
                 _requestHandler = requestHandler;
@@ -337,6 +338,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
                 public abstract DelegatedCompletionItemResolveParams DelegatedParams { get; }
 
                 public abstract Task<object> OnCompletionResolveDelegationAsync(object parameters);
+
+                public Task<object> OnGetFormattingOptionsAsync(object parameters)
+                {
+                    var formattingOptions = new FormattingOptions()
+                    {
+                        InsertSpaces = true,
+                        TabSize = 4,
+                    };
+                    return Task.FromResult<object>(formattingOptions);
+                }
             }
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             var request = new RazorDocumentRangeFormattingParams()
             {
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
             var request = new CodeActionParams()
             {
                 TextDocument = new LanguageServer.Protocol.TextDocumentIdentifier()
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
             var codeAction = new VSInternalCodeAction()
             {
                 Title = "Something",
@@ -463,7 +463,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
             var request = new ProvideSemanticTokensRangeParams(
                 textDocument: new TextDocumentIdentifier()
                 {
@@ -518,7 +518,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
-                uIContextManager.Object, disposable.Object, EditorSettingsManager, documentSynchronizer.Object);
+                uIContextManager.Object, disposable.Object, TestFormattingOptionsProvider.Default, EditorSettingsManager, documentSynchronizer.Object);
 
             // Act
             await target.RazorServerReadyAsync(CancellationToken.None);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -1307,23 +1307,5 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             var result = await completionHandler.HandleRequestAsync(completionParams, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
             return result;
         }
-
-        private class TestFormattingOptionsProvider : FormattingOptionsProvider
-        {
-            public static readonly TestFormattingOptionsProvider Default = new(
-                new FormattingOptions()
-                {
-                    InsertSpaces = true,
-                    TabSize = 4,
-                });
-            private readonly FormattingOptions _options;
-
-            public TestFormattingOptionsProvider(FormattingOptions options)
-            {
-                _options = options;
-            }
-
-            public override FormattingOptions GetOptions(LSPDocumentSnapshot documentSnapshot) => _options;
-        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -26,7 +26,6 @@ using CompletionItem = Microsoft.VisualStudio.LanguageServer.Protocol.Completion
 using CompletionOptions = Microsoft.VisualStudio.LanguageServer.Protocol.CompletionOptions;
 using CompletionParams = Microsoft.VisualStudio.LanguageServer.Protocol.CompletionParams;
 using CompletionTriggerKind = Microsoft.VisualStudio.LanguageServer.Protocol.CompletionTriggerKind;
-using FormattingOptions = Microsoft.VisualStudio.LanguageServer.Protocol.FormattingOptions;
 using Position = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
 using TextDocumentIdentifier = Microsoft.VisualStudio.LanguageServer.Protocol.TextDocumentIdentifier;
 
@@ -61,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         private TestLSPDocumentMappingProvider DocumentMappingProvider { get; } = new();
 
-        private TestFormattingOptionsProvider FormattingOptionsProvider { get; } = new();
+        private FormattingOptionsProvider FormattingOptionsProvider { get; } = TestFormattingOptionsProvider.Default;
 
         private CompletionRequestContextCache CompletionRequestContextCache { get; } = new();
 
@@ -316,11 +315,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 OriginalData = originalData,
             };
             item.Data = data;
-        }
-
-        private class TestFormattingOptionsProvider : FormattingOptionsProvider
-        {
-            public override FormattingOptions GetOptions(LSPDocumentSnapshot documentSnapshot) => new FormattingOptions();
         }
 
         private record CompletionResolveResponse(VSInternalCompletionItem UnresolvedItem, VSInternalCompletionItem ResolvedItem, int TextEditRemapCount);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestFormattingOptionsProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestFormattingOptionsProvider.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Test
+{
+    internal class TestFormattingOptionsProvider : FormattingOptionsProvider
+    {
+        public static readonly TestFormattingOptionsProvider Default = new(
+            new FormattingOptions()
+            {
+                InsertSpaces = true,
+                TabSize = 4,
+            });
+        private readonly FormattingOptions _options;
+
+        public TestFormattingOptionsProvider(FormattingOptions options)
+        {
+            _options = options;
+        }
+
+        public override FormattingOptions? GetOptions(Uri uri) => _options;
+    }
+}


### PR DESCRIPTION
- This is the final part to #6618 to enable completion resolve to acquire formatting options for complex text edits so it can properly format text edits
- We now expose a new endpoint on the client under `razor/formatting/options` that will return the most recent understanding of formatting options
- To make this possible updated the `FormattingOptionsProvider` API to take a `Uri` instead of a document snapshot.
- Updated tests accordingly

Final part of #6618