### PR TITLE
Fix the method name for HoverAsync

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, VSInternalHover?>(
                 textBuffer,
-                Methods.TextDocumentRenameName,
+                Methods.TextDocumentHoverName,
                 languageServerName,
                 hoverParams,
                 cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
When delegating to C#/HTML hover was using the rename method name....

</shame>
