### PR TITLE
Single line directive snippets

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -208,113 +208,130 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             switch (razorCompletionItem.Kind)
             {
                 case RazorCompletionItemKind.Directive:
+                {
+                    var directiveCompletionItem = new VSInternalCompletionItem()
                     {
-                        var directiveCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = CompletionItemKind.Struct,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = CompletionItemKind.Struct,
+                    };
 
-                        directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        if (razorCompletionItem == DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem)
-                        {
-                            directiveCompletionItem.Command = s_retriggerCompletionCommand;
-                            directiveCompletionItem.Kind = tagHelperCompletionItemKind;
-                        }
-
-                        completionItem = directiveCompletionItem;
-                        return true;
+                    if (razorCompletionItem == DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem)
+                    {
+                        directiveCompletionItem.Command = s_retriggerCompletionCommand;
+                        directiveCompletionItem.Kind = tagHelperCompletionItemKind;
                     }
+
+                    completionItem = directiveCompletionItem;
+                    return true;
+                }
+                case RazorCompletionItemKind.DirectiveSnippet:
+                {
+                    var directiveSnippetCompletionItem = new VSInternalCompletionItem()
+                    {
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = CompletionItemKind.Snippet,
+                    };
+
+                    directiveSnippetCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+
+                    completionItem = directiveSnippetCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.DirectiveAttribute:
+                {
+                    var directiveAttributeCompletionItem = new VSInternalCompletionItem()
                     {
-                        var directiveAttributeCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.InsertText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        directiveAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    directiveAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = directiveAttributeCompletionItem;
-                        return true;
-                    }
+                    completionItem = directiveAttributeCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.DirectiveAttributeParameter:
+                {
+                    var parameterCompletionItem = new VSInternalCompletionItem()
                     {
-                        var parameterCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.InsertText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        parameterCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    parameterCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = parameterCompletionItem;
-                        return true;
-                    }
+                    completionItem = parameterCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.MarkupTransition:
+                {
+                    var markupTransitionCompletionItem = new VSInternalCompletionItem()
                     {
-                        var markupTransitionCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        markupTransitionCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    markupTransitionCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = markupTransitionCompletionItem;
-                        return true;
-                    }
+                    completionItem = markupTransitionCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.TagHelperElement:
+                {
+                    var tagHelperElementCompletionItem = new VSInternalCompletionItem()
                     {
-                        var tagHelperElementCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        tagHelperElementCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    tagHelperElementCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = tagHelperElementCompletionItem;
-                        return true;
-                    }
+                    completionItem = tagHelperElementCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.TagHelperAttribute:
+                {
+                    var tagHelperAttributeCompletionItem = new VSInternalCompletionItem()
                     {
-                        var tagHelperAttributeCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        tagHelperAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    tagHelperAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = tagHelperAttributeCompletionItem;
-                        return true;
-                    }
+                    completionItem = tagHelperAttributeCompletionItem;
+                    return true;
+                }
             }
 
             completionItem = null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                         FilterText = razorCompletionItem.DisplayText,
                         SortText = razorCompletionItem.SortText,
                         InsertTextFormat = insertTextFormat,
-                        Kind = CompletionItemKind.Struct,
+                        Kind = razorCompletionItem.IsSnippet ? CompletionItemKind.Snippet : CompletionItemKind.Struct, // TODO: Make separate CompletionItemKind for razor directives. See https://github.com/dotnet/razor-tooling/issues/6504 and https://github.com/dotnet/razor-tooling/issues/6505
                     };
 
                     directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
@@ -228,23 +228,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     }
 
                     completionItem = directiveCompletionItem;
-                    return true;
-                }
-                case RazorCompletionItemKind.DirectiveSnippet:
-                {
-                    var directiveSnippetCompletionItem = new VSInternalCompletionItem()
-                    {
-                        Label = razorCompletionItem.DisplayText,
-                        InsertText = razorCompletionItem.InsertText,
-                        FilterText = razorCompletionItem.DisplayText,
-                        SortText = razorCompletionItem.SortText,
-                        InsertTextFormat = insertTextFormat,
-                        Kind = CompletionItemKind.Snippet,
-                    };
-
-                    directiveSnippetCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
-
-                    completionItem = directiveSnippetCompletionItem;
                     return true;
                 }
                 case RazorCompletionItemKind.DirectiveAttribute:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
@@ -117,65 +117,66 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             switch (associatedRazorCompletion.Kind)
             {
                 case RazorCompletionItemKind.Directive:
+                case RazorCompletionItemKind.DirectiveSnippet:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
+                    if (descriptionInfo is not null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem.Documentation = descriptionInfo.Description;
-                        }
-
-                        break;
+                        completionItem.Documentation = descriptionInfo.Description;
                     }
+
+                    break;
+                }
                 case RazorCompletionItemKind.MarkupTransition:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
+                    if (descriptionInfo is not null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem.Documentation = descriptionInfo.Description;
-                        }
-
-                        break;
+                        completionItem.Documentation = descriptionInfo.Description;
                     }
+
+                    break;
+                }
                 case RazorCompletionItemKind.DirectiveAttribute:
                 case RazorCompletionItemKind.DirectiveAttributeParameter:
                 case RazorCompletionItemKind.TagHelperAttribute:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
+                    if (descriptionInfo == null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
-                        if (descriptionInfo == null)
-                        {
-                            break;
-                        }
-
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else 
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
-                        }
-
                         break;
                     }
+
+                    if (useDescriptionProperty)
+                    {
+                        _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                    }
+                    else
+                    {
+                        _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
+                    }
+
+                    break;
+                }
                 case RazorCompletionItemKind.TagHelperElement:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
+                    if (descriptionInfo == null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
-                        if (descriptionInfo == null)
-                        {
-                            break;
-                        }
-
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
-                        }
-
                         break;
                     }
