### PR TITLE
Don't try to delegate to Razor

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -46,10 +46,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         /// <summary>
         /// The name of the endpoint to delegate to, from <see cref="RazorLanguageServerCustomMessageTargets"/>. This is the
         /// custom endpoint that is sent via <see cref="ClientNotifierServiceBase"/> which returns
-        /// a response by delegating to C#/HTML. 
+        /// a response by delegating to C#/HTML.
         /// </summary>
         /// <remarks>
-        /// An example is <see cref="RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName"/> 
+        /// An example is <see cref="RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName"/>
         /// </remarks>
         protected abstract string CustomMessageTarget { get; }
 
@@ -108,6 +108,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             if (!_languageServerFeatureOptions.SingleServerSupport)
+            {
+                return default;
+            }
+
+            // We can only delegate to C# and HTML, so if we're in a Razor context and our inheritor didn't want to provide
+            // any response then that's all we can do.
+            if (projection.LanguageKind == RazorLanguageKind.Razor)
             {
                 return default;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -437,6 +437,37 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring.Test
         }
 
         [Fact]
+        public async Task Handle_Rename_SingleServer_DoesntDelegateForRazor()
+        {
+            // Arrange
+            var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(options => options.SupportsFileManipulation == true && options.SingleServerSupport == true, MockBehavior.Strict);
+            var responseRouterReturnsMock = new Mock<IResponseRouterReturns>(MockBehavior.Strict);
+            var languageServerMock = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
+            var documentMappingServiceMock = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
+            documentMappingServiceMock
+                .Setup(c => c.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Returns(RazorLanguageKind.Razor);
+
+            var endpoint = CreateEndpoint(languageServerFeatureOptions, documentMappingServiceMock.Object, languageServerMock.Object);
+
+            var request = new RenameParamsBridge
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri("file:///c:/Second/ComponentWithParam.razor")
+                },
+                Position = new Position(1, 0),
+                NewName = "Test2"
+            };
+
+            // Act
+            var result = await endpoint.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
         public async Task Handle_Rename_SingleServer_CSharpEditsAreMapped()
         {
             var input = """


### PR DESCRIPTION
Found while debugging.

Fortunately in release this has no negative effect, other than an extra call to the custom message target before we return null, but during debugging its annoying with the constant assert popups.