### PR TITLE
Unskip completion list provider test.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -62,8 +63,15 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
         {
             tagHelpers ??= Array.Empty<TagHelperDescriptor>();
             var sourceDocument = TestRazorSourceDocument.Create(text);
-            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Create("/"), builder => { });
-            var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, "mvc", Array.Empty<RazorSourceDocument>(), tagHelpers);
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Create("C:/"), builder => {
+                RazorExtensions.Register(builder);
+            });
+            var defaultImportDocument = TestRazorSourceDocument.Create(
+                """
+                @using System;
+                """,
+                new RazorSourceDocumentProperties("_ViewImports.cshtml", "_ViewImports.cshtml"));
+            var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, "mvc", new[] { defaultImportDocument }, tagHelpers);
             return codeDocument;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -150,14 +150,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation
             Assert.Contains(completionList.Items, item => item.Label == "System");
         }
 
-        [Fact(Skip = "For some reason trigger based completion items aren't returning any items")]
+        [Fact]
         public async Task CSharp_Operator_Triggered()
         {
             // Arrange & Act
-            var completionList = await GetCompletionListAsync("@if ($$)", CompletionTriggerKind.TriggerCharacter);
+            var completionList = await GetCompletionListAsync("@(DateTime.$$)", CompletionTriggerKind.TriggerCharacter);
 
             // Assert
-            Assert.Contains(completionList.Items, item => item.Label == "true");
+            Assert.Contains(completionList.Items, item => item.Label == "Now");
         }
 
         [Fact]


### PR DESCRIPTION
- The original `CSharp_Operator_Triggered` test was an incorrect scenario. For instance, C# doesn't typically trigger completions off of typing `(`. Instead I migrated the test to do a `DateTime.` variant with `.` being the trigger. The only catch then was that our generated C# document did not contain `using System` so I had to update our generated code document bits to properly generate the using statement.

Part of #6618