### PR TITLE
Fix VSMack embedded grammars inclusion on CI

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -49,12 +49,6 @@
     <Content Include="$(RepositoryRoot)NOTICE.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-
-    <!-- Embedded grammars -->
-    <Content Include="..\Microsoft.VisualStudio.RazorExtension\EmbeddedGrammars\*">
-      <Link>Grammars\%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -103,7 +97,7 @@
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\NOTICE.txt" />
 
     <!-- Embedded Grammars -->
-    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Grammars\**">
+    <MPackFile Include="..\Microsoft.VisualStudio.RazorExtension\EmbeddedGrammars\*">
       <Folder>Grammars</Folder>
     </MPackFile>
   </ItemGroup>


### PR DESCRIPTION
- Turns out on the CI creating an mpack was only including the Razor grammar and not our sub-grammars. That in-turn lead to our mpack lacking C#, HTML, CSS, JavaScript etc. grammars. This changeset goes from including grammars in the Addin output (doesn't have any impact) to directly including the grammars in the MPack file.


### Before
![image](https://user-images.githubusercontent.com/2008729/182682183-7d036240-c2ba-4155-9022-5aebe91d1651.png)


### After

![image](https://user-images.githubusercontent.com/2008729/182682132-a0dd36eb-ba42-4962-95a5-cfad5c91626b.png)
