### PR TITLE
Revert "Remove duplicate assemblies from extension install. (#6508)"

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -153,7 +153,9 @@
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.Binder.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Logging.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll" />
+    <RazorNgendVSIXSourceItem Include="$(OutputPath)System.IO.Pipelines.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)System.Reactive.dll" />
+    <RazorNgendVSIXSourceItem Include="$(OutputPath)System.Runtime.CompilerServices.Unsafe.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)System.Threading.Channels.dll" />
 
     <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.dll" />

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -49,7 +49,9 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Configuration.Abstractions.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Logging.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Logging.Abstractions.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.IO.Pipelines.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Reactive.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Runtime.CompilerServices.Unsafe.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Threading.Channels.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.Protocol.dll" />


### PR DESCRIPTION
- Turns out these are required for ngen: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/413012

This reverts commit 47badc17ac8f5e98cd45c71e496345e6d4333a4e.
