### PR TITLE
Fix directive completions on deletion for incomplete sessions.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -260,6 +260,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 return false;
             }
 
+            if (vsCompletionContext.TriggerKind == CompletionTriggerKind.TriggerForIncompleteCompletions)
+            {
+                // For incomplete completions we want to re-provide information if we would have originally.
+                return true;
+            }
+
             if (vsCompletionContext.InvokeKind == VSInternalCompletionInvokeKind.Deletion)
             {
                 // We do not support providing completions on delete.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -358,6 +358,31 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             Assert.Contains(completionList.Items, item => item.InsertText == "removeTagHelper");
             Assert.Contains(completionList.Items, item => item.InsertText == "tagHelperPrefix");
         }
+        
+        [Fact]
+        public async Task GetCompletionListAsync_ProvidesDirectiveCompletions_IncompleteTriggerOnDeletion()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var codeDocument = CreateCodeDocument("@");
+            var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+            var completionContext = new VSInternalCompletionContext()
+            {
+                TriggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions,
+                InvokeKind = VSInternalCompletionInvokeKind.Deletion,
+            };
+            var provider = new RazorCompletionListProvider(CompletionFactsService, CompletionListCache, LoggerFactory);
+
+            // Act
+            var completionList = await provider.GetCompletionListAsync(absoluteIndex: 1, completionContext, documentContext, ClientCapabilities, CancellationToken.None);
+
+            // Assert
+
+            // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
+            Assert.Contains(completionList.Items, item => item.InsertText == "addTagHelper");
+            Assert.Contains(completionList.Items, item => item.InsertText == "removeTagHelper");
+            Assert.Contains(completionList.Items, item => item.InsertText == "tagHelperPrefix");
+        }
 
         [Fact]
         public async Task GetCompletionListAsync_ProvidesInjectOnIncomplete_KeywordIn()


### PR DESCRIPTION
- When typing out Razor directives we previously had a check that straight up outruled any deletion based interaction at completion time. This resulted in funky behavior when folks would accidentally mis-type a directive -> delete -> try to fix. That funky behavior would be an empty completion liset (see below for before gif).
- This fix makes our completion engine respect the `TriggerForIncompleteCompletions` even if it's on delete. This aligns with what C# does and because HTML doesn't currently offer incomplete completions doesn't really impact component completions; although if they ever end up going down that path we'll work as expected.
- Added a test for this scenario.
- This doesn't entirely fix the below associated issue, just one aspect of it. It's still possible for a completion provider to fail and then we eagerly provide completions.

### Before

![before gif](https://i.imgur.com/WuqPkXc.gif)

### After

![after gif](https://i.imgur.com/mkyZQ61.gif)

--------

Part of #6659
