### PR TITLE
Fix Razor's C# doc population into the workspace.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioMacDocumentInfoFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioMacDocumentInfoFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public override DocumentInfo CreateEmpty(string razorFilePath, ProjectId projectId)
         {
-            var filename = Path.ChangeExtension(razorFilePath, ".g.cs");
+            var filename = razorFilePath + ".g.cs";
             var textLoader = new EmptyTextLoader(filename);
             var docId = DocumentId.CreateNewId(projectId, debugName: filename);
             return DocumentInfo.Create(


### PR DESCRIPTION
- Not sure why we originally were changing the file extension of our generated documents to not include the Razor file extension. This aligns LSP's understanding of file paths with the dynamic file info understanding. Given how much tribal knowledge / convention is baked into the `.g.cs` ending we should probably build a factory; however, getting that factory to work across all products (VS, VSCode, VSMac) is less than simple. For now here's the quick fix.