### PR TITLE
Mac: Add Addin dependency on TextEditor

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
@@ -43,5 +43,6 @@
   <Dependencies>
     <Addin id="::MonoDevelop.Core" version="17.3" />
     <Addin id="::MonoDevelop.Ide" version="17.3" />
+    <Addin id="TextEditor" version="17.3" />
   </Dependencies>
 </Addin>

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
@@ -43,6 +43,6 @@
   <Dependencies>
     <Addin id="::MonoDevelop.Core" version="17.3" />
     <Addin id="::MonoDevelop.Ide" version="17.3" />
-    <Addin id="TextEditor" version="17.3" />
+    <Addin id="::MonoDevelop.TextEditor" version="17.3" />
   </Dependencies>
 </Addin>


### PR DESCRIPTION
This should allow using the TextMate extension point.