### PR TITLE
Include Language Configuration in VS Mac addin.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -100,6 +100,13 @@
     <MPackFile Include="..\Microsoft.VisualStudio.RazorExtension\EmbeddedGrammars\*">
       <Folder>Grammars</Folder>
     </MPackFile>
+
+    <!-- Embedded Language Configuration Files -->
+    <MPackFile Include="$(RepositoryRoot)src\Razor\src\Microsoft.VisualStudio.RazorExtension\language-configuration.json" />
+    <MPackFile Include="$(RepositoryRoot)src\Razor\src\Microsoft.VisualStudio.RazorExtension\javascript-language-configuration.json" />
+    <MPackFile Include="$(RepositoryRoot)src\Razor\src\Microsoft.VisualStudio.RazorExtension\css-language-configuration.json" />
+    <MPackFile Include="$(RepositoryRoot)src\Razor\src\Microsoft.VisualStudio.RazorExtension\csharp-language-configuration.json" />
+    <MPackFile Include="$(RepositoryRoot)src\Razor\src\Microsoft.VisualStudio.RazorExtension\razordirective-language-configuration.json" />
   </ItemGroup>
 
   <ItemGroup Condition="$(DebugType) != 'embedded'">

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -68,4 +68,12 @@
   <Extension path="/MonoDevelop/Ide/Editor/TextMate">
     <Repository folderPath="Grammars"/>
   </Extension>
+
+  <Extension path="/MonoDevelop/Ide/Editor/LanguageConfiguration">
+    <LanguageConfiguration contentTypeName="Razor" scopeName="text.aspnetcorerazor" languageConfigurationFilePath="language-configuration.json" />
+    <LanguageConfiguration scopeName="source.js" languageConfigurationFilePath="javascript-language-configuration.json" />
+    <LanguageConfiguration scopeName="source.css" languageConfigurationFilePath="css-language-configuration.json" />
+    <LanguageConfiguration scopeName="source.cs" languageConfigurationFilePath="csharp-language-configuration.json" />
+    <LanguageConfiguration scopeName="meta.directive" languageConfigurationFilePath="razordirective-language-configuration.json" />
+  </Extension>
 </ExtensionModel>


### PR DESCRIPTION
### Summary of the changes

- Includes Razor Language Configuration file in the MPack with the requisite authoring required for VS Mac.
- Compliments this: https://github.com/xamarin/vsmac/pull/8621/files