### PR TITLE
Don't update anything if we've been disposed

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Razor
         private async Task UpdateWorkspaceStateAsync(Project workspaceProject, ProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
         {
             // We fire this up on a background thread so we could have been disposed already, and if so, waiting on our semaphore
-            // throws an exception, and then RPS yells at us.
+            // throws an exception.
             if (_disposed)
             {
                 return;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectWorkspaceStateGenerator.cs
@@ -116,6 +116,13 @@ namespace Microsoft.CodeAnalysis.Razor
 
         private async Task UpdateWorkspaceStateAsync(Project workspaceProject, ProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
         {
+            // We fire this up on a background thread so we could have been disposed already, and if so, waiting on our semaphore
+            // throws an exception, and then RPS yells at us.
+            if (_disposed)
+            {
+                return;
+            }
+            
             try
             {
                 // Only allow a single TagHelper resolver request to process at a time in order to reduce Visual Studio memory pressure. Typically a TagHelper resolution result can be upwards of 10mb+.


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1601533


Unfortunately this isn't testable on our end, because it relies on a race in .NET where the semaphore is disposed after the check for disposal. Given there was no user impact, this is just RPS noise, I'm totally okay with this :)