### PR TITLE
Use Main from DartLab.Templates

### DIFF
--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -15,7 +15,7 @@ resources:
   - repository: DartLabTemplates
     type: git
     name: DartLab.Templates
-    ref: refs/heads/dev/bradwhit/RemoveCheckoutNone
+    ref: main
   - repository: RazorMirror
     endpoint: dnceng/internal dotnet-razor-tooling
     type: git


### PR DESCRIPTION
### Summary of the changes

- The `RemoveCheckoutNone` branch was deleted because it got merged into main, so lets use main.