### PR TITLE
Fix Extract To Code Behind Produces "__GeneratedComponent" Namespace

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtractToCodeBehindCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/ExtractToCodeBehindCodeActionParams.cs
@@ -14,5 +14,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models
         public int ExtractEnd { get; set; }
         public int RemoveStart { get; set; }
         public int RemoveEnd { get; set; }
+        public string Namespace { get; set; }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -117,6 +117,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var documentPath = new Uri("c:/Test.razor");
             var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private var x = 1; }}";
             var codeDocument = CreateCodeDocument(contents);
+            Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
             var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
             var actionParams = new ExtractToCodeBehindCodeActionParams
@@ -126,6 +127,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
                 ExtractEnd = contents.IndexOf("}", StringComparison.Ordinal),
                 RemoveEnd = contents.IndexOf("}", StringComparison.Ordinal),
+                Namespace = @namespace,
             };
             var data = JObject.FromObject(actionParams);
 
@@ -164,6 +166,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var documentPath = new Uri("c:/Test.razor");
             var contents = $"@page \"/test\"{Environment.NewLine}@functions {{ private var x = 1; }}";
             var codeDocument = CreateCodeDocument(contents);
+            Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
             var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
             var actionParams = new ExtractToCodeBehindCodeActionParams
@@ -173,6 +176,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
                 ExtractEnd = contents.IndexOf("}", StringComparison.Ordinal),
                 RemoveEnd = contents.IndexOf("}", StringComparison.Ordinal),
+                Namespace = @namespace,
             };
             var data = JObject.FromObject(actionParams);
 
@@ -211,6 +215,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var documentPath = new Uri("c:/Test.razor");
             var contents = $"@page \"/test\"\n@using System.Diagnostics{Environment.NewLine}@code {{ private var x = 1; }}";
             var codeDocument = CreateCodeDocument(contents);
+            Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
             var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
             var actionParams = new ExtractToCodeBehindCodeActionParams
@@ -220,6 +225,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
                 ExtractEnd = contents.IndexOf("}", StringComparison.Ordinal),
                 RemoveEnd = contents.IndexOf("}", StringComparison.Ordinal),
+                Namespace = @namespace,
             };
             var data = JObject.FromObject(actionParams);
 


### PR DESCRIPTION
In extract to code behind, there are cases where the setup is not fully ready for the compiler to accurately generate a namespace. Luckily they provide a public extension point to get the namespace for a document, which handles fallback behavior and failure. Use that in the action provider to determine if a namespace is accurately available. If it is, fill the action params with that namespace and use for generating the code rather than recalculating it again. 

Fixes #4441 