+
+                    if (useDescriptionProperty)
+                    {
+                        _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                    }
+                    else
+                    {
+                        _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
+                    }
+
+                    break;
+                }
             }
 
             if (tagHelperMarkupTooltip != null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
@@ -117,7 +117,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             switch (associatedRazorCompletion.Kind)
             {
                 case RazorCompletionItemKind.Directive:
-                case RazorCompletionItemKind.DirectiveSnippet:
                 {
                     var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
                     if (descriptionInfo is not null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
@@ -58,7 +58,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             switch (associatedRazorCompletion.Kind)
             {
                 case RazorCompletionItemKind.Directive:
-                case RazorCompletionItemKind.DirectiveSnippet:
                 {
                     var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
                     if (descriptionInfo is not null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
@@ -58,65 +58,66 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             switch (associatedRazorCompletion.Kind)
             {
                 case RazorCompletionItemKind.Directive:
+                case RazorCompletionItemKind.DirectiveSnippet:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
+                    if (descriptionInfo is not null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetDirectiveCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem.Documentation = descriptionInfo.Description;
-                        }
-
-                        break;
+                        completionItem.Documentation = descriptionInfo.Description;
                     }
+
+                    break;
+                }
                 case RazorCompletionItemKind.MarkupTransition:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
+                    if (descriptionInfo is not null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetMarkupTransitionCompletionDescription();
-                        if (descriptionInfo is not null)
-                        {
-                            completionItem.Documentation = descriptionInfo.Description;
-                        }
-
-                        break;
+                        completionItem.Documentation = descriptionInfo.Description;
                     }
+
+                    break;
+                }
                 case RazorCompletionItemKind.DirectiveAttribute:
                 case RazorCompletionItemKind.DirectiveAttributeParameter:
                 case RazorCompletionItemKind.TagHelperAttribute:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
+                    if (descriptionInfo == null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetAttributeCompletionDescription();
-                        if (descriptionInfo == null)
-                        {
-                            break;
-                        }
-
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
-                        }
-
                         break;
                     }
+
+                    if (useDescriptionProperty)
+                    {
+                        _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                    }
+                    else
+                    {
+                        _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
+                    }
+
+                    break;
+                }
                 case RazorCompletionItemKind.TagHelperElement:
+                {
+                    var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
+                    if (descriptionInfo == null)
                     {
-                        var descriptionInfo = associatedRazorCompletion.GetTagHelperElementDescriptionInfo();
-                        if (descriptionInfo == null)
-                        {
-                            break;
-                        }
-
-                        if (useDescriptionProperty)
-                        {
-                            _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
-                        }
-                        else
-                        {
-                            _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
-                        }
-
                         break;
                     }
+
+                    if (useDescriptionProperty)
+                    {
+                        _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                    }
+                    else
+                    {
+                        _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
+                    }
+
+                    break;
+                }
             }
 
             if (tagHelperMarkupTooltip != null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                         FilterText = razorCompletionItem.DisplayText,
                         SortText = razorCompletionItem.SortText,
                         InsertTextFormat = insertTextFormat,
-                        Kind = CompletionItemKind.Struct,
+                        Kind = razorCompletionItem.IsSnippet ? CompletionItemKind.Snippet : CompletionItemKind.Struct, // TODO: Make separate CompletionItemKind for razor directives. See https://github.com/dotnet/razor-tooling/issues/6504 and https://github.com/dotnet/razor-tooling/issues/6505
                     };
 
                     directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
@@ -156,23 +156,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                     }
 
                     completionItem = directiveCompletionItem;
-                    return true;
-                }
-                case RazorCompletionItemKind.DirectiveSnippet:
-                {
-                    var directiveSnippetCompletionItem = new VSInternalCompletionItem()
-                    {
-                        Label = razorCompletionItem.DisplayText,
-                        InsertText = razorCompletionItem.InsertText,
-                        FilterText = razorCompletionItem.DisplayText,
-                        SortText = razorCompletionItem.SortText,
-                        InsertTextFormat = insertTextFormat,
-                        Kind = CompletionItemKind.Snippet,
-                    };
-
-                    directiveSnippetCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
-
-                    completionItem = directiveSnippetCompletionItem;
                     return true;
                 }
                 case RazorCompletionItemKind.DirectiveAttribute:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -136,113 +136,130 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             switch (razorCompletionItem.Kind)
             {
                 case RazorCompletionItemKind.Directive:
+                {
+                    var directiveCompletionItem = new VSInternalCompletionItem()
                     {
-                        var directiveCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = CompletionItemKind.Struct,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = CompletionItemKind.Struct,
+                    };
 
-                        directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        if (razorCompletionItem == DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem)
-                        {
-                            directiveCompletionItem.Command = s_retriggerCompletionCommand;
-                            directiveCompletionItem.Kind = tagHelperCompletionItemKind;
-                        }
-
-                        completionItem = directiveCompletionItem;
-                        return true;
+                    if (razorCompletionItem == DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem)
+                    {
+                        directiveCompletionItem.Command = s_retriggerCompletionCommand;
+                        directiveCompletionItem.Kind = tagHelperCompletionItemKind;
                     }
+
+                    completionItem = directiveCompletionItem;
+                    return true;
+                }
+                case RazorCompletionItemKind.DirectiveSnippet:
+                {
+                    var directiveSnippetCompletionItem = new VSInternalCompletionItem()
+                    {
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = CompletionItemKind.Snippet,
+                    };
+
+                    directiveSnippetCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+
+                    completionItem = directiveSnippetCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.DirectiveAttribute:
+                {
+                    var directiveAttributeCompletionItem = new VSInternalCompletionItem()
                     {
-                        var directiveAttributeCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.InsertText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        directiveAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    directiveAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = directiveAttributeCompletionItem;
-                        return true;
-                    }
+                    completionItem = directiveAttributeCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.DirectiveAttributeParameter:
+                {
+                    var parameterCompletionItem = new VSInternalCompletionItem()
                     {
-                        var parameterCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.InsertText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.InsertText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        parameterCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    parameterCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = parameterCompletionItem;
-                        return true;
-                    }
+                    completionItem = parameterCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.MarkupTransition:
+                {
+                    var markupTransitionCompletionItem = new VSInternalCompletionItem()
                     {
-                        var markupTransitionCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        markupTransitionCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    markupTransitionCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = markupTransitionCompletionItem;
-                        return true;
-                    }
+                    completionItem = markupTransitionCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.TagHelperElement:
+                {
+                    var tagHelperElementCompletionItem = new VSInternalCompletionItem()
                     {
-                        var tagHelperElementCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        tagHelperElementCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    tagHelperElementCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = tagHelperElementCompletionItem;
-                        return true;
-                    }
+                    completionItem = tagHelperElementCompletionItem;
+                    return true;
+                }
                 case RazorCompletionItemKind.TagHelperAttribute:
+                {
+                    var tagHelperAttributeCompletionItem = new VSInternalCompletionItem()
                     {
-                        var tagHelperAttributeCompletionItem = new VSInternalCompletionItem()
-                        {
-                            Label = razorCompletionItem.DisplayText,
-                            InsertText = razorCompletionItem.InsertText,
-                            FilterText = razorCompletionItem.DisplayText,
-                            SortText = razorCompletionItem.SortText,
-                            InsertTextFormat = insertTextFormat,
-                            Kind = tagHelperCompletionItemKind,
-                        };
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = tagHelperCompletionItemKind,
+                    };
 
-                        tagHelperAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+                    tagHelperAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                        completionItem = tagHelperAttributeCompletionItem;
-                        return true;
-                    }
+                    completionItem = tagHelperAttributeCompletionItem;
+                    return true;
+                }
             }
 
             completionItem = null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             ["addTagHelper"] = "addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
             ["attribute"] = "attribute [${1:Authorize}]$0",
             ["implements"] = "implements ${1:IDisposable}",
-            ["inherits"] = "inherits ${1:MyRazorPageClass}",
+            ["inherits"] = "inherits ${1:ComponentBase}",
             ["inject"] = "inject ${1:IService} ${2:MyService}",
             ["layout"] = "layout ${1:MainLayout}",
             ["model"] = "model ${1:MyModelClass}",

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -28,21 +28,22 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         };
 
         // internal for testing
-        internal static readonly IReadOnlyDictionary<string, string> s_singleLineDirectiveSnippets = new Dictionary<string, string>(StringComparer.Ordinal)
+        // Do not forget to update both insert and display text !important
+        internal static readonly IReadOnlyDictionary<string, (string InsertText, string DisplayText)> s_singleLineDirectiveSnippets = new Dictionary<string, (string InsertText, string DisplayText)>(StringComparer.Ordinal)
         {
-            ["addTagHelper"] = "addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
-            ["attribute"] = "attribute [${1:Authorize}]$0",
-            ["implements"] = "implements ${1:IDisposable}",
-            ["inherits"] = "inherits ${1:ComponentBase}",
-            ["inject"] = "inject ${1:IService} ${2:MyService}",
-            ["layout"] = "layout ${1:MainLayout}",
-            ["model"] = "model ${1:MyModelClass}",
-            ["namespace"] = "namespace ${1:MyNameSpace}",
-            ["page"] = "page \"${1:/page}\"$0",
-            ["preservewhitespace"] = "preservewhitespace ${1:true}",
-            ["removeTagHelper"] = "removeTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
-            ["tagHelperPrefix"] = "tagHelperPrefix ${1:prefix}",
-            ["typeparam"] = "typeparam ${1:T}"
+            ["addTagHelper"] = ("addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}", "addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers"),
+            ["attribute"] = ("attribute [${1:Authorize}]$0", "attribute [Authorize]"),
+            ["implements"] = ("implements ${1:IDisposable}$0", "implements IDisposable"),
+            ["inherits"] = ("inherits ${1:ComponentBase}$0", "inherits ComponentBase"),
+            ["inject"] = ("inject ${1:IService} ${2:MyService}", "inject IService MyService"),
+            ["layout"] = ("layout ${1:MainLayout}$0", "layout MainLayout"),
+            ["model"] = ("model ${1:MyModelClass}$0", "model MyModelClass"),
+            ["namespace"] = ("namespace ${1:MyNameSpace}$0", "namespace MyNameSpace"),
+            ["page"] = ("page \"${1:/page}\"$0", "page \"/page\""),
+            ["preservewhitespace"] = ("preservewhitespace ${1:true}$0", "preservewhitespace true"),
+            ["removeTagHelper"] = ("removeTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}", "removeTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers"),
+            ["tagHelperPrefix"] = ("tagHelperPrefix ${1:prefix}$0", "tagHelperPrefix prefix"),
+            ["typeparam"] = ("typeparam ${1:T}$0", "typeparam T")
         };
 
         public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
@@ -134,23 +135,33 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             {
                 var completionDisplayText = directive.DisplayName ?? directive.Directive;
                 var commitCharacters = GetDirectiveCommitCharacters(directive.Kind);
-                var insertText = directive.Directive;
-                var isSnippet = false;
-                if (s_singleLineDirectiveSnippets.TryGetValue(directive.Directive, out var snippetText))
-                {
-                    insertText = snippetText;
-                    isSnippet = true;
-                }
                 
                 var completionItem = new RazorCompletionItem(
                     completionDisplayText,
-                    insertText,
+                    directive.Directive,
                     RazorCompletionItemKind.Directive,
                     commitCharacters: commitCharacters,
-                    isSnippet: isSnippet);
+                    isSnippet: false);
                 var completionDescription = new DirectiveCompletionDescription(directive.Description);
                 completionItem.SetDirectiveCompletionDescription(completionDescription);
                 completionItems.Add(completionItem);
+
+                if (s_singleLineDirectiveSnippets.TryGetValue(directive.Directive, out var snippetTexts))
+                {
+                    var snippetCompletionItem = new RazorCompletionItem(
+                        $"{completionDisplayText} ...",
+                        snippetTexts.InsertText,
+                        RazorCompletionItemKind.DirectiveSnippet,
+                        commitCharacters: commitCharacters,
+                        isSnippet: true);
+
+                    var snippetDescription = "@" + snippetTexts.DisplayText
+                                                 + Environment.NewLine + Environment.NewLine
+                                                 + "Type to replace placeholders. [Tab] to navigate or [Return] to complete snippet.";
+
+                    snippetCompletionItem.SetDirectiveCompletionDescription(new(snippetDescription));
+                    completionItems.Add(snippetCompletionItem);
+                }
             }
 
             return completionItems;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -145,19 +145,19 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 var completionDescription = new DirectiveCompletionDescription(directive.Description);
                 completionItem.SetDirectiveCompletionDescription(completionDescription);
                 completionItems.Add(completionItem);
-
+                
                 if (s_singleLineDirectiveSnippets.TryGetValue(directive.Directive, out var snippetTexts))
                 {
                     var snippetCompletionItem = new RazorCompletionItem(
                         $"{completionDisplayText} ...",
                         snippetTexts.InsertText,
-                        RazorCompletionItemKind.DirectiveSnippet,
+                        RazorCompletionItemKind.Directive,
                         commitCharacters: commitCharacters,
                         isSnippet: true);
-
+                    
                     var snippetDescription = "@" + snippetTexts.DisplayText
-                                                 + Environment.NewLine + Environment.NewLine
-                                                 + "Type to replace placeholders. [Tab] to navigate or [Return] to complete snippet.";
+                                                 + Environment.NewLine
+                                                 + Resources.DirectiveSnippetDescription;
 
                     snippetCompletionItem.SetDirectiveCompletionDescription(new(snippetDescription));
                     completionItems.Add(snippetCompletionItem);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         };
 
         // internal for testing
-        internal static readonly IReadOnlyDictionary<string, string> s_singleLineDirectiveSnippets = new Dictionary<string, string>()
+        internal static readonly IReadOnlyDictionary<string, string> s_singleLineDirectiveSnippets = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["addTagHelper"] = "addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
             ["attribute"] = "attribute [${1:Attribute}]$0",

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         internal static readonly IReadOnlyDictionary<string, string> s_singleLineDirectiveSnippets = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["addTagHelper"] = "addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
-            ["attribute"] = "attribute [${1:Attribute}]$0",
+            ["attribute"] = "attribute [${1:Authorize}]$0",
             ["implements"] = "implements ${1:IDisposable}",
             ["inherits"] = "inherits ${1:MyRazorPageClass}",
             ["inject"] = "inject ${1:IService} ${2:MyService}",

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Resources = Microsoft.CodeAnalysis.Razor.Workspaces.Resources;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
 {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -31,14 +31,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         internal static readonly IReadOnlyDictionary<string, string> s_singleLineDirectiveSnippets = new Dictionary<string, string>()
         {
             ["addTagHelper"] = "addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
-            ["attribute"] = "attribute [$0]",
+            ["attribute"] = "attribute [${1:Attribute}]$0",
             ["implements"] = "implements ${1:IDisposable}",
             ["inherits"] = "inherits ${1:MyRazorPageClass}",
             ["inject"] = "inject ${1:IService} ${2:MyService}",
             ["layout"] = "layout ${1:MainLayout}",
             ["model"] = "model ${1:MyModelClass}",
             ["namespace"] = "namespace ${1:MyNameSpace}",
-            ["page"] = "page \"$0\"",
+            ["page"] = "page \"${1:/page}\"$0",
             ["preservewhitespace"] = "preservewhitespace ${1:true}",
             ["removeTagHelper"] = "removeTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
             ["tagHelperPrefix"] = "tagHelperPrefix ${1:prefix}",

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -27,6 +27,24 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
         };
 
+        // internal for testing
+        internal static readonly IReadOnlyDictionary<string, string> s_singleLineDirectiveSnippets = new Dictionary<string, string>()
+        {
+            ["addTagHelper"] = "addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
+            ["attribute"] = "attribute [$0]",
+            ["implements"] = "implements ${1:IDisposable}",
+            ["inherits"] = "inherits ${1:MyRazorPageClass}",
+            ["inject"] = "inject ${1:IService} ${2:MyService}",
+            ["layout"] = "layout ${1:MainLayout}",
+            ["model"] = "model ${1:MyModelClass}",
+            ["namespace"] = "namespace ${1:MyNameSpace}",
+            ["page"] = "page \"$0\"",
+            ["preservewhitespace"] = "preservewhitespace ${1:true}",
+            ["removeTagHelper"] = "removeTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}",
+            ["tagHelperPrefix"] = "tagHelperPrefix ${1:prefix}",
+            ["typeparam"] = "typeparam ${1:T}"
+        };
+
         public override IReadOnlyList<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
         {
             if (context is null)
@@ -116,11 +134,20 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             {
                 var completionDisplayText = directive.DisplayName ?? directive.Directive;
                 var commitCharacters = GetDirectiveCommitCharacters(directive.Kind);
+                var insertText = directive.Directive;
+                var isSnippet = false;
+                if (s_singleLineDirectiveSnippets.TryGetValue(directive.Directive, out var snippetText))
+                {
+                    insertText = snippetText;
+                    isSnippet = true;
+                }
+                
                 var completionItem = new RazorCompletionItem(
                     completionDisplayText,
-                    directive.Directive,
+                    insertText,
                     RazorCompletionItemKind.Directive,
-                    commitCharacters: commitCharacters);
+                    commitCharacters: commitCharacters,
+                    isSnippet: isSnippet);
                 var completionDescription = new DirectiveCompletionDescription(directive.Description);
                 completionItem.SetDirectiveCompletionDescription(completionDescription);
                 completionItems.Add(completionItem);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -74,10 +74,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 {
                     lock (this)
                     {
-                        if (_items is null)
-                        {
-                            _items = new ItemCollection();
-                        }
+                        _items ??= new ItemCollection();
                     }
                 }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     internal enum RazorCompletionItemKind
     {
         Directive,
+        DirectiveSnippet,
         DirectiveAttribute,
         DirectiveAttributeParameter,
         MarkupTransition,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
@@ -6,7 +6,6 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
     internal enum RazorCompletionItemKind
     {
         Directive,
-        DirectiveSnippet,
         DirectiveAttribute,
         DirectiveAttributeParameter,
         MarkupTransition,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources.resx
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources.resx
@@ -121,6 +121,7 @@
     <value>Value cannot be null or an empty string.</value>
   </data>
   <data name="DirectiveSnippetDescription" xml:space="preserve">
-    <value>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</value>
+    <value>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</value>
   </data>
 </root>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources.resx
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources.resx
@@ -120,4 +120,7 @@
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>Value cannot be null or an empty string.</value>
   </data>
+  <data name="DirectiveSnippetDescription" xml:space="preserve">
+    <value>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</value>
+  </data>
 </root>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.cs.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Hodnota nesmí být null ani prázdný řetězec.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.cs.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.cs.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.de.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Der Wert darf nicht NULL oder eine leere Zeichenfolge sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.de.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.de.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.es.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.es.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.es.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">El valor no puede ser nulo ni una cadena vacía.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.fr.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.fr.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.fr.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La valeur ne peut pas être Null ni être une chaîne vide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.it.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Il valore non può essere null o una stringa vuota.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.it.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.it.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ja.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">値を null または空の文字列にすることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ja.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ja.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ko.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ko.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ko.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">값은 null이거나 빈 문자열일 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pl.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Wartość nie może być wartością null ani pustym ciągiem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pl.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pl.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">O valor não pode ser nulo ou uma cadeia de caracteres vazia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.pt-BR.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ru.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ru.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ru.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Значение не может быть NULL или пустой строкой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.tr.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Değer null veya boş bir dize olamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.tr.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.tr.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hans.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">值不能为 null 或空字符串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hant.xlf
@@ -8,8 +8,10 @@
         <note />
       </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
-        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
-        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <source>Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet
+[Tab] to navigate between elements, [Enter] to complete</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/xlf/Resources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">值不能為 Null 或空字串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DirectiveSnippetDescription">
+        <source>Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</source>
+        <target state="new">Insert a directive code snippet\r\n[Tab] to navigate between elements, [Enter] to complete</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
@@ -22,11 +22,11 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
     internal class RazorDirectiveCompletionSource : IAsyncCompletionSource
     {
         // Internal for testing
-        internal static readonly object DescriptionKey = new object();
+        internal static readonly object DescriptionKey = new();
         // Hardcoding the Guid here to avoid a reference to Microsoft.VisualStudio.ImageCatalog.dll
         // that is not present in Visual Studio for Mac
-        internal static readonly Guid ImageCatalogGuid = new Guid("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
-        internal static readonly ImageElement DirectiveImageGlyph = new ImageElement(
+        internal static readonly Guid ImageCatalogGuid = new("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
+        internal static readonly ImageElement DirectiveImageGlyph = new(
             new ImageId(ImageCatalogGuid, 3233), // KnownImageIds.Type = 3233
             "Razor Directive.");
         internal static readonly ImmutableArray<CompletionFilter> DirectiveCompletionFilters = new[] {
@@ -82,9 +82,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 var completionItems = new List<CompletionItem>();
                 foreach (var razorCompletionItem in razorCompletionItems)
                 {
-                    if (razorCompletionItem.Kind != RazorCompletionItemKind.Directive)
+                    if (razorCompletionItem.Kind != RazorCompletionItemKind.Directive &&
+                        razorCompletionItem.Kind != RazorCompletionItemKind.DirectiveSnippet)
                     {
-                        // Don't support any other types of completion kinds other than directives.
+                        // Don't support any other types of completion kinds other than directives and directive snippets.
                         continue;
                     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Completion/RazorDirectiveCompletionSource.cs
@@ -82,10 +82,9 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
                 var completionItems = new List<CompletionItem>();
                 foreach (var razorCompletionItem in razorCompletionItems)
                 {
-                    if (razorCompletionItem.Kind != RazorCompletionItemKind.Directive &&
-                        razorCompletionItem.Kind != RazorCompletionItemKind.DirectiveSnippet)
+                    if (razorCompletionItem.Kind != RazorCompletionItemKind.Directive)
                     {
-                        // Don't support any other types of completion kinds other than directives and directive snippets.
+                        // Don't support any other types of completion kinds other than directives.
                         continue;
                     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -394,9 +394,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Assert
 
             // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "removeTagHelper"));
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "tagHelperPrefix"));
+            Assert.Collection(completionList.Items,
+                item => Assert.Equal("addTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "addTagHelper"),
+                item => Assert.Equal("removeTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "removeTagHelper"),
+                item => Assert.Equal("tagHelperPrefix", item.InsertText),
+                item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            );
         }
 
         [Fact]
@@ -433,7 +438,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await Task.Run(() => completionEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
+            Assert.Collection(completionList.Items,
+                item => Assert.Equal("addTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "addTagHelper"),
+                item => Assert.Equal("removeTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "removeTagHelper"),
+                item => Assert.Equal("tagHelperPrefix", item.InsertText),
+                item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            );
         }
 
         [Fact]
@@ -506,7 +518,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await Task.Run(() => completionEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
+            Assert.Collection(completionList.Items,
+                item => Assert.Equal("addTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "addTagHelper"),
+                item => Assert.Equal("removeTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "removeTagHelper"),
+                item => Assert.Equal("tagHelperPrefix", item.InsertText),
+                item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            );
         }
 
         // This is more of an integration test to validate that all the pieces work together
@@ -594,10 +613,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             return codeDocument;
         }
 
-        private static bool CheckDirectiveSnippet(CompletionItem completionItem, string directive)
+        private static void AssertDirectiveSnippet(CompletionItem completionItem, string directive)
         {
-            return completionItem.InsertText.StartsWith(directive) &&
-                   completionItem.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive];
+            Assert.StartsWith(directive, completionItem.InsertText);
+            Assert.Equal(DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive].InsertText, completionItem.InsertText);
+            Assert.Equal(CompletionItemKind.Snippet, completionItem.Kind);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -380,6 +380,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         // This is more of an integration test to validate that all the pieces work together
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public async Task Handle_ProvidesDirectiveCompletionItems()
         {
             // Arrange
@@ -405,12 +406,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Assert
 
             // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
-            Assert.Contains(completionList.Items, item => item.InsertText == "addTagHelper");
-            Assert.Contains(completionList.Items, item => item.InsertText == "removeTagHelper");
-            Assert.Contains(completionList.Items, item => item.InsertText == "tagHelperPrefix");
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["removeTagHelper"]);
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["tagHelperPrefix"]);
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public async Task Handle_ProvidesInjectOnIncomplete_KeywordIn()
         {
             // Arrange
@@ -443,7 +445,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await Task.Run(() => completionEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Contains(completionList.Items, item => item.InsertText == "addTagHelper");
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
         }
 
         [Fact]
@@ -483,6 +485,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public async Task Handle_ProvidesInjectOnIncomplete()
         {
             // Arrange
@@ -515,7 +518,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await Task.Run(() => completionEndpoint.Handle(request, default));
 
             // Assert
-            Assert.Contains(completionList.Items, item => item.InsertText == "addTagHelper");
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
         }
 
         // This is more of an integration test to validate that all the pieces work together

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -355,9 +355,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Assert
 
             // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
-            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
-            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["removeTagHelper"]);
-            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["tagHelperPrefix"]);
+            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
+            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "removeTagHelper"));
+            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "tagHelperPrefix"));
         }
 
         [Fact]
@@ -384,7 +384,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
 
             // Assert
-            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
+            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
         }
 
         [Fact]
@@ -437,7 +437,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
 
             // Assert
-            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
+            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
         }
 
         // This is more of an integration test to validate that all the pieces work together
@@ -501,6 +501,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Enumerable.Empty<TagHelperDescriptor>());
             codeDocument.SetTagHelperContext(tagHelperDocumentContext);
             return codeDocument;
+        }
+
+        private static bool CheckDirectiveSnippet(CompletionItem completionItem, string directive)
+        {
+            return completionItem.InsertText.StartsWith(directive) &&
+                   completionItem.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive];
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -340,6 +340,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         // This is more of an integration test to validate that all the pieces work together
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public async Task GetCompletionListAsync_ProvidesDirectiveCompletionItems()
         {
             // Arrange
@@ -354,12 +355,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Assert
 
             // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
-            Assert.Contains(completionList.Items, item => item.InsertText == "addTagHelper");
-            Assert.Contains(completionList.Items, item => item.InsertText == "removeTagHelper");
-            Assert.Contains(completionList.Items, item => item.InsertText == "tagHelperPrefix");
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["removeTagHelper"]);
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["tagHelperPrefix"]);
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public async Task GetCompletionListAsync_ProvidesInjectOnIncomplete_KeywordIn()
         {
             // Arrange
@@ -382,7 +384,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
 
             // Assert
-            Assert.Contains(completionList.Items, item => item.InsertText == "addTagHelper");
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
         }
 
         [Fact]
@@ -412,6 +414,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public async Task GetCompletionListAsync_ProvidesInjectOnIncomplete()
         {
             // Arrange
@@ -434,7 +437,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
 
             // Assert
-            Assert.Contains(completionList.Items, item => item.InsertText == "addTagHelper");
+            Assert.Contains(completionList.Items, item => item.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets["addTagHelper"]);
         }
 
         // This is more of an integration test to validate that all the pieces work together

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -355,9 +355,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Assert
 
             // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "removeTagHelper"));
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "tagHelperPrefix"));
+            Assert.Collection(completionList.Items,
+                item => Assert.Equal("addTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "addTagHelper"),
+                item => Assert.Equal("removeTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "removeTagHelper"),
+                item => Assert.Equal("tagHelperPrefix", item.InsertText),
+                item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            );
         }
 
         [Fact]
@@ -384,7 +389,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
 
             // Assert
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
+            Assert.Collection(completionList.Items,
+                item => Assert.Equal("addTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "addTagHelper"),
+                item => Assert.Equal("removeTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "removeTagHelper"),
+                item => Assert.Equal("tagHelperPrefix", item.InsertText),
+                item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            );
         }
 
         [Fact]
@@ -437,7 +449,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
 
             // Assert
-            Assert.Contains(completionList.Items, item => CheckDirectiveSnippet(item, "addTagHelper"));
+            Assert.Collection(completionList.Items,
+                item => Assert.Equal("addTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "addTagHelper"),
+                item => Assert.Equal("removeTagHelper", item.InsertText),
+                item => AssertDirectiveSnippet(item, "removeTagHelper"),
+                item => Assert.Equal("tagHelperPrefix", item.InsertText),
+                item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            );
         }
 
         // This is more of an integration test to validate that all the pieces work together
@@ -503,10 +522,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             return codeDocument;
         }
 
-        private static bool CheckDirectiveSnippet(CompletionItem completionItem, string directive)
+        private static void AssertDirectiveSnippet(CompletionItem completionItem, string directive)
         {
-            return completionItem.InsertText.StartsWith(directive) &&
-                   completionItem.InsertText == DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive];
+            Assert.StartsWith(directive, completionItem.InsertText);
+            Assert.Equal(DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive].InsertText, completionItem.InsertText);
+            Assert.Equal(CompletionItemKind.Snippet, completionItem.Kind);
         }
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -162,6 +162,31 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
         }
 
