### PR TITLE
Don't swallow exceptions during completion.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/AggregateCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/AggregateCompletionListProviderTest.cs
@@ -37,10 +37,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         private CompletionListProvider CompletionListProvider2 { get; }
 
-        private CompletionListProvider AsyncThrowingCompletionListProvider { get; } = new ThrowingCompletionListProvider(asynchronouslyThrow: true);
-
-        private CompletionListProvider SyncThrowingCompletionListProvider { get; } = new ThrowingCompletionListProvider(asynchronouslyThrow: false);
-
         private VSInternalCompletionContext CompletionContext { get; } = new VSInternalCompletionContext();
 
         private DocumentContext DocumentContext => TestDocumentContext.From("C:/path/to/file.cshtml");
@@ -51,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public async Task NoCompletionLists_ReturnsNull()
         {
             // Arrange
-            var provider = new AggregateCompletionListProvider(Array.Empty<CompletionListProvider>(), LoggerFactory);
+            var provider = new AggregateCompletionListProvider(Array.Empty<CompletionListProvider>());
 
             // Act
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 0, CompletionContext, DocumentContext, ClientCapabilities, CancellationToken.None);
@@ -64,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public async Task SingleCompletionList()
         {
             // Arrange
-            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1 }, LoggerFactory);
+            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1 });
 
             // Act
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 0, CompletionContext, DocumentContext, ClientCapabilities, CancellationToken.None);
@@ -77,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public async Task MultipleCompletionLists_Merges()
         {
             // Arrange
-            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1, CompletionListProvider2 }, LoggerFactory);
+            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1, CompletionListProvider2 });
 
             // Act
             var completionList = await provider.GetCompletionListAsync(absoluteIndex: 0, CompletionContext, DocumentContext, ClientCapabilities, CancellationToken.None);
@@ -91,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public async Task MultipleCompletionLists_DifferentCommitCharacters_OnlyCallsApplicable()
         {
             // Arrange
-            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1, CompletionListProvider2 }, LoggerFactory);
+            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1, CompletionListProvider2 });
             CompletionContext.TriggerKind = CompletionTriggerKind.TriggerCharacter;
             CompletionContext.TriggerCharacter = CompletionList2OnlyTriggerCharacter;
 
@@ -100,32 +96,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
             // Assert
             Assert.Same(CompletionList2, completionList);
-        }
-
-        [Fact]
-        public async Task SynchronousThrowingProvider()
-        {
-            // Arrange
-            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1, SyncThrowingCompletionListProvider }, LoggerFactory);
-
-            // Act
-            var completionList = await provider.GetCompletionListAsync(absoluteIndex: 0, CompletionContext, DocumentContext, ClientCapabilities, CancellationToken.None);
-
-            // Assert
-            Assert.Same(CompletionList1, completionList);
-        }
-
-        [Fact]
-        public async Task AsyncThrowingProvider()
-        {
-            // Arrange
-            var provider = new AggregateCompletionListProvider(new[] { CompletionListProvider1, AsyncThrowingCompletionListProvider }, LoggerFactory);
-
-            // Act
-            var completionList = await provider.GetCompletionListAsync(absoluteIndex: 0, CompletionContext, DocumentContext, ClientCapabilities, CancellationToken.None);
-
-            // Assert
-            Assert.Same(CompletionList1, completionList);
         }
 
         private class TestCompletionListProvider : CompletionListProvider
@@ -148,33 +118,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
                 CancellationToken cancellationToken)
             {
                 return Task.FromResult(_completionList);
-            }
-        }
-
-        private class ThrowingCompletionListProvider : CompletionListProvider
-        {
-            private readonly bool _asynchronouslyThrow;
-
-            public ThrowingCompletionListProvider(bool asynchronouslyThrow)
-            {
-                _asynchronouslyThrow = asynchronouslyThrow;
-            }
-
-            public override ImmutableHashSet<string> TriggerCharacters => new[] { "@", "<", ":" }.ToImmutableHashSet();
-
-            public override async Task<VSInternalCompletionList> GetCompletionListAsync(
-                int absoluteIndex,
-                VSInternalCompletionContext completionContext,
-                DocumentContext documentContext,
-                VSInternalClientCapabilities clientCapabilities,
-                CancellationToken cancellationToken)
-            {
-                if (_asynchronouslyThrow)
-                {
-                    await Task.Delay(1);
-                }
-
-                throw new InvalidOperationException("I'm supposed to throw!");
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
     {
         public RazorCompletionEndpointTest()
         {
-            CompletionListProvider = new AggregateCompletionListProvider(Array.Empty<CompletionListProvider>(), LoggerFactory);
+            CompletionListProvider = new AggregateCompletionListProvider(Array.Empty<CompletionListProvider>());
         }
 
         private AggregateCompletionListProvider CompletionListProvider { get; }


### PR DESCRIPTION
- Removed all error handling logic from our aggregate completion list provider. The motivator behind this change is that we want to properly "fail" in the case that completion explodes so we can capture that information in LogHub logs, telemetry and anything else sub-systems use those exceptions for. Effectively we don't want to hide issues.
- A side effect of not swallowing exceptions means if C#/HTML throws then we also wont provide Razor completions. This is desirable because it'll mean that we're at the very least not providing super partial information to the user. i.e. imagine only getting a list of Razor directives in your completion list after typing `@`. That list probably isn't very valuable and portrays unreliability.

/cc @mikadumont & @ryzngard this may negatively impact our completion metrics since we purposefully will not be swallowing exceptions

Fixes #6659