### PR TITLE
Allow any add using to work

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             if (documentChanges!.Length != 1)
             {
-                // We don't yet support multi-document code actions, return original code action
+                Debug.Fail("We don't yet support multi-document code actions! If you're seeing this, something about Roslyn changed and we should react.");
                 return codeAction;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
@@ -46,9 +49,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!AddUsingsCodeActionProviderHelper.TryExtractNamespace(codeAction.Title, out var @namespace))
+            var resolvedCodeAction = await ResolveCodeActionWithServerAsync(csharpParams.RazorFileUri, codeAction, cancellationToken).ConfigureAwait(false);
+
+            // TODO: Move this higher, so it happens on any code action.
+            //       For that though, we need a deeper understanding of applying workspace edits to documents, rather than
+            //       just picking out the first one because we assume thats where it will be.
+            //       Tracked by https://github.com/dotnet/razor-tooling/issues/6159
+            if (resolvedCodeAction?.Edit?.TryGetDocumentChanges(out var documentChanges) != true)
             {
-                // Invalid text edit, missing namespace
+                return codeAction;
+            }
+
+            if (documentChanges!.Length != 1)
+            {
+                // We don't yet support multi-document code actions, return original code action
                 return codeAction;
             }
 
@@ -64,14 +78,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return codeAction;
             }
 
-            var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier()
-            {
-                Uri = csharpParams.RazorFileUri,
-                Version = documentContext.Version
-            };
+            var csharpText = codeDocument.GetCSharpSourceText();
+            var edits = documentChanges[0].Edits;
+            var changes = edits.Select(e => e.AsTextChange(csharpText));
+            var changedText = csharpText.WithChanges(changes);
 
-            var edit = AddUsingsCodeActionResolver.CreateAddUsingWorkspaceEdit(@namespace, codeDocument, codeDocumentIdentifier);
-            codeAction.Edit = edit;
+            edits = await AddUsingsCodeActionProviderHelper.GetUsingStatementEditsAsync(codeDocument, csharpText, changedText, cancellationToken).ConfigureAwait(false);
+
+            codeAction.Edit = new WorkspaceEdit
+            {
+                DocumentChanges = new TextDocumentEdit[]
+                {
+                    new TextDocumentEdit
+                    {
+                        TextDocument = new OptionalVersionedTextDocumentIdentifier()
+                        {
+                            Uri = csharpParams.RazorFileUri,
+                            Version = documentContext.Version
+                        },
+                        Edits = edits
+                    }
+                }
+            };
 
             return codeAction;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/WorkspaceEditExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/WorkspaceEditExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions
