### PR TITLE
Actually listen to LSP requests (and tell the server that we can)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ISignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ISignatureHelpEndpoint.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+using LS = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    [Parallel, Method(Methods.TextDocumentSignatureHelpName)]
+    internal interface ISignatureHelpEndpoint : IJsonRpcRequestHandler<SignatureHelpParamsBridge, LS.SignatureHelp?>,
+        IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Threading;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using System.Threading;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using LS = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp
 {
-    internal class SignatureHelpEndpoint : AbstractRazorDelegatingEndpoint<SignatureHelpParamsBridge, LS.SignatureHelp>
+    internal class SignatureHelpEndpoint : AbstractRazorDelegatingEndpoint<SignatureHelpParamsBridge, LS.SignatureHelp>, ISignatureHelpEndpoint
     {
         public SignatureHelpEndpoint(
             DocumentContextFactory documentContextFactory,
@@ -21,11 +22,22 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp
             ILoggerFactory loggerProvider)
             : base(documentContextFactory, languageServerFeatureOptions, documentMappingService, languageServer, loggerProvider.CreateLogger<SignatureHelpEndpoint>())
         {
-
         }
 
         /// <inheritdoc />
         protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorSignatureHelpEndpointName;
+
+        public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
+        {
+            const string ServerCapability = "signatureHelpProvider";
+            var option = new SignatureHelpOptions()
+            {
+                TriggerCharacters = new[] { "(", ",", "<" },
+                RetriggerCharacters = new[] { ">", ")" }
+            };
+
+            return new RegistrationExtensionResult(ServerCapability, option);
+        }
 
         /// <inheritdoc />
         protected override IDelegatedParams CreateDelegatedParams(SignatureHelpParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1599320

We regressed signature help when we moved it to single server in https://github.com/dotnet/razor-tooling/pull/6722