+        [Theory]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
+        [InlineData("model")] // Currently "model" is the only cshtml-only single-line directive. "add(remove)TagHelper" and "tagHelperPrefix" are there by default
+        public void GetDirectiveCompletionItems_ReturnsKnownDirectivesAsSnippets_SingleLine_Legacy(string knownDirective)
+        {
+            // Arrange
+            var customDirective = DirectiveDescriptor.CreateRazorBlockDirective(knownDirective, builder =>
+            {
+                builder.DisplayName = knownDirective;
+                builder.Description = string.Empty; // Doesn't matter for this test. Just need to provide something to avoid ArgumentNullException
+            });
+            var syntaxTree = CreateSyntaxTree("@", FileKinds.Legacy, customDirective);
+
+            // Act
+            var completionItems = DirectiveCompletionItemProvider.GetDirectiveCompletionItems(syntaxTree);
+
+            // Assert
+            Assert.Collection(
+                completionItems,
+                item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+        }
+
         [Fact]
         public void GetDirectiveCompletionItems_ComponentDocument_DoesNotReturnsDefaultDirectivesAsCompletionItems()
         {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -162,15 +162,14 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
                 item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
         }
 
-        [Theory]
+        [Fact]
         [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
-        [InlineData("model")] // Currently "model" is the only cshtml-only single-line directive. "add(remove)TagHelper" and "tagHelperPrefix" are there by default
-        public void GetDirectiveCompletionItems_ReturnsKnownDirectivesAsSnippets_SingleLine_Legacy(string knownDirective)
+        public void GetDirectiveCompletionItems_ReturnsKnownDirectivesAsSnippets_SingleLine_Legacy()
         {
             // Arrange
-            var customDirective = DirectiveDescriptor.CreateRazorBlockDirective(knownDirective, builder =>
+            var customDirective = DirectiveDescriptor.CreateRazorBlockDirective("model", builder =>
             {
-                builder.DisplayName = knownDirective;
+                builder.DisplayName = "model"; // Currently "model" is the only cshtml-only single-line directive. "add(remove)TagHelper" and "tagHelperPrefix" are there by default
                 builder.Description = string.Empty; // Doesn't matter for this test. Just need to provide something to avoid ArgumentNullException
             });
             var syntaxTree = CreateSyntaxTree("@", FileKinds.Legacy, customDirective);
@@ -181,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Assert
             Assert.Collection(
                 completionItems,
-                item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true),
+                item => AssertRazorCompletionItem("model", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -36,8 +36,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Assert
             Assert.Collection(
                 completionItems,
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
@@ -56,8 +59,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem(customDirective, item),
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
@@ -80,8 +86,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem("different", customDirective, item),
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
@@ -104,8 +113,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem("code", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters),
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
@@ -127,8 +139,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem("section", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters),
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
@@ -159,6 +174,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Assert
             Assert.Collection(
                 completionItems,
+                item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
                 item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
         }
 
@@ -180,9 +196,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Assert
             Assert.Collection(
                 completionItems,
+                item => AssertRazorCompletionItem("model", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
                 item => AssertRazorCompletionItem("model", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
@@ -434,7 +454,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             if (isSnippet)
             {
                 Assert.StartsWith(directive.Directive, item.InsertText);
-                Assert.Equal(item.InsertText, DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive]);
+                Assert.Equal(item.InsertText, DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive].InsertText);
             }
             else
             {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -430,7 +430,17 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item, IReadOnlyList<RazorCommitCharacter> commitCharacters = null, bool isSnippet = false)
         {
             Assert.Equal(item.DisplayText, completionDisplayText);
-            Assert.Equal(item.InsertText, isSnippet ? DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive] : directive.Directive);
+
+            if (isSnippet)
+            {
+                Assert.StartsWith(directive.Directive, item.InsertText);
+                Assert.Equal(item.InsertText, DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive]);
+            }
+            else
+            {
+                Assert.Equal(item.InsertText, directive.Directive);
+            }
+
             var completionDescription = item.GetDirectiveCompletionDescription();
             Assert.Equal(directive.Description, completionDescription.Description);
             Assert.Equal(item.CommitCharacters, commitCharacters ?? DirectiveCompletionItemProvider.SingleLineDirectiveCommitCharacters);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion
@@ -23,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
         };
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public void GetDirectiveCompletionItems_ReturnsDefaultDirectivesAsCompletionItems()
         {
             // Arrange
@@ -34,12 +36,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             // Assert
             Assert.Collection(
                 completionItems,
-                item => AssertRazorCompletionItem(s_defaultDirectives[0], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[1], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[2], item));
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public void GetDirectiveCompletionItems_ReturnsCustomDirectivesAsCompletionItems()
         {
             // Arrange
@@ -53,12 +56,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem(customDirective, item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[0], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[1], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[2], item));
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public void GetDirectiveCompletionItems_UsesDisplayNamesWhenNotNull()
         {
             // Arrange
@@ -76,12 +80,13 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem("different", customDirective, item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[0], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[1], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[2], item));
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public void GetDirectiveCompletionItems_CodeBlockCommitCharacters()
         {
             // Arrange
@@ -99,9 +104,9 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem("code", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters),
-                item => AssertRazorCompletionItem(s_defaultDirectives[0], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[1], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[2], item));
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
         }
 
         [Fact]
@@ -122,9 +127,39 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             Assert.Collection(
                 completionItems,
                 item => AssertRazorCompletionItem("section", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters),
-                item => AssertRazorCompletionItem(s_defaultDirectives[0], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[1], item),
-                item => AssertRazorCompletionItem(s_defaultDirectives[2], item));
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+        }
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
+        [InlineData("attribute")]
+        [InlineData("implements")]
+        [InlineData("inherits")]
+        [InlineData("inject")]
+        [InlineData("layout")]
+        [InlineData("namespace")]
+        [InlineData("page")]
+        [InlineData("preservewhitespace")]
+        [InlineData("typeparam")]
+        public void GetDirectiveCompletionItems_ReturnsKnownDirectivesAsSnippets_SingleLine_Component(string knownDirective)
+        {
+            // Arrange
+            var customDirective = DirectiveDescriptor.CreateRazorBlockDirective(knownDirective, builder =>
+            {
+                builder.DisplayName = knownDirective;
+                builder.Description = string.Empty; // Doesn't matter for this test. Just need to provide something to avoid ArgumentNullException
+            });
+            var syntaxTree = CreateSyntaxTree("@", FileKinds.Component, customDirective);
+
+            // Act
+            var completionItems = DirectiveCompletionItemProvider.GetDirectiveCompletionItems(syntaxTree);
+
+            // Assert
+            Assert.Collection(
+                completionItems,
+                item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
         }
 
         [Fact]
@@ -368,17 +403,17 @@ namespace Microsoft.CodeAnalysis.Razor.Completion
             return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext, reason);
         }
 
-        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item, IReadOnlyList<RazorCommitCharacter> commitCharacters = null)
+        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, RazorCompletionItem item, IReadOnlyList<RazorCommitCharacter> commitCharacters = null, bool isSnippet = false)
         {
             Assert.Equal(item.DisplayText, completionDisplayText);
-            Assert.Equal(item.InsertText, directive.Directive);
+            Assert.Equal(item.InsertText, isSnippet ? DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive] : directive.Directive);
             var completionDescription = item.GetDirectiveCompletionDescription();
             Assert.Equal(directive.Description, completionDescription.Description);
             Assert.Equal(item.CommitCharacters, commitCharacters ?? DirectiveCompletionItemProvider.SingleLineDirectiveCommitCharacters);
         }
 
