### PR TITLE
Publish symbols with default arcade settings.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,8 +22,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DebugType>portable</DebugType>
-    <PublishWindowsPdb>true</PublishWindowsPdb>
     <GenerateResxSource>true</GenerateResxSource>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
     <ExcludeFromSourceBuild Condition="'$(IsUnitTestProject)' == 'true'">true</ExcludeFromSourceBuild>


### PR DESCRIPTION
- Arcade by default does the right thing supposedly for projects & publishing symbols. We were holistically swapping debug types / setting if we should publish windows pdbs. Arcade now supports all of this by default so this is an attempt at resolving #6239 in hopes that arcade does the right thing.