### PR TITLE
Single server go to definition

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
@@ -34,5 +34,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public const string RazorRenameEndpointName = "razor/rename";
 
         public const string RazorHoverEndpointName = "razor/hover";
+
+        public const string RazorDefinitionEndpointName = "razor/definition";
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -5,32 +5,42 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 // A file for delegated record types to be put. Each individually
 // should be a plain record. If more logic is needed than record
-// definition please put in a separate file. 
+// definition please put in a separate file.
+
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 
-internal record DelegatedHoverParams(
+/// <summary>
+/// Interface for delegated params that enables sharing of code in DefaultRazorLanguageServerCustomMessageTarget
+/// </summary>
+internal interface IDelegatedParams
+{
+    public VersionedTextDocumentIdentifier HostDocument { get; }
+    public RazorLanguageKind ProjectedKind { get; }
+}
+
+internal record DelegatedPositionParams(
     VersionedTextDocumentIdentifier HostDocument,
     Position ProjectedPosition,
-    RazorLanguageKind ProjectedKind);
-
-internal record DelegatedCompletionParams(
-        VersionedTextDocumentIdentifier HostDocument,
-        Position ProjectedPosition,
-        RazorLanguageKind ProjectedKind,
-        VSInternalCompletionContext Context,
-        TextEdit? ProvisionalTextEdit);
-
-internal record DelegatedCompletionResolutionContext(
-    DelegatedCompletionParams OriginalRequestParams,
-    object? OriginalCompletionListData);
+    RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
 internal record DelegatedRenameParams(
     VersionedTextDocumentIdentifier HostDocument,
     Position ProjectedPosition,
     RazorLanguageKind ProjectedKind,
-    string NewName);
+    string NewName) : IDelegatedParams;
+
+internal record DelegatedCompletionParams(
+    VersionedTextDocumentIdentifier HostDocument,
+    Position ProjectedPosition,
+    RazorLanguageKind ProjectedKind,
+    VSInternalCompletionContext Context,
+    TextEdit? ProvisionalTextEdit) : IDelegatedParams;
+
+internal record DelegatedCompletionResolutionContext(
+    DelegatedCompletionParams OriginalRequestParams,
+    object? OriginalCompletionListData);
 
 internal record DelegatedCompletionItemResolveParams(
-        TextDocumentIdentifier HostDocument,
-        VSInternalCompletionItem CompletionItem,
-        RazorLanguageKind OriginatingKind);
+    TextDocumentIdentifier HostDocument,
+    VSInternalCompletionItem CompletionItem,
+    RazorLanguageKind OriginatingKind);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -9,15 +9,6 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 
-/// <summary>
-/// Interface for delegated params that enables sharing of code in DefaultRazorLanguageServerCustomMessageTarget
-/// </summary>
-internal interface IDelegatedParams
-{
-    public VersionedTextDocumentIdentifier HostDocument { get; }
-    public RazorLanguageKind ProjectedKind { get; }
-}
-
 internal record DelegatedPositionParams(
     VersionedTextDocumentIdentifier HostDocument,
     Position ProjectedPosition,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/IDelegatedParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/IDelegatedParams.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+
+/// <summary>
+/// Interface for delegated params that enables sharing of code in DefaultRazorLanguageServerCustomMessageTarget
+/// </summary>
+internal interface IDelegatedParams
+{
+    public VersionedTextDocumentIdentifier HostDocument { get; }
+    public RazorLanguageKind ProjectedKind { get; }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -15,8 +15,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     internal abstract class AbstractRazorDelegatingEndpoint<TRequest, TResponse, TDelegatedParams> : IJsonRpcRequestHandler<TRequest, TResponse?>
         where TRequest : TextDocumentPositionParams, IRequest<TResponse?>
-        where TResponse : class
-        where TDelegatedParams : class
     {
         private readonly DocumentContextFactory _documentContextFactory;
         private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
@@ -62,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         /// will be used in <see cref="Handle(TRequest, CancellationToken)"/>
         /// </summary>
         protected virtual Task<TResponse?> TryHandleAsync(TRequest request, DocumentContext documentContext, CancellationToken cancellationToken)
-            => Task.FromResult<TResponse?>(null);
+            => Task.FromResult<TResponse?>(default);
 
         /// <summary>
         /// Returns true if the configuration supports this operation being handled, otherwise returns false. Use to
@@ -83,13 +81,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             if (!IsSupported())
             {
-                return null;
+                return default;
             }
 
             var documentContext = await _documentContextFactory.TryCreateAsync(request.TextDocument.Uri, cancellationToken).ConfigureAwait(false);
             if (documentContext is null)
             {
-                return null;
+                return default;
             }
 
             var response = await TryHandleAsync(request, documentContext, cancellationToken).ConfigureAwait(false);
@@ -100,7 +98,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             if (!_languageServerFeatureOptions.SingleServerSupport)
             {
-                return null;
+                return default;
             }
 
             var delegatedParams = await CreateDelegatedParamsAsync(request, documentContext, cancellationToken);
@@ -110,7 +108,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             if (delegatedResponse is null)
             {
-                return null;
+                return default;
             }
 
             var remappedResponse = await HandleDelegatedResponseAsync(delegatedResponse, documentContext, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -13,7 +14,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal abstract class AbstractRazorDelegatingEndpoint<TRequest, TResponse, TDelegatedParams> : IJsonRpcRequestHandler<TRequest, TResponse?>
+    internal abstract class AbstractRazorDelegatingEndpoint<TRequest, TResponse> : IJsonRpcRequestHandler<TRequest, TResponse?>
         where TRequest : TextDocumentPositionParams, IRequest<TResponse?>
     {
         private readonly DocumentContextFactory _documentContextFactory;
@@ -40,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         /// <summary>
         /// The delegated object to send to the <see cref="CustomMessageTarget"/>
         /// </summary>
-        protected abstract TDelegatedParams CreateDelegatedParams(TRequest request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken);
+        protected abstract IDelegatedParams CreateDelegatedParams(TRequest request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken);
 
         /// <summary>
         /// The name of the endpoint to delegate to, from <see cref="RazorLanguageServerCustomMessageTargets"/>. This is the

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -823,6 +823,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             foreach (var entry in documentEdits)
             {
                 var virtualDocumentUri = entry.TextDocument.Uri;
+
+                // Check if the edit is actually for a generated document, because if not we don't need to do anything
                 if (!_languageServerFeatureOptions.IsVirtualDocumentUri(virtualDocumentUri))
                 {
                     // This location doesn't point to a background razor file. No need to remap.
@@ -868,9 +870,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 var uri = new Uri(entry.Key);
                 var edits = entry.Value;
 
+                // Check if the edit is actually for a generated document, because if not we don't need to do anything
                 if (!_languageServerFeatureOptions.IsVirtualDocumentUri(uri))
                 {
-                    // This location doesn't point to a background razor file. No need to remap.
                     remappedChanges[entry.Key] = entry.Value;
                     continue;
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
@@ -5,6 +5,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -103,6 +105,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var sourceText = codeDocument.GetHtmlSourceText();
 
             return sourceText;
+        }
+
+        public async Task<SyntaxNode?> GetSyntaxNodeAsync(int absoluteIndex, CancellationToken cancellationToken)
+        {
+            var change = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
+            var syntaxTree = await GetSyntaxTreeAsync(cancellationToken);
+            if (syntaxTree.Root is null)
+            {
+                return null;
+            }
+
+            return syntaxTree.Root.LocateOwner(change);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 {
-    internal class RazorHoverEndpoint : AbstractRazorDelegatingEndpoint<VSHoverParamsBridge, VSInternalHover, DelegatedHoverParams>, IVSHoverEndpoint
+    internal class RazorHoverEndpoint : AbstractRazorDelegatingEndpoint<VSHoverParamsBridge, VSInternalHover>, IVSHoverEndpoint
     {
         private readonly RazorHoverInfoService _hoverInfoService;
         private readonly RazorDocumentMappingService _documentMappingService;
@@ -50,8 +50,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName;
 
         /// <inheritdoc/>
-        protected override DelegatedHoverParams CreateDelegatedParams(VSHoverParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
-            => new DelegatedHoverParams(
+        protected override IDelegatedParams CreateDelegatedParams(VSHoverParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+            => new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
                     projection.LanguageKind);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -7,10 +7,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
-using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -18,7 +16,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 {
     internal class RazorHoverEndpoint : AbstractRazorDelegatingEndpoint<VSHoverParamsBridge, VSInternalHover, DelegatedHoverParams>, IVSHoverEndpoint
     {
-        private readonly DocumentContextFactory _documentContextFactory;
         private readonly RazorHoverInfoService _hoverInfoService;
         private readonly RazorDocumentMappingService _documentMappingService;
         private VSInternalClientCapabilities? _clientCapabilities;
@@ -30,9 +27,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
             RazorDocumentMappingService documentMappingService,
             ClientNotifierServiceBase languageServer,
             ILoggerFactory loggerFactory)
-            : base(documentContextFactory, languageServerFeatureOptions, languageServer, loggerFactory.CreateLogger<RazorHoverEndpoint>())
+            : base(documentContextFactory, languageServerFeatureOptions, documentMappingService, languageServer, loggerFactory.CreateLogger<RazorHoverEndpoint>())
         {
-            _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
             _hoverInfoService = hoverInfoService ?? throw new ArgumentNullException(nameof(hoverInfoService));
             _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
         }
@@ -54,27 +50,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName;
 
         /// <inheritdoc/>
-        protected override async Task<DelegatedHoverParams> CreateDelegatedParamsAsync(VSHoverParamsBridge request, DocumentContext documentContext, CancellationToken cancellationToken)
-        {
-            var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
-            var absoluteIndex = request.Position.GetRequiredAbsoluteIndex(sourceText, Logger);
-            var projection = await _documentMappingService.GetProjectionAsync(documentContext, absoluteIndex, cancellationToken).ConfigureAwait(false);
-
-            return new DelegatedHoverParams(
-                        documentContext.Identifier,
-                        projection.Position,
-                        projection.LanguageKind);
-        }
+        protected override DelegatedHoverParams CreateDelegatedParams(VSHoverParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+            => new DelegatedHoverParams(
+                    documentContext.Identifier,
+                    projection.Position,
+                    projection.LanguageKind);
 
         /// <inheritdoc/>
-        protected override async Task<VSInternalHover?> TryHandleAsync(VSHoverParamsBridge request, DocumentContext documentContext, CancellationToken cancellationToken)
+        protected override async Task<VSInternalHover?> TryHandleAsync(VSHoverParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
-            var projection = await _documentMappingService.TryGetProjectionAsync(documentContext, request.Position, Logger, cancellationToken).ConfigureAwait(false);
-            if (projection is null)
-            {
-                return null;
-            }
-
             // HTML can still sometimes be handled by razor. For example hovering over
             // a component tag like <Counter /> will still be in an html context
             if (projection.LanguageKind == RazorLanguageKind.CSharp)
@@ -82,10 +66,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
                 return null;
             }
 
-            var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
-            var linePosition = new LinePosition(request.Position.Line, request.Position.Character);
-            var hostDocumentIndex = sourceText.Lines.GetPosition(linePosition);
-            var location = new SourceLocation(hostDocumentIndex, request.Position.Line, request.Position.Character);
+            var location = new SourceLocation(projection.AbsoluteIndex, request.Position.Line, request.Position.Character);
             var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken);
 
             return _hoverInfoService.GetHoverInfo(codeDocument, location, _clientCapabilities!);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +32,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public abstract RazorLanguageKind GetLanguageKind(RazorCodeDocument codeDocument, int originalIndex, bool rightAssociative);
 
         public abstract Task<WorkspaceEdit> RemapWorkspaceEditAsync(WorkspaceEdit workspaceEdit, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Maps a range in the specified virtual document uri to a range in the Razor document that owns the
+        /// virtual document. If the uri passed in is not for a virtual document, or the range cannot be mapped
+        /// for some other reason, the original passed in range is returned unchanged.
+        /// </summary>
+        public abstract Task<Range> MapFromProjectedDocumentRangeAsync(Uri virtualDocumentUri, Range projectedRange, CancellationToken cancellationToken);
 
         public async Task<Projection> GetProjectionAsync(DocumentContext documentContext, int absoluteIndex, CancellationToken cancellationToken)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -25,7 +25,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
 {
-    internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBridge, WorkspaceEdit, DelegatedRenameParams>, IRenameEndpoint
+    internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBridge, WorkspaceEdit>, IRenameEndpoint
     {
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
         private readonly DocumentContextFactory _documentContextFactory;
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             => _languageServerFeatureOptions.SupportsFileManipulation;
 
         /// <inheritdoc/>
-        protected override DelegatedRenameParams CreateDelegatedParams(RenameParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        protected override IDelegatedParams CreateDelegatedParams(RenameParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
             => new DelegatedRenameParams(
                     documentContext.Identifier,
                     projection.Position,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -70,6 +70,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
         /// <inheritdoc/>
         protected override async Task<WorkspaceEdit?> TryHandleAsync(RenameParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
+            // We only support renaming of .razor components, not .cshtml tag helpers
+            if (!FileKinds.IsComponent(documentContext.FileKind))
+            {
+                return null;
+            }
 
             // If we're in C# then there is no point checking for a component tag, because there won't be one
             if (projection.LanguageKind == RazorLanguageKind.CSharp)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1107,6 +1107,33 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return response?.Response;
         }
 
+        public async override Task<Location[]?> DefinitionAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
+        {
+            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+            if (delegationDetails is null)
+            {
+                return null;
+            }
+
+            var definitionParams = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = delegationDetails.ProjectedUri,
+                },
+                Position = request.ProjectedPosition,
+            };
+
+            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]?>(
+                delegationDetails.TextBuffer,
+                Methods.TextDocumentDefinitionName,
+                delegationDetails.LanguageServerName,
+                definitionParams,
+                cancellationToken).ConfigureAwait(false);
+
+            return response?.Response;
+        }
+
         private async Task<DelegationRequestDetails?> GetProjectedRequestDetailsAsync(IDelegatedParams request, CancellationToken cancellationToken)
         {
             string languageServerName;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1174,6 +1174,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return new DelegationRequestDetails(languageServerName, projectedUri, virtualDocumentSnapshot.Snapshot.TextBuffer);
         }
 
-        private record DelegationRequestDetails(string LanguageServerName, Uri ProjectedUri, ITextBuffer TextBuffer);
+        private record struct DelegationRequestDetails(string LanguageServerName, Uri ProjectedUri, ITextBuffer TextBuffer);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1064,17 +1064,17 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
-                    Uri = delegationDetails.ProjectedUri,
+                    Uri = delegationDetails.Value.ProjectedUri,
                 },
                 Position = request.ProjectedPosition,
                 NewName = request.NewName,
             };
 
-            var textBuffer = delegationDetails.TextBuffer;
+            var textBuffer = delegationDetails.Value.TextBuffer;
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<RenameParams, WorkspaceEdit?>(
                 textBuffer,
                 Methods.TextDocumentRenameName,
-                delegationDetails.LanguageServerName,
+                delegationDetails.Value.LanguageServerName,
                 renameParams,
                 cancellationToken).ConfigureAwait(false);
             return response?.Response;
@@ -1092,15 +1092,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
-                    Uri = delegationDetails.ProjectedUri,
+                    Uri = delegationDetails.Value.ProjectedUri,
                 },
                 Position = request.ProjectedPosition,
             };
 
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, VSInternalHover?>(
-                delegationDetails.TextBuffer,
+                delegationDetails.Value.TextBuffer,
                 Methods.TextDocumentHoverName,
-                delegationDetails.LanguageServerName,
+                delegationDetails.Value.LanguageServerName,
                 hoverParams,
                 cancellationToken).ConfigureAwait(false);
 
@@ -1119,15 +1119,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
-                    Uri = delegationDetails.ProjectedUri,
+                    Uri = delegationDetails.Value.ProjectedUri,
                 },
                 Position = request.ProjectedPosition,
             };
 
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, Location[]?>(
-                delegationDetails.TextBuffer,
+                delegationDetails.Value.TextBuffer,
                 Methods.TextDocumentDefinitionName,
-                delegationDetails.LanguageServerName,
+                delegationDetails.Value.LanguageServerName,
                 definitionParams,
                 cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.WrapWithTag;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json.Linq;
 using OmniSharpConfigurationParams = OmniSharp.Extensions.LanguageServer.Protocol.Models.ConfigurationParams;
@@ -1053,39 +1054,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         public override async Task<WorkspaceEdit?> RenameAsync(DelegatedRenameParams request, CancellationToken cancellationToken)
         {
-            var hostDocumentUri = request.HostDocument.Uri;
-            if (!_documentManager.TryGetDocument(hostDocumentUri, out var documentSnapshot))
-            {
-                return null;
-            }
-
-            string languageServerName;
-            Uri projectedUri;
-            VirtualDocumentSnapshot virtualDocumentSnapshot;
-            if (request.ProjectedKind == RazorLanguageKind.Html &&
-                documentSnapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var htmlVirtualDocument))
-            {
-                languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-                projectedUri = htmlVirtualDocument.Uri;
-                virtualDocumentSnapshot = htmlVirtualDocument;
-            }
-            else if (request.ProjectedKind == RazorLanguageKind.CSharp &&
-                documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpVirtualDocument))
-            {
-                languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
-                projectedUri = csharpVirtualDocument.Uri;
-                virtualDocumentSnapshot = csharpVirtualDocument;
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
-                return null;
-            }
-
-            var synchronized = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync(
-                request.HostDocument.Version, virtualDocumentSnapshot, rejectOnNewerParallelRequest: false, cancellationToken);
-
-            if (!synchronized)
+            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+            if (delegationDetails is null)
             {
                 return null;
             }
@@ -1094,32 +1064,59 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
-                    Uri = projectedUri,
+                    Uri = delegationDetails.ProjectedUri,
                 },
                 Position = request.ProjectedPosition,
                 NewName = request.NewName,
             };
 
-            var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
+            var textBuffer = delegationDetails.TextBuffer;
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<RenameParams, WorkspaceEdit?>(
                 textBuffer,
                 Methods.TextDocumentRenameName,
-                languageServerName,
+                delegationDetails.LanguageServerName,
                 renameParams,
                 cancellationToken).ConfigureAwait(false);
             return response?.Response;
         }
 
-        public async override Task<VSInternalHover?> HoverAsync(DelegatedHoverParams request, CancellationToken cancellationToken)
+        public async override Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
         {
-            var hostDocumentUri = request.HostDocument.Uri;
-            if (!_documentManager.TryGetDocument(hostDocumentUri, out var documentSnapshot))
+            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+            if (delegationDetails is null)
             {
                 return null;
             }
 
+            var hoverParams = new TextDocumentPositionParams()
+            {
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = delegationDetails.ProjectedUri,
+                },
+                Position = request.ProjectedPosition,
+            };
+
+            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, VSInternalHover?>(
+                delegationDetails.TextBuffer,
+                Methods.TextDocumentHoverName,
+                delegationDetails.LanguageServerName,
+                hoverParams,
+                cancellationToken).ConfigureAwait(false);
+
+            return response?.Response;
+        }
+
+        private async Task<DelegationRequestDetails?> GetProjectedRequestDetailsAsync(IDelegatedParams request, CancellationToken cancellationToken)
+        {
             string languageServerName;
             Uri projectedUri;
+
+            if (!_documentManager.TryGetDocument(request.HostDocument.Uri, out var documentSnapshot))
+            {
+                return null;
+            }
+
             VirtualDocumentSnapshot virtualDocumentSnapshot;
             if (request.ProjectedKind == RazorLanguageKind.Html &&
                 documentSnapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var htmlVirtualDocument))
@@ -1141,32 +1138,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return null;
             }
 
-            var synchronized = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync(
-                request.HostDocument.Version, virtualDocumentSnapshot, rejectOnNewerParallelRequest: false, cancellationToken);
-
+            var synchronized = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync(request.HostDocument.Version, virtualDocumentSnapshot, rejectOnNewerParallelRequest: false, cancellationToken);
             if (!synchronized)
             {
                 return null;
             }
 
-            var hoverParams = new TextDocumentPositionParams()
-            {
-                TextDocument = new TextDocumentIdentifier()
-                {
-                    Uri = projectedUri,
-                },
-                Position = request.ProjectedPosition,
-            };
-
-            var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
-            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, VSInternalHover?>(
-                textBuffer,
-                Methods.TextDocumentHoverName,
-                languageServerName,
-                hoverParams,
-                cancellationToken).ConfigureAwait(false);
-
-            return response?.Response;
+            return new DelegationRequestDetails(languageServerName, projectedUri, virtualDocumentSnapshot.Snapshot.TextBuffer);
         }
+
+        private record DelegationRequestDetails(string LanguageServerName, Uri ProjectedUri, ITextBuffer TextBuffer);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -109,6 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             {
                 _initializeResult.Capabilities.RenameProvider = false;
                 _initializeResult.Capabilities.HoverProvider = false;
+                _initializeResult.Capabilities.DefinitionProvider = false;
             }
 
             if (!_languageServerFeatureOptions.SingleServerCompletionSupport)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -98,6 +98,6 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         public abstract Task<WorkspaceEdit?> RenameAsync(DelegatedRenameParams request, CancellationToken cancellationToken);
 
         [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<VSInternalHover?> HoverAsync(DelegatedHoverParams request, CancellationToken cancellationToken);
+        public abstract Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -99,5 +99,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
+
+        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorDefinitionEndpointName, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<Location[]?> DefinitionAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -1,22 +1,38 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#nullable disable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using Xunit;
+using DefinitionResult = Microsoft.VisualStudio.LanguageServer.Protocol.SumType<
+    Microsoft.VisualStudio.LanguageServer.Protocol.VSInternalLocation,
+    Microsoft.VisualStudio.LanguageServer.Protocol.VSInternalLocation[],
+    Microsoft.VisualStudio.LanguageServer.Protocol.DocumentLink[]>;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 {
+    [UseExportProvider]
     public class RazorDefinitionEndpointTest : TagHelperServiceTestBase
     {
         private const string DefaultContent = @"@addTagHelper *, TestAssembly
@@ -337,7 +353,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             SetupDocument(out var codeDocument, out _, content);
             var expectedRange = selection.AsRange(codeDocument.GetSourceText());
 
-            var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(),LoggerFactory);
+            var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
 
             // Act II
             var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, Logger, CancellationToken.None).ConfigureAwait(false);
@@ -364,7 +380,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             SetupDocument(out var codeDocument, out _, content);
             var expectedRange = selection.AsRange(codeDocument.GetSourceText());
 
-            var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(),LoggerFactory);
+            var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
 
             // Act II
             var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, Logger, CancellationToken.None).ConfigureAwait(false);
@@ -395,7 +411,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             SetupDocument(out var codeDocument, out _, content);
             var expectedRange = selection.AsRange(codeDocument.GetSourceText());
 
-            var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(),LoggerFactory);
+            var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
 
             // Act II
             var range = await RazorDefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, "Title", mappingService, Logger, CancellationToken.None).ConfigureAwait(false);
@@ -409,7 +425,185 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             codeDocument = CreateCodeDocument(content, "text.razor", DefaultTagHelpers);
             var outDoc = codeDocument;
             documentSnapshot = Mock.Of<DocumentSnapshot>(d => d.GetTextAsync() == Task.FromResult(sourceText), MockBehavior.Strict);
-            Mock.Get(documentSnapshot).Setup( s => s.GetGeneratedOutputAsync()).Returns(Task.FromResult(outDoc));
+            Mock.Get(documentSnapshot).Setup(s => s.GetGeneratedOutputAsync()).Returns(Task.FromResult(outDoc));
+        }
+
+        [Fact]
+        public async Task Handle_SingleServer_CSharp_Method()
+        {
+            var input = """
+                <div></div>
+
+                @{
+                    var x = Ge$$tX();
+                }
+
+                @functions
+                {
+                    void [|GetX|]()
+                    {
+                    }
+                }
+                """;
+
+            await VerifyCSharpGoToDefinitionAsync(input);
+        }
+
+        [Fact]
+        public async Task Handle_SingleServer_CSharp_Local()
+        {
+            var input = """
+                <div></div>
+
+                @{
+                    var x = GetX();
+                }
+
+                @functions
+                {
+                    private string [|_name|];
+
+                    string GetX()
+                    {
+                        return _na$$me;
+                    }
+                }
+                """;
+
+            await VerifyCSharpGoToDefinitionAsync(input);
+        }
+
+        [Fact]
+        public async Task Handle_SingleServer_CSharp_MetadataReference()
+        {
+            var input = """
+                <div></div>
+
+                @functions
+                {
+                    private stri$$ng _name;
+                }
+                """;
+
+            // Arrange
+            TestFileMarkupParser.GetPosition(input, out var output, out var cursorPosition);
+
+            var codeDocument = CreateCodeDocument(output);
+            var csharpDocumentUri = new Uri("C:/path/to/file.razor__virtual.g.cs");
+
+            // Act
+            var result = await GetDefinitionResultAsync(codeDocument, csharpDocumentUri, cursorPosition);
+
+            // Assert
+            Assert.NotNull(result.Value.Second);
+            var locations = result.Value.Second;
+            var location = Assert.Single(locations);
+            Assert.EndsWith("String.cs", location.Uri.ToString());
+            Assert.Equal(21, location.Range.Start.Line);
+        }
+
+        private async Task VerifyCSharpGoToDefinitionAsync(string input)
+        {
+            // Arrange
+            TestFileMarkupParser.GetPositionAndSpan(input, out var output, out var cursorPosition, out var expectedSpan);
+
+            var codeDocument = CreateCodeDocument(output);
+            var csharpDocumentUri = new Uri("C:/path/to/file.razor__virtual.g.cs");
+
+            // Act
+            var result = await GetDefinitionResultAsync(codeDocument, csharpDocumentUri, cursorPosition);
+
+            // Assert
+            Assert.NotNull(result.Value.Second);
+            var locations = result.Value.Second;
+            var location = Assert.Single(locations);
+            Assert.Equal(csharpDocumentUri, location.Uri);
+
+            var expectedRange = expectedSpan.AsRange(codeDocument.GetSourceText());
+            Assert.Equal(expectedRange, location.Range);
+        }
+
+        private async Task<DefinitionResult?> GetDefinitionResultAsync(RazorCodeDocument codeDocument, Uri csharpDocumentUri, int cursorPosition)
+        {
+            var csharpSourceText = codeDocument.GetCSharpSourceText();
+            var serverCapabilities = new ServerCapabilities()
+            {
+                DefinitionProvider = true
+            };
+            var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(csharpSourceText, csharpDocumentUri, serverCapabilities, razorSpanMappingService: null).ConfigureAwait(false);
+            await csharpServer.OpenDocumentAsync(csharpDocumentUri, csharpSourceText.ToString()).ConfigureAwait(false);
+
+            var razorFilePath = "C:/path/to/file.razor";
+            var documentContextFactory = new TestDocumentContextFactory(razorFilePath, codeDocument, version: 1337);
+            var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(options =>
+                options.SupportsFileManipulation == true &&
+                options.SingleServerSupport == true &&
+                options.CSharpVirtualDocumentSuffix == ".g.cs" &&
+                options.HtmlVirtualDocumentSuffix == ".g.html"
+                , MockBehavior.Strict);
+            var languageServer = new DefinitionLanguageServer(csharpServer, csharpDocumentUri);
+            var documentMappingService = new DefaultRazorDocumentMappingService(languageServerFeatureOptions, documentContextFactory, LoggerFactory);
+            var projectSnapshotManager = Mock.Of<ProjectSnapshotManagerBase>(p => p.Projects == new[] { Mock.Of<ProjectSnapshot>(MockBehavior.Strict) }, MockBehavior.Strict);
+            var projectSnapshotManagerAccessor = new TestProjectSnapshotManagerAccessor(projectSnapshotManager);
+            var projectSnapshotManagerDispatcher = new LSPProjectSnapshotManagerDispatcher(LoggerFactory);
+            var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, projectSnapshotManagerAccessor, LoggerFactory);
+
+            var endpoint = new RazorDefinitionEndpoint(documentContextFactory, searchEngine, documentMappingService, languageServerFeatureOptions, languageServer, TestLoggerFactory.Instance);
+
+            codeDocument.GetSourceText().GetLineAndOffset(cursorPosition, out var line, out var offset);
+            var request = new DefinitionParamsBridge
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri(razorFilePath)
+                },
+                Position = new Position(line, offset)
+            };
+
+            return await endpoint.Handle(request, CancellationToken.None);
+        }
+
+        private class DefinitionLanguageServer : ClientNotifierServiceBase
+        {
+            private readonly CSharpTestLspServer _csharpServer;
+            private readonly Uri _csharpDocumentUri;
+
+            public DefinitionLanguageServer(CSharpTestLspServer csharpServer, Uri csharpDocumentUri)
+            {
+                _csharpServer = csharpServer;
+                _csharpDocumentUri = csharpDocumentUri;
+            }
+
+            public override OmniSharp.Extensions.LanguageServer.Protocol.Models.InitializeParams ClientSettings { get; }
+
+            public override Task OnStarted(ILanguageServer server, CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public override Task<IResponseRouterReturns> SendRequestAsync(string method)
+            {
+                throw new NotImplementedException();
+            }
+
+            public async override Task<IResponseRouterReturns> SendRequestAsync<T>(string method, T @params)
+            {
+                Assert.Equal(RazorLanguageServerCustomMessageTargets.RazorDefinitionEndpointName, method);
+                var definitionParams = Assert.IsType<DelegatedPositionParams>(@params);
+
+                var definitionRequest = new TextDocumentPositionParams()
+                {
+                    TextDocument = new TextDocumentIdentifier()
+                    {
+                        Uri = _csharpDocumentUri
+                    },
+                    Position = definitionParams.ProjectedPosition
+                };
+
+                var result = await _csharpServer.ExecuteRequestAsync<TextDocumentPositionParams, DefinitionResult?>(Methods.TextDocumentDefinitionName, definitionRequest, CancellationToken.None);
+
+                return new TestResponseRouterReturn(result);
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
 
@@ -38,11 +37,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             Mock.Get(documentSnapshot).Setup(s => s.GetGeneratedOutputAsync()).Returns(Task.FromResult(codeDocument));
 
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 2);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 34, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);
@@ -56,11 +54,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             // Arrange
             SetupDocument(out var _, out var documentSnapshot);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 2);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 34, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);
