### PR TITLE
Don't NFW when we get a bad edit from C#

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 _logger.LogInformation("Received {textEditsLength} results from C#.", textEdits.Length);
             }
 
-            // Sometimes teh C# document is out of sync with our document, so Roslyn can return edits to us that will throw when we try
+            // Sometimes the C# document is out of sync with our document, so Roslyn can return edits to us that will throw when we try
             // to normalize them. Instead of having this flow up and log a NFW, we just capture it here. Since this only happens when typing
             // very quickly, it is a safe assumption that we'll get another chance to do on type formatting, since we know the user is typing.
             // The proper fix for this is https://github.com/dotnet/razor-tooling/issues/6650 at which point this can be removed


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1596109
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1593766

When typing fast, its possible for Roslyn to not be up to date with the state of the world, and so can send us edits that are out-of-bounds when we try to go apply them during formatting. This is a very quick fix to not error in those situations. The real fix will be https://github.com/dotnet/razor-tooling/issues/6650 which I'll pick up soon.