### PR TITLE
Actually add MonoDevelop.TextEditor dependency

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -35,6 +35,10 @@
       <_Parameter1>::MonoDevelop.Ide</_Parameter1>
       <_Parameter2>17.3</_Parameter2>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
+      <_Parameter1>::MonoDevelop.TextEditor</_Parameter1>
+      <_Parameter2>17.3</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/razor-tooling/pull/6663.