-        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item) =>
-            AssertRazorCompletionItem(directive.Directive, directive, item);
+        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item, bool isSnippet = false) =>
+            AssertRazorCompletionItem(directive.Directive, directive, item, isSnippet: isSnippet);
 
         private static RazorSyntaxTree CreateSyntaxTree(string text, params DirectiveDescriptor[] directives)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -134,7 +134,17 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
         {
             Assert.Equal(item.DisplayText, completionDisplayText);
             Assert.Equal(item.FilterText, completionDisplayText);
-            Assert.Equal(item.InsertText, isSnippet ? DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive] : directive.Directive);
+
+            if (isSnippet)
+            {
+                Assert.StartsWith(directive.Directive, item.InsertText);
+                Assert.Equal(item.InsertText, DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive]);
+            }
+            else
+            {
+                Assert.Equal(item.InsertText, directive.Directive);
+            }
+
             Assert.Same(item.Source, source);
             Assert.True(item.Properties.TryGetProperty<DirectiveCompletionDescription>(RazorDirectiveCompletionSource.DescriptionKey, out var actualDescription));
             Assert.Equal(directive.Description, actualDescription.Description);

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
@@ -73,6 +74,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
         // This is more of an integration level test validating the end-to-end completion flow.
         [UIFact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
         public async Task GetCompletionContextAsync_ProvidesCompletionsWhenAtCompletionPoint()
         {
             // Arrange
@@ -91,9 +93,9 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             Assert.Collection(
                 completionContext.Items,
                 item => AssertRazorCompletionItem(SectionDirective.Directive, item, completionSource),
-                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, completionSource),
-                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, completionSource),
-                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, completionSource));
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, completionSource, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, completionSource, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, completionSource, isSnippet: true));
         }
 
         [Fact]