@@ -74,11 +71,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             // Arrange
             SetupDocument(out var _, out var documentSnapshot);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 35);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 67, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);
@@ -92,11 +88,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             // Arrange
             SetupDocument(out var _, out var documentSnapshot);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 14);
 
             // Act
             var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 46, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
@@ -109,11 +104,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             // Arrange
             SetupDocument(out var _, out var documentSnapshot);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 24);
 
             // Act
             var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 56, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
@@ -126,11 +120,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             // Arrange
             SetupDocument(out var _, out var documentSnapshot);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 18);
 
             // Act
             var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 50, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
@@ -143,11 +136,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             // Arrange
             SetupDocument(out var _, out var documentSnapshot);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 29);
 
             // Act
             var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 61, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
@@ -167,11 +159,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 }";
             SetupDocument(out var _, out var documentSnapshot, content);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 2);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 34, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);
@@ -192,11 +183,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 }";
             SetupDocument(out var _, out var documentSnapshot, content);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 2);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 34, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);
@@ -218,11 +208,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 }";
             SetupDocument(out var _, out var documentSnapshot, content);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 2);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 34, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);
@@ -237,11 +226,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             var content = $"@addTagHelper *, TestAssembly{Environment.NewLine}<p><strong></strong></p>";
             SetupDocument(out var _, out var documentSnapshot, content);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 6);
 
             // Act
             var (binding, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 38, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.Null(binding);
@@ -262,11 +250,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 }";
             SetupDocument(out var _, out var documentSnapshot, content);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 14);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 46, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);
