### PR TITLE
Don't target win10

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm64;linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>


### PR DESCRIPTION
### Summary of the changes

- The win10 change was to try and address CG issues that have been resolved separately from the change.