@@ -128,11 +130,11 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             Assert.Equal(string.Empty, description);
         }
 
-        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source)
+        private static void AssertRazorCompletionItem(string completionDisplayText, DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source, bool isSnippet = false)
         {
             Assert.Equal(item.DisplayText, completionDisplayText);
             Assert.Equal(item.FilterText, completionDisplayText);
-            Assert.Equal(item.InsertText, directive.Directive);
+            Assert.Equal(item.InsertText, isSnippet ? DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive] : directive.Directive);
             Assert.Same(item.Source, source);
             Assert.True(item.Properties.TryGetProperty<DirectiveCompletionDescription>(RazorDirectiveCompletionSource.DescriptionKey, out var actualDescription));
             Assert.Equal(directive.Description, actualDescription.Description);
@@ -140,8 +142,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             AssertRazorCompletionItemDefaults(item);
         }
 
-        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source) =>
-            AssertRazorCompletionItem(directive.Directive, directive, item, source);
+        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source, bool isSnippet = false) =>
+            AssertRazorCompletionItem(directive.Directive, directive, item, source, isSnippet: isSnippet);
 
         private static void AssertRazorCompletionItemDefaults(CompletionItem item)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -150,13 +151,21 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
 
             Assert.Same(item.Source, source);
             Assert.True(item.Properties.TryGetProperty<DirectiveCompletionDescription>(RazorDirectiveCompletionSource.DescriptionKey, out var actualDescription));
