### PR TITLE
Fixed Go to Definition for TypeScript

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -114,13 +114,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 
             if (response.Value.TryGetFirst(out var location))
             {
-                location.Range = await _documentMappingService.MapFromProjectedDocumentRangeAsync(location.Uri, location.Range, cancellationToken).ConfigureAwait(false);
+                (location.Uri, location.Range) = await _documentMappingService.MapFromProjectedDocumentRangeAsync(location.Uri, location.Range, cancellationToken).ConfigureAwait(false);
             }
             else if (response.Value.TryGetSecond(out var locations))
             {
                 foreach (var loc in locations)
                 {
-                    loc.Range = await _documentMappingService.MapFromProjectedDocumentRangeAsync(loc.Uri, loc.Range, cancellationToken).ConfigureAwait(false);
+                    (loc.Uri, loc.Range) = await _documentMappingService.MapFromProjectedDocumentRangeAsync(loc.Uri, loc.Range, cancellationToken).ConfigureAwait(false);
                 }
             }
             else if (response.Value.TryGetThird(out var links))
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
                 {
                     if (link.Target is not null)
                     {
-                        link.Range = await _documentMappingService.MapFromProjectedDocumentRangeAsync(link.Target, link.Range, cancellationToken).ConfigureAwait(false);
+                        (link.Target, link.Range) = await _documentMappingService.MapFromProjectedDocumentRangeAsync(link.Target, link.Range, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         /// virtual document. If the uri passed in is not for a virtual document, or the range cannot be mapped
         /// for some other reason, the original passed in range is returned unchanged.
         /// </summary>
-        public abstract Task<Range> MapFromProjectedDocumentRangeAsync(Uri virtualDocumentUri, Range projectedRange, CancellationToken cancellationToken);
+        public abstract Task<(Uri MappedDocumentUri, Range MappedRange)> MapFromProjectedDocumentRangeAsync(Uri virtualDocumentUri, Range projectedRange, CancellationToken cancellationToken);
 
         public async Task<Projection> GetProjectionAsync(DocumentContext documentContext, int absoluteIndex, CancellationToken cancellationToken)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.CodeAnalysis;


### PR DESCRIPTION
Noticed today while working. Not only did this not work, my tests were validating the wrong Uri 🤦‍♂️

C# was unaffected (at runtime) because Roslyn calls us for mapping anyway. Sad we can't (easily) test this with the real Html and TypeScript language servers.