@@ -289,11 +276,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 }";
             SetupDocument(out var _, out var documentSnapshot, content);
             var documentContext = CreateDocumentContext(new Uri("C:\\file.razor"), documentSnapshot);
-            var position = new Position(1, 14);
 
             // Act
             var (descriptor, attributeDescriptor) = await RazorDefinitionEndpoint.GetOriginTagHelperBindingAsync(
-                documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
+                documentContext, 46, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), CancellationToken.None).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(descriptor);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -524,7 +524,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
 
             var languageServerMock = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
             languageServerMock
-                .Setup(c => c.SendRequestAsync(RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName, It.IsAny<DelegatedHoverParams>()))
+                .Setup(c => c.SendRequestAsync<IDelegatedParams>(RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName, It.IsAny<DelegatedPositionParams>()))
                 .Returns(Task.FromResult(responseRouterReturnsMock.Object));
 
             var documentMappingServiceMock = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
@@ -774,7 +774,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             public async override Task<IResponseRouterReturns> SendRequestAsync<T>(string method, T @params)
             {
                 Assert.Equal(RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName, method);
-                var hoverParams = Assert.IsType<DelegatedHoverParams>(@params);
+                var hoverParams = Assert.IsType<DelegatedPositionParams>(@params);
 
                 var hoverRequest = new VisualStudio.LanguageServer.Protocol.TextDocumentPositionParams()
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -575,7 +575,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
                 }
                 """;
 
-
             // Act
             var result = await GetResultFromSingleServerEndpointAsync(input);
 
@@ -738,16 +737,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
             return new DefaultRazorHoverInfoService(TagHelperFactsService, lspTagHelperTooltipFactory, vsLspTagHelperTooltipFactory, HtmlFactsService);
         }
 
-        internal class TestProjectSnapshotManagerAccessor : ProjectSnapshotManagerAccessor
-        {
-            public TestProjectSnapshotManagerAccessor(ProjectSnapshotManagerBase instance)
-            {
-                Instance = instance;
-            }
-
-            public override ProjectSnapshotManagerBase Instance { get; }
-        }
-
         private class HoverLanguageServer : ClientNotifierServiceBase
         {
             private readonly CSharpTestLspServer _csharpServer;
@@ -787,29 +776,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
 
                 var result = await _csharpServer.ExecuteRequestAsync<VisualStudio.LanguageServer.Protocol.TextDocumentPositionParams, VSInternalHover>(Methods.TextDocumentHoverName, hoverRequest, CancellationToken.None);
 
-                return new ResponseRouterReturn(result);
-            }
-        }
-
-        private class ResponseRouterReturn : IResponseRouterReturns
-        {
-            private readonly VSInternalHover _result;
-
-            public ResponseRouterReturn(VSInternalHover result)
-            {
-                _result = result;
-            }
-
-            public Task<TResponse> Returning<TResponse>(CancellationToken cancellationToken)
-            {
-                Assert.IsType<TResponse>(_result);
-
-                return Task.FromResult((TResponse)(object)_result);
-            }
-
-            public Task ReturningVoid(CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
+                return new TestResponseRouterReturn(result);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.CSharp;
@@ -651,16 +652,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
             return endpoint;
         }
 
-        internal class TestProjectSnapshotManagerAccessor : ProjectSnapshotManagerAccessor
-        {
-            public TestProjectSnapshotManagerAccessor(ProjectSnapshotManagerBase instance)
-            {
-                Instance = instance;
-            }
-
-            public override ProjectSnapshotManagerBase Instance { get; }
-        }
-
         private class RenameLanguageServer : ClientNotifierServiceBase
         {
             private readonly CSharpTestLspServer _csharpServer;
@@ -701,29 +692,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
 
                 var result = await _csharpServer.ExecuteRequestAsync<RenameParams, WorkspaceEdit>(Methods.TextDocumentRenameName, renameRequest, CancellationToken.None);
 
-                return new ResponseRouterReturn(result);
-            }
-        }
-
-        private class ResponseRouterReturn : IResponseRouterReturns
-        {
-            private WorkspaceEdit _result;
-
-            public ResponseRouterReturn(WorkspaceEdit result)
-            {
-                _result = result;
-            }
-
-            public Task<TResponse> Returning<TResponse>(CancellationToken cancellationToken)
-            {
-                Assert.IsType<TResponse>(_result);
-
-                return Task.FromResult((TResponse)(object)_result);
-            }
-
-            public Task ReturningVoid(CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
+                return new TestResponseRouterReturn(result);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -401,7 +401,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
 
             var languageServerMock = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
             languageServerMock
-                .Setup(c => c.SendRequestAsync(RazorLanguageServerCustomMessageTargets.RazorRenameEndpointName, It.IsAny<DelegatedRenameParams>()))
+                .Setup(c => c.SendRequestAsync<IDelegatedParams>(RazorLanguageServerCustomMessageTargets.RazorRenameEndpointName, It.IsAny<DelegatedRenameParams>()))
                 .Returns(Task.FromResult(responseRouterReturnsMock.Object));
 
             var documentMappingServiceMock = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestClient.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestClient.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             throw new NotImplementedException();
         }
 
-        private IResponseRouterReturns GetResponseRouterReturns()
+        private static IResponseRouterReturns GetResponseRouterReturns()
         {
             var mock = new Mock<IResponseRouterReturns>(MockBehavior.Strict);
             mock.Setup(r => r.ReturningVoid(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshotManagerAccessor.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshotManagerAccessor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
+{
+    internal class TestProjectSnapshotManagerAccessor : ProjectSnapshotManagerAccessor
+    {
+        public TestProjectSnapshotManagerAccessor(ProjectSnapshotManagerBase instance)
+        {
+            Instance = instance;
+        }
+
+        public override ProjectSnapshotManagerBase Instance { get; }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestResponseRouterReturn.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestResponseRouterReturn.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test
+{
+    internal class TestResponseRouterReturn : IResponseRouterReturns
+    {
+        private readonly object _result;
+
+        public TestResponseRouterReturn(object result)
+        {
+            _result = result;
+        }
+
+        public Task<TResponse> Returning<TResponse>(CancellationToken cancellationToken)
+        {
+            return Task.FromResult((TResponse)(object)_result);
+        }
+
+        public Task ReturningVoid(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6652

Unfortunately due to a lot of build issues, I couldn't make the tests actually use the real custom message target, but maybe one day.

I inched the rename and hover endpoints a bit further too, so might want to review commit-by-commit. Each commit has a _little_ more info about what it is too.