-            Assert.Equal(directive.Description, actualDescription.Description);
+
+            var description = isSnippet ? "@" + DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive].DisplayText
+                             + Environment.NewLine
+                             + CodeAnalysis.Razor.Workspaces.Resources.DirectiveSnippetDescription
+                             : directive.Description;
+            Assert.Equal(description, actualDescription.Description);
 
             AssertRazorCompletionItemDefaults(item);
         }
 
-        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source, bool isSnippet = false) =>
-            AssertRazorCompletionItem(directive.Directive, directive, item, source, isSnippet: isSnippet);
+        private static void AssertRazorCompletionItem(DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source, bool isSnippet = false)
+        {
+            var expectedDisplayText = isSnippet ? directive.Directive + " ..." : directive.Directive;
+            AssertRazorCompletionItem(expectedDisplayText, directive, item, source, isSnippet: isSnippet);
+        }
 
         private static void AssertRazorCompletionItemDefaults(CompletionItem item)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -93,8 +93,11 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             Assert.Collection(
                 completionContext.Items,
                 item => AssertRazorCompletionItem(SectionDirective.Directive, item, completionSource),
+                item => AssertRazorCompletionItem(s_defaultDirectives[0], item, completionSource, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[0], item, completionSource, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[1], item, completionSource, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[1], item, completionSource, isSnippet: true),
+                item => AssertRazorCompletionItem(s_defaultDirectives[2], item, completionSource, isSnippet: false),
                 item => AssertRazorCompletionItem(s_defaultDirectives[2], item, completionSource, isSnippet: true));
         }
 
@@ -138,7 +141,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Completion
             if (isSnippet)
             {
                 Assert.StartsWith(directive.Directive, item.InsertText);
-                Assert.Equal(item.InsertText, DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive]);
+                Assert.Equal(item.InsertText, DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive.Directive].InsertText);
             }
             else
             {


### PR DESCRIPTION
Most of https://github.com/dotnet/razor-tooling/issues/4547

Multi-line directives (e.g. `@code`) require additional tweaking to correctly determine ident size and type (spaces or tabs). Maybe I will implement them later, but not sure. Single-line directives are used a lot more frequently, so this PR will cover most use cases anyway