### PR TITLE
Fix null ref exception

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -434,7 +434,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                     owner.Parent is MarkupBlockSyntax block &&
                     owner == block.Children[block.Children.Count - 1] &&
                     // MarkupBlock -> CSharpCodeBlock -> RazorDirectiveBody -> RazorDirective
-                    block.Parent.Parent.Parent is RazorDirectiveSyntax directive &&
+                    block.Parent?.Parent?.Parent is RazorDirectiveSyntax directive &&
                     directive.DirectiveDescriptor.Directive == SectionDirective.Directive.Directive)
                 {
                     return true;


### PR DESCRIPTION
(Hopefully) Fixes one of the exceptions in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1593766

Would love to know what the code looked like, that hit this, but alas, this is mostly just an educated guess at what could possibly be null in this method. The compiler is not nullable annotated in this area.

<img width="591" alt="image" src="https://user-images.githubusercontent.com/754264/186838046-a5756015-c0fd-4e12-81fc-ba0b0f482914.png">
