### PR TITLE
Add TextMate information to VSMac Addin.

### DIFF
--- a/eng/MPack.targets
+++ b/eng/MPack.targets
@@ -27,7 +27,8 @@
 
     <RemoveDir Directories="$(IntermediateOutputPath)MPack\" />
     <MakeDir Directories="$(IntermediateOutputPath);$(IntermediateOutputPath)MPack\" />
-    <Copy SourceFiles="@(MPackFile)" DestinationFolder="$(IntermediateOutputPath)MPack\" />
+    <Copy SourceFiles="@(MPackFile)" DestinationFolder="$(IntermediateOutputPath)MPack" Condition="%(MPackFile.Folder) == ''" />
+    <Copy SourceFiles="@(MPackFile)" DestinationFolder="$(IntermediateOutputPath)MPack\%(MPackFile.Folder)" Condition="%(MPackFile.Folder) != ''" />
 
     <MakeDir Directories="$(ArtifactsMPackDir)" />
     <ZipDirectory

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -45,7 +45,7 @@
     <Content Include="$(RepositoryRoot)NOTICE.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    
+
     <!-- Embedded grammars -->
     <Content Include="..\Microsoft.VisualStudio.RazorExtension\EmbeddedGrammars\*">
       <Link>Grammars\%(Filename)%(Extension)</Link>
@@ -121,4 +121,16 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Mac.LanguageServices.Razor\Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServerClient.Razor\Microsoft.VisualStudio.LanguageServerClient.Razor.csproj" />
   </ItemGroup>
+
+  <Target Name="_BuildRazorGrammar">
+    <MSBuild Projects="..\Microsoft.AspNetCore.Razor.VSCode.Extension\Microsoft.AspNetCore.Razor.VSCode.Extension.npmproj" Targets="Build" />
+  </Target>
+
+  <Target Name="_IncludeRazorGrammar" DependsOnTargets="PrepareForBuild;_BuildRazorGrammar" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <MPackFile Include="..\Microsoft.AspNetCore.Razor.VSCode.Extension\syntaxes\aspnetcorerazor.tmLanguage.json">
+        <Folder>Grammars</Folder>
+      </MPackFile>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -45,6 +45,12 @@
     <Content Include="$(RepositoryRoot)NOTICE.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    
+    <!-- Embedded grammars -->
+    <Content Include="..\Microsoft.VisualStudio.RazorExtension\EmbeddedGrammars\*">
+      <Link>Grammars\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -91,6 +97,11 @@
 
     <!-- Third Party Notices -->
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\NOTICE.txt" />
+
+    <!-- Embedded Grammars -->
+    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Grammars\**">
+      <Folder>Grammars</Folder>
+    </MPackFile>
   </ItemGroup>
 
   <ItemGroup Condition="$(DebugType) != 'embedded'">

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -63,4 +63,9 @@
   <Extension path="/MonoDevelop/Core/FeatureSwitches">
     <FeatureSwitch id="Razor.LSP.Editor" _description="Enables the Razor LSP editor for ASP.NET Core scenarios" defaultValue="false" />
   </Extension>
+
+  <!-- TextMate -->
+  <Extension path="/MonoDevelop/Ide/Editor/TextMate">
+    <Repository folderPath="Grammars"/>
+  </Extension>
 </ExtensionModel>


### PR DESCRIPTION
- Update TextMate information for VSMac.
- Added new MSBuild goop to copy VSWin's TextMate pieces into VSMac's addin.
    - As part of this I had to update our mpack generator to respect a sub-folder indicator.