### PR TITLE
Try alternate file moving code for ARM macx

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ProjectRazorJsonPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/ProjectRazorJsonPublisher.cs
@@ -286,15 +286,15 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             {
                 var projectRazorJson = new ProjectRazorJson(publishFilePath, projectSnapshot);
                 _serializer.Serialize(writer, projectRazorJson);
-
-                var fileInfo = new FileInfo(publishFilePath);
-                if (fileInfo.Exists)
-                {
-                    fileInfo.Delete();
-                }
             }
 
-            tempFileInfo.MoveTo(publishFilePath);
+            var fileInfo = new FileInfo(publishFilePath);
+            if (fileInfo.Exists)
+            {
+                fileInfo.Delete();
+            }
+
+            File.Move(tempFilePath, publishFilePath);
         }
 
         protected virtual bool FileExists(string file)


### PR DESCRIPTION
Serializing the project.razor.json is failing for me on an M1 Mac, specifically the temp file is being created, but then I'm getting a file not found error when it tries to get renamed (moved) to the real file name. I don't know for sure what is going on, but it could be https://github.com/dotnet/runtime/issues/35122 so going to see if this works any better.