### PR TITLE
Fix component IntelliSense after rename.

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -299,14 +299,6 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
                         break;
                     }
-                case ProjectChangeKind.DocumentRemoved:
-                    {
-                        var owningProject = args.Newer;
-
-                        var key = new Key(owningProject.FilePath, args.DocumentFilePath);
-                        _entries.TryRemove(key, out _);
-                        break;
-                    }
             }
         }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
@@ -109,44 +109,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.ProjectSystem
         }
 
         [Fact]
-        public async Task UpdateLSPFileInfo_DocumentRemoved_Noops()
-        {
-            // Arrange
-            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document1.FilePath, CancellationToken.None).ConfigureAwait(false);
-            var called = false;
-            Provider.Updated += (sender, args) => called = true;
-            ProjectSnapshotManager.DocumentRemoved(Project.HostProject, Document1.State.HostDocument);
-
-            // Act
-            Provider.UpdateLSPFileInfo(new Uri(Document1.FilePath), LSPDocumentContainer);
-
-            // Assert
-            Assert.False(called);
-        }
-
-        [Fact]
-        public async Task UpdateLSPFileInfo_UnrelatedDocumentRemoved_UpdateOnlyValidDocuments()
-        {
-            // Arrange
-            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document1.FilePath, CancellationToken.None).ConfigureAwait(false);
-            await TestAccessor.GetDynamicFileInfoAsync(Project.FilePath, Document2.FilePath, CancellationToken.None).ConfigureAwait(false);
-            var callCount = 0;
-            Provider.Updated += (sender, documentFilePath) =>
-            {
-                Assert.Equal(Document1.FilePath, documentFilePath);
-                callCount++;
-            };
-            ProjectSnapshotManager.DocumentRemoved(Project.HostProject, Document2.State.HostDocument);
-
-            // Act
-            Provider.UpdateLSPFileInfo(new Uri(Document2.FilePath), LSPDocumentContainer);
-            Provider.UpdateLSPFileInfo(new Uri(Document1.FilePath), LSPDocumentContainer);
-
-            // Assert
-            Assert.Equal(1, callCount);
-        }
-
-        [Fact]
         public async Task UpdateLSPFileInfo_SolutionClosing_ClearsAllDocuments()
         {
             // Arrange


### PR DESCRIPTION
- Turns out that after one would rename a component there was a race that could occur where that component would be ejected from the C# compilation until close/reopen. This race was introduced in several different ways over the past year; however, it's primarily due to us trying not to leak memory on solution close. When we originally fixed https://github.com/dotnet/razor-tooling/issues/4703 we aggressively also added "document removed" mechanics to our cleanup mechanisms. We later then introduced the "solution is closing" path which accomplishes the same thing. Turns out that because we had a document remove mechanic built in what would happen is a user would rename a document which would enqueue a "document removed" on our project snapshot manager dispatcher thread while simultaneously the UI thread would kick Roslyn into removing / requesting dynamic document information from us. We'd provide it but then immediately re-remove the document in our background thread. This resulted in that document not existing in the C# compilation anymore and therefore not getting a TagHelper created for it.
- Because we already handle solution close in multiple ways in our dynamic file info provider we can now easily remove the document removed condition that ensures we don't leak to allow rename operations to not race with each other.
- Deleted tests because effectively this "fix" is allll just removing old code :D

Fixes #6149