+{
+    internal static class WorkspaceEditExtensions
+    {
+        public static bool TryGetDocumentChanges(this WorkspaceEdit workspaceEdit, [NotNullWhen(true)] out TextDocumentEdit[]? documentChanges)
+        {
+            if (workspaceEdit.DocumentChanges?.Value is TextDocumentEdit[] documentEdits)
+            {
+                documentChanges = documentEdits;
+                return true;
+            }
+
+            if (workspaceEdit.DocumentChanges?.Value is SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[] sumTypeArray)
+            {
+                var documentEditList = new List<TextDocumentEdit>();
+                foreach (var sumType in sumTypeArray)
+                {
+                    if (sumType.Value is TextDocumentEdit textDocumentEdit)
+                    {
+                        documentEditList.Add(textDocumentEdit);
+                    }
+                }
+
+                if (documentEditList.Count > 0)
+                {
+                    documentChanges = documentEditList.ToArray();
+                    return true;
+                }
+            }
+
+            documentChanges = null;
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             if (context.AutomaticallyAddUsings)
             {
                 // Because we need to parse the C# code twice for this operation, lets do a quick check to see if its even necessary
-                if (finalEdits.Any(e => e.NewText.IndexOf("using") != -1))
+                if (textEdits.Any(e => e.NewText.IndexOf("using") != -1))
                 {
                     var usingStatementEdits = await AddUsingsCodeActionProviderHelper.GetUsingStatementEditsAsync(codeDocument, csharpText, originalTextWithChanges, cancellationToken);
                     finalEdits = usingStatementEdits.Concat(finalEdits).ToArray();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
@@ -4,41 +4,25 @@
 #nullable disable
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     public class AddUsingsCSharpCodeActionResolverTest : LanguageServerTestBase
     {
-        private static readonly CodeAction s_defaultResolvedCodeAction = new CodeAction()
-        {
-            Title = "@using System.Net",
-            Data = null,
-            Edit = new WorkspaceEdit()
-            {
-                DocumentChanges = new TextDocumentEdit[] {
-                    new TextDocumentEdit()
-                    {
-                        Edits = new TextEdit[] {
-                            new TextEdit()
-                            {
-                                NewText = "using System.Net;"
-                            }
-                        }
-                    }
-                }
-            }
-        };
-
         private static readonly CodeAction s_defaultUnresolvedCodeAction = new CodeAction()
         {
             Title = "@using System.Net"
@@ -48,25 +32,139 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         public async Task ResolveAsync_ReturnsResolvedCodeAction()
         {
             // Arrange
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver);
+            var resolvedCodeAction = new CodeAction()
+            {
+                Title = "@using System.Net",
+                Data = null,
+                Edit = new WorkspaceEdit()
+                {
+                    DocumentChanges = new TextDocumentEdit[] {
+                        new TextDocumentEdit()
+                        {
+                            Edits = new TextEdit[] {
+                                new TextEdit()
+                                {
+                                    Range = new Range
+                                    {
+                                        Start = new Position(0, 0),
+                                        End = new Position(0, 0)
+                                    },
+                                    NewText = "using System.Net;"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
 
             // Act
             var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
 
             // Assert
-            Assert.Equal(s_defaultResolvedCodeAction.Title, returnedCodeAction.Title);
-            Assert.Equal(s_defaultResolvedCodeAction.Data, returnedCodeAction.Data);
+            Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
+            Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
 
             Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
             var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
             Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
             var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
-            Assert.Equal($"@using System.Net{Environment.NewLine}", returnedTextDocumentEdit.NewText);
+            Assert.Equal($"@using System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_FragmentedEdit_ReturnsResolvedCodeAction()
+        {
+            // Arrange
+            var resolvedCodeAction = new CodeAction()
+            {
+                Title = "@using System.Net",
+                Data = null,
+                Edit = new WorkspaceEdit()
+                {
+                    DocumentChanges = new TextDocumentEdit[] {
+                        new TextDocumentEdit()
+                        {
+                            Edits = new TextEdit[] {
+                                new TextEdit()
+                                {
+                                    Range = new Range
+                                    {
+                                        // This puts it just after another "using" keyword
+                                        Start = new Position(8, 9),
+                                        End = new Position(8, 9)
+                                    },
+                                    NewText = " System.Net;\r\n    using"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
+
+            // Act
+            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+
+            // Assert
+            Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
+            Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
+
+            Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
+            var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
+            Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
+            var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
+            Assert.Equal($"@using System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
+        }
+
+        [Fact]
+        public async Task ResolveAsync_GlobalUsing_ReturnsResolvedCodeAction()
+        {
+            // Arrange
+            var resolvedCodeAction = new CodeAction()
+            {
+                Title = "@using System.Net",
+                Data = null,
+                Edit = new WorkspaceEdit()
+                {
+                    DocumentChanges = new TextDocumentEdit[] {
+                        new TextDocumentEdit()
+                        {
+                            Edits = new TextEdit[] {
+                                new TextEdit()
+                                {
+                                    Range = new Range
+                                    {
+                                        Start = new Position(0, 0),
+                                        End = new Position(0, 0)
+                                    },
+                                    NewText = "using global::System.Net;"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
+
+            // Act
+            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+
+            // Assert
+            Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
+            Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
+
+            Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
+            var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
+            Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
+            var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
+            Assert.Equal($"@using global::System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
         }
 
         private void CreateCodeActionResolver(
             out CSharpCodeActionParams codeActionParams,
-            out AddUsingsCSharpCodeActionResolver addUsingResolver)
+            out AddUsingsCSharpCodeActionResolver addUsingResolver,
+            CodeAction resolvedCodeAction)
         {
             var documentUri = new Uri("c:/Test.razor");
             var contents = string.Empty;
@@ -78,16 +176,24 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 RazorFileUri = documentUri
             };
 
-            var languageServer = CreateLanguageServer();
+            var languageServer = CreateLanguageServer(resolvedCodeAction);
 
             addUsingResolver = new AddUsingsCSharpCodeActionResolver(
                 CreateDocumentContextFactory(documentUri, codeDocument),
                 languageServer);
         }
 
-        private static ClientNotifierServiceBase CreateLanguageServer()
+        private static ClientNotifierServiceBase CreateLanguageServer(CodeAction resolvedCodeAction)
         {
+            var responseRouterReturns = new Mock<IResponseRouterReturns>(MockBehavior.Strict);
+            responseRouterReturns
+                .Setup(l => l.Returning<CodeAction>(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(resolvedCodeAction));
+
             var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
+            languageServer
+                .Setup(l => l.SendRequestAsync(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>()))
+                .Returns(Task.FromResult(responseRouterReturns.Object));
 
             return languageServer.Object;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6784

Originally our add using code would try to parse out the text edit, and manually add the using from that. That was problematic for fragmented edits, so it was changed to just process the title of the code action. That was problematic because sometimes usings aren't as simple as they appear.

This fixes all of that, and is in fact part of https://github.com/dotnet/razor-tooling/issues/6159 and actually uses the patent that we filed, which is not a bad thing. We had all of the interesting code as part of on type formatting anyway, this mainly just moves things around.