### PR TITLE
Single Server OnAutoInsert

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
@@ -43,6 +43,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 
         public const string RazorImplementationEndpointName = "razor/implementation";
 
-        public const string RazorOnAutoInsertnEndpointName = "razor/onAutoInsert";
+        public const string RazorOnAutoInsertEndpointName = "razor/onAutoInsert";
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
@@ -42,5 +42,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public const string RazorSignatureHelpEndpointName = "razor/signatureHelp";
 
         public const string RazorImplementationEndpointName = "razor/implementation";
+
+        public const string RazorOnAutoInsertnEndpointName = "razor/onAutoInsert";
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -14,6 +14,13 @@ internal record DelegatedPositionParams(
     Position ProjectedPosition,
     RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
+internal record DelegatedOnAutoInsertParams(
+    VersionedTextDocumentIdentifier HostDocument,
+    Position ProjectedPosition,
+    RazorLanguageKind ProjectedKind,
+    string Character,
+    FormattingOptions Options) : IDelegatedParams;
+
 internal record DelegatedRenameParams(
     VersionedTextDocumentIdentifier HostDocument,
     Position ProjectedPosition,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             _onAutoInsertProviders = onAutoInsertProvider?.ToList() ?? throw new ArgumentNullException(nameof(onAutoInsertProvider));
         }
 
-        protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertnEndpointName;
+        protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName;
 
         public RegistrationExtensionResult GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -7,68 +7,69 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 {
-    internal class OnAutoInsertEndpoint : IVSOnAutoInsertEndpoint
+    internal class OnAutoInsertEndpoint : AbstractRazorDelegatingEndpoint<OnAutoInsertParamsBridge, VSInternalDocumentOnAutoInsertResponseItem>, IVSOnAutoInsertEndpoint
     {
+        private static readonly HashSet<string> s_htmlAllowedTriggerCharacters = new(StringComparer.Ordinal) { "=", };
+        private static readonly HashSet<string> s_cSharpAllowedTriggerCharacters = new(StringComparer.Ordinal) { "'", "/", "\n" };
+
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private readonly AdhocWorkspaceFactory _workspaceFactory;
+        private readonly RazorFormattingService _razorFormattingService;
         private readonly IReadOnlyList<RazorOnAutoInsertProvider> _onAutoInsertProviders;
-        private readonly ImmutableHashSet<string> _onAutoInsertTriggerCharacters;
-        private readonly DocumentContextFactory _documentContextFactory;
 
         public OnAutoInsertEndpoint(
             DocumentContextFactory documentContextFactory,
+            LanguageServerFeatureOptions languageServerFeatureOptions,
+            RazorDocumentMappingService documentMappingService,
+            ClientNotifierServiceBase languageServer,
             IEnumerable<RazorOnAutoInsertProvider> onAutoInsertProvider,
-            AdhocWorkspaceFactory workspaceFactory)
+            AdhocWorkspaceFactory workspaceFactory,
+            RazorFormattingService razorFormattingService,
+            ILoggerFactory loggerFactory)
+            : base(documentContextFactory, languageServerFeatureOptions, documentMappingService, languageServer, loggerFactory.CreateLogger<OnAutoInsertEndpoint>())
         {
-            if (documentContextFactory is null)
-            {
-                throw new ArgumentNullException(nameof(documentContextFactory));
-            }
-
-            if (onAutoInsertProvider is null)
-            {
-                throw new ArgumentNullException(nameof(onAutoInsertProvider));
-            }
-
-            if (workspaceFactory is null)
-            {
-                throw new ArgumentNullException(nameof(workspaceFactory));
-            }
-
-            _documentContextFactory = documentContextFactory;
-            _workspaceFactory = workspaceFactory;
-            _onAutoInsertProviders = onAutoInsertProvider.ToList();
-            _onAutoInsertTriggerCharacters = _onAutoInsertProviders.Select(provider => provider.TriggerCharacter).ToImmutableHashSet();
+            _workspaceFactory = workspaceFactory ?? throw new ArgumentNullException(nameof(workspaceFactory));
+            _razorFormattingService = razorFormattingService ?? throw new ArgumentNullException(nameof(razorFormattingService));
+            _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
+            _onAutoInsertProviders = onAutoInsertProvider?.ToList() ?? throw new ArgumentNullException(nameof(onAutoInsertProvider));
         }
+
+        protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertnEndpointName;
 
         public RegistrationExtensionResult GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
             const string AssociatedServerCapability = "_vs_onAutoInsertProvider";
 
+            var triggerCharacters = _onAutoInsertProviders.Select(provider => provider.TriggerCharacter);
+
+            if (_languageServerFeatureOptions.SingleServerSupport)
+            {
+                triggerCharacters = triggerCharacters.Concat(s_htmlAllowedTriggerCharacters).Concat(s_cSharpAllowedTriggerCharacters);
+            }
+
             var registrationOptions = new VSInternalDocumentOnAutoInsertOptions()
             {
-                TriggerCharacters = _onAutoInsertTriggerCharacters.ToArray(),
+                TriggerCharacters = triggerCharacters.Distinct().ToArray()
             };
 
             return new RegistrationExtensionResult(AssociatedServerCapability, registrationOptions);
         }
 
-        public async Task<VSInternalDocumentOnAutoInsertResponseItem?> Handle(OnAutoInsertParamsBridge request, CancellationToken cancellationToken)
+        protected override async Task<VSInternalDocumentOnAutoInsertResponseItem?> TryHandleAsync(OnAutoInsertParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
-            var documentContext = await _documentContextFactory.TryCreateAsync(request.TextDocument.Uri, cancellationToken).ConfigureAwait(false);
-            if (documentContext is null || cancellationToken.IsCancellationRequested)
-            {
-                return null;
-            }
-
-            var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken);
+            var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
             if (codeDocument.IsUnsupported())
             {
                 return null;
@@ -115,6 +116,67 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
             // No provider could handle the text edit.
             return null;
+        }
+
+        protected override IDelegatedParams? CreateDelegatedParams(OnAutoInsertParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        {
+            if (projection.LanguageKind == RazorLanguageKind.Html &&
+               !s_htmlAllowedTriggerCharacters.Contains(request.Character))
+            {
+                Logger.LogInformation("Inapplicable HTML trigger char {request.Character}.", request.Character);
+                return null;
+            }
+            else if (projection.LanguageKind == RazorLanguageKind.CSharp &&
+                !s_cSharpAllowedTriggerCharacters.Contains(request.Character))
+            {
+                Logger.LogInformation("Inapplicable C# trigger char {request.Character}.", request.Character);
+                return null;
+            }
+
+            return new DelegatedOnAutoInsertParams(
+                documentContext.Identifier,
+                projection.Position,
+                projection.LanguageKind,
+                request.Character,
+                request.Options);
+        }
+
+        protected override async Task<VSInternalDocumentOnAutoInsertResponseItem?> HandleDelegatedResponseAsync(VSInternalDocumentOnAutoInsertResponseItem? delegatedResponse, OnAutoInsertParamsBridge originalRequest, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        {
+            if (delegatedResponse is null)
+            {
+                return null;
+            }
+
+            // For Html we just return the edit as is
+            if (projection.LanguageKind == RazorLanguageKind.Html)
+            {
+                return delegatedResponse;
+            }
+
+            // For C# we run the edit through our formatting engine
+            var edits = new[] { delegatedResponse.TextEdit };
+
+            TextEdit[] mappedEdits;
+            if (delegatedResponse.TextEditFormat == InsertTextFormat.Snippet)
+            {
+                mappedEdits = await _razorFormattingService.FormatSnippetAsync(documentContext.Identifier.Uri, documentContext.Snapshot, projection.LanguageKind, edits, originalRequest.Options, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                mappedEdits = await _razorFormattingService.FormatOnTypeAsync(documentContext.Identifier.Uri, documentContext.Snapshot, projection.LanguageKind, edits, originalRequest.Options, hostDocumentIndex: 0, triggerCharacter: '\0', cancellationToken).ConfigureAwait(false);
+            }
+
+            if (mappedEdits.Length != 1)
+            {
+                return null;
+            }
+
+            return new VSInternalDocumentOnAutoInsertResponseItem()
+            {
+                TextEdit = mappedEdits[0],
+                TextEditFormat = delegatedResponse.TextEditFormat,
+            };
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -99,13 +99,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             };
         }
 
-        protected override IDelegatedParams CreateDelegatedParams(DefinitionParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        protected override IDelegatedParams? CreateDelegatedParams(DefinitionParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
             => new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
                     projection.LanguageKind);
 
-        protected async override Task<DefinitionResult?> HandleDelegatedResponseAsync(DefinitionResult? response, DocumentContext documentContext, CancellationToken cancellationToken)
+        protected async override Task<DefinitionResult?> HandleDelegatedResponseAsync(DefinitionResult? response, DefinitionParamsBridge originalRequest, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
             if (response is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
@@ -50,14 +50,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentHighlighting
         }
 
         /// <inheritdoc/>
-        protected override IDelegatedParams CreateDelegatedParams(DocumentHighlightParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        protected override IDelegatedParams? CreateDelegatedParams(DocumentHighlightParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
             => new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
                     projection.LanguageKind);
 
         /// <inheritdoc/>
-        protected override async Task<DocumentHighlight[]?> HandleDelegatedResponseAsync(DocumentHighlight[]? response, DocumentContext documentContext, CancellationToken cancellationToken)
+        protected override async Task<DocumentHighlight[]?> HandleDelegatedResponseAsync(DocumentHighlight[]? response, DocumentHighlightParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
             var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DefinitionParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DefinitionParamsBridge.cs
@@ -10,7 +10,7 @@ using DefinitionResult = Microsoft.VisualStudio.LanguageServer.Protocol.SumType<
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
-    internal class DefinitionParamsBridge : TextDocumentPositionParams, IRequest<DefinitionResult?>
+    internal class DefinitionParamsBridge : TextDocumentPositionParams, IRequest<DefinitionResult?>, ITextDocumentPositionParams
     {
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DocumentHighlightParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/DocumentHighlightParamsBridge.cs
@@ -25,6 +25,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 /// we inherit DocumentHighlightParams,  and they do work if we don't.
 /// As I always say: "If it hurts when you do that, don't do that".
 /// </remarks>
-internal class DocumentHighlightParamsBridge : TextDocumentPositionParams, IRequest<DocumentHighlight[]?>
+internal class DocumentHighlightParamsBridge : TextDocumentPositionParams, IRequest<DocumentHighlight[]?>, ITextDocumentPositionParams
 {
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ITextDocumentPositionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ITextDocumentPositionParams.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    internal interface ITextDocumentPositionParams
+    {
+        public TextDocumentIdentifier TextDocument { get; set; }
+
+        public Position Position { get; set; }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ImplementationParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ImplementationParamsBridge.cs
@@ -9,7 +9,7 @@ using ImplementationResult = Microsoft.VisualStudio.LanguageServer.Protocol.SumT
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
-    internal class ImplementationParamsBridge : TextDocumentPositionParams, IRequest<ImplementationResult>
+    internal class ImplementationParamsBridge : TextDocumentPositionParams, IRequest<ImplementationResult>, ITextDocumentPositionParams
     {
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/OnAutoInsertParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/OnAutoInsertParamsBridge.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
     /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="VSInternalDocumentOnAutoInsertParams"/>
     /// type does not implement <see cref="IRequest"/>.
     /// </summary>
-    internal class OnAutoInsertParamsBridge : VSInternalDocumentOnAutoInsertParams, IRequest<VSInternalDocumentOnAutoInsertResponseItem>
+    internal class OnAutoInsertParamsBridge : VSInternalDocumentOnAutoInsertParams, IRequest<VSInternalDocumentOnAutoInsertResponseItem>, ITextDocumentPositionParams
     {
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RenameParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RenameParamsBridge.cs
@@ -10,6 +10,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="RenameParams"/>
 /// type does not implement <see cref="IRequest"/>.
 /// </summary>
-internal class RenameParamsBridge : RenameParams, IRequest<WorkspaceEdit?>
+internal class RenameParamsBridge : RenameParams, IRequest<WorkspaceEdit?>, ITextDocumentPositionParams
 {
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/SignatureHelpParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/SignatureHelpParamsBridge.cs
@@ -7,6 +7,6 @@ using LS = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 
-internal class SignatureHelpParamsBridge : TextDocumentPositionParams, IRequest<LS.SignatureHelp?>
+internal class SignatureHelpParamsBridge : TextDocumentPositionParams, IRequest<LS.SignatureHelp?>, ITextDocumentPositionParams
 {
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/VSHoverParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/VSHoverParamsBridge.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
     /// This class is used as a "bridge" between the O# and VS worlds. Ultimately it only exists because the base <see cref="TextDocumentPositionParams"/>
     /// type does not implement <see cref="IRequest{TResponse}"/>.
     /// </summary>
-    internal class VSHoverParamsBridge : TextDocumentPositionParams, IRequest<VSInternalHover?>
+    internal class VSHoverParamsBridge : TextDocumentPositionParams, IRequest<VSInternalHover?>, ITextDocumentPositionParams
     {
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName;
 
         /// <inheritdoc/>
-        protected override IDelegatedParams CreateDelegatedParams(VSHoverParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        protected override IDelegatedParams? CreateDelegatedParams(VSHoverParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
             => new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         }
 
         /// <inheritdoc/>
-        protected override async Task<VSInternalHover?> HandleDelegatedResponseAsync(VSInternalHover? response, DocumentContext documentContext, CancellationToken cancellationToken)
+        protected override async Task<VSInternalHover?> HandleDelegatedResponseAsync(VSInternalHover? response, VSHoverParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
             if (response is null || response.Range is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
@@ -41,13 +41,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Implementation
             return new RegistrationExtensionResult(ServerCapability, option);
         }
 
-        protected override IDelegatedParams CreateDelegatedParams(ImplementationParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        protected override IDelegatedParams? CreateDelegatedParams(ImplementationParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
             => new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
                     projection.LanguageKind);
 
-        protected async override Task<ImplementationResult> HandleDelegatedResponseAsync(ImplementationResult delegatedResponse, DocumentContext documentContext, CancellationToken cancellationToken)
+        protected async override Task<ImplementationResult> HandleDelegatedResponseAsync(ImplementationResult delegatedResponse, ImplementationParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
             // Not using .TryGetXXX because this does the null check for us too
             if (delegatedResponse.Value is Location[] locations)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             => _languageServerFeatureOptions.SupportsFileManipulation;
 
         /// <inheritdoc/>
-        protected override IDelegatedParams CreateDelegatedParams(RenameParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        protected override IDelegatedParams? CreateDelegatedParams(RenameParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
             => new DelegatedRenameParams(
                     documentContext.Identifier,
                     projection.Position,
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                     request.NewName);
 
         /// <inheritdoc/>
-        protected override async Task<WorkspaceEdit?> HandleDelegatedResponseAsync(WorkspaceEdit? response, DocumentContext documentContext, CancellationToken cancellationToken)
+        protected override async Task<WorkspaceEdit?> HandleDelegatedResponseAsync(WorkspaceEdit? response, RenameParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
         {
             if (response is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp
         }
 
         /// <inheritdoc />
-        protected override IDelegatedParams CreateDelegatedParams(SignatureHelpParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        protected override IDelegatedParams? CreateDelegatedParams(SignatureHelpParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
             => new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1083,6 +1083,34 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return response?.Response;
         }
 
+        public override async Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken)
+        {
+            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+            if (delegationDetails is null)
+            {
+                return default;
+            }
+
+            var onAutoInsertParams = new VSInternalDocumentOnAutoInsertParams
+            {
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = delegationDetails.Value.ProjectedUri,
+                },
+                Position = request.ProjectedPosition,
+                Character = request.Character,
+                Options = request.Options
+            };
+
+            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentOnAutoInsertParams, VSInternalDocumentOnAutoInsertResponseItem?>(
+               delegationDetails.Value.TextBuffer,
+               VSInternalMethods.OnAutoInsertName,
+               delegationDetails.Value.LanguageServerName,
+               onAutoInsertParams,
+               cancellationToken).ConfigureAwait(false);
+            return response?.Response;
+        }
+
         public override Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
             => DelegateTextDocumentPositionRequestAsync<VSInternalHover>(request, Methods.TextDocumentHoverName, cancellationToken);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -113,6 +113,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
                 _initializeResult.Capabilities.DocumentHighlightProvider = false;
                 _initializeResult.Capabilities.SignatureHelpProvider = null;
                 _initializeResult.Capabilities.ImplementationProvider = false;
+
+                ((VSInternalServerCapabilities)_initializeResult.Capabilities).OnAutoInsertProvider = null;
             }
 
             if (!_languageServerFeatureOptions.SingleServerCompletionSupport)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -114,5 +114,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorImplementationEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<ImplementationResult> ImplementationAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
+
+        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertnEndpointName, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
         [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorImplementationEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<ImplementationResult> ImplementationAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertnEndpointName, UseSingleObjectParameterDeserialization = true)]
+        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -8,8 +8,10 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test;
-using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
@@ -17,7 +19,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
-    public class OnAutoInsertEndpointTest : LanguageServerTestBase
+    public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
     {
         public OnAutoInsertEndpointTest()
         {
@@ -31,13 +33,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var codeDocument = CreateCodeDocument();
-            var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
-            var endpoint = new OnAutoInsertEndpoint(documentContextFactory, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
+            var razorFormattingService = Mock.Of<RazorFormattingService>(MockBehavior.Strict);
+            var providers = new[] { insertProvider };
+            var endpoint = new OnAutoInsertEndpoint(DocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
             var @params = new OnAutoInsertParamsBridge()
             {
-                TextDocument = new TextDocumentIdentifier { Uri = uri, },
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(0, 0),
                 Character = ">",
                 Options = new FormattingOptions
                 {
@@ -52,6 +58,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Assert
             Assert.NotNull(result);
             Assert.True(insertProvider.Called);
+            Assert.Equal(0, LanguageServer.RequestCount);
         }
 
         [Fact]
@@ -59,8 +66,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var codeDocument = CreateCodeDocument();
-            var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
             var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: false, LoggerFactory)
             {
                 ResolvedTextEdit = new TextEdit()
@@ -69,10 +77,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 ResolvedTextEdit = new TextEdit()
             };
-            var endpoint = new OnAutoInsertEndpoint(documentContextFactory, new[] { insertProvider1, insertProvider2 }, TestAdhocWorkspaceFactory.Instance);
+            var razorFormattingService = Mock.Of<RazorFormattingService>(MockBehavior.Strict);
+            var providers = new[] { insertProvider1, insertProvider2 };
+            var endpoint = new OnAutoInsertEndpoint(DocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
             var @params = new OnAutoInsertParamsBridge()
             {
-                TextDocument = new TextDocumentIdentifier { Uri = uri, },
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(0, 0),
                 Character = ">",
                 Options = new FormattingOptions
                 {
@@ -89,6 +100,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             Assert.True(insertProvider1.Called);
             Assert.True(insertProvider2.Called);
             Assert.Same(insertProvider2.ResolvedTextEdit, result?.TextEdit);
+            Assert.Equal(0, LanguageServer.RequestCount);
         }
 
         [Fact]
@@ -96,8 +108,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var codeDocument = CreateCodeDocument();
-            var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
             var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory)
             {
                 ResolvedTextEdit = new TextEdit()
@@ -106,10 +119,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 ResolvedTextEdit = new TextEdit()
             };
-            var endpoint = new OnAutoInsertEndpoint(documentContextFactory, new[] { insertProvider1, insertProvider2 }, TestAdhocWorkspaceFactory.Instance);
+            var razorFormattingService = Mock.Of<RazorFormattingService>(MockBehavior.Strict);
+            var providers = new[] { insertProvider1, insertProvider2 };
+            var endpoint = new OnAutoInsertEndpoint(DocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
             var @params = new OnAutoInsertParamsBridge()
             {
-                TextDocument = new TextDocumentIdentifier { Uri = uri, },
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(0, 0),
                 Character = ">",
                 Options = new FormattingOptions
                 {
@@ -133,14 +149,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var codeDocument = CreateCodeDocument();
-            var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
             var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
             var insertProvider2 = new TestOnAutoInsertProvider("<", canResolve: true, LoggerFactory);
-            var endpoint = new OnAutoInsertEndpoint(documentContextFactory, new[] { insertProvider1, insertProvider2 }, TestAdhocWorkspaceFactory.Instance);
+            var razorFormattingService = Mock.Of<RazorFormattingService>(MockBehavior.Strict);
+            var providers = new[] { insertProvider1, insertProvider2 };
+            var endpoint = new OnAutoInsertEndpoint(DocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
             var @params = new OnAutoInsertParamsBridge()
             {
-                TextDocument = new TextDocumentIdentifier { Uri = uri, },
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(0, 0),
                 Character = "!",
                 Options = new FormattingOptions
                 {
@@ -156,18 +176,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             Assert.Null(result);
             Assert.False(insertProvider1.Called);
             Assert.False(insertProvider2.Called);
+            Assert.Equal(0, LanguageServer.RequestCount);
         }
 
         [Fact]
         public async Task Handle_DocumentNotFound_ReturnsNull()
         {
             // Arrange
+            var codeDocument = CreateCodeDocument();
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
-            var endpoint = new OnAutoInsertEndpoint(EmptyDocumentContextFactory, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
-            var uri = new Uri("file://path/test.razor");
+            var razorFormattingService = Mock.Of<RazorFormattingService>(MockBehavior.Strict);
+            var providers = new[] { insertProvider };
+            var endpoint = new OnAutoInsertEndpoint(EmptyDocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
             var @params = new OnAutoInsertParamsBridge()
             {
-                TextDocument = new TextDocumentIdentifier { Uri = uri, },
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(0, 0),
                 Character = ">",
                 Options = new FormattingOptions
                 {
@@ -182,6 +209,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Assert
             Assert.Null(result);
             Assert.False(insertProvider.Called);
+            Assert.Equal(0, LanguageServer.RequestCount);
         }
 
         [Fact]
@@ -190,13 +218,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Arrange
             var codeDocument = CreateCodeDocument();
             codeDocument.SetUnsupported();
-            var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true, LoggerFactory);
-            var endpoint = new OnAutoInsertEndpoint(documentContextFactory, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
+            var razorFormattingService = Mock.Of<RazorFormattingService>(MockBehavior.Strict);
+            var providers = new[] { insertProvider };
+            var endpoint = new OnAutoInsertEndpoint(DocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
             var @params = new OnAutoInsertParamsBridge()
             {
-                TextDocument = new TextDocumentIdentifier { Uri = uri, },
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(0, 0),
                 Character = ">",
                 Options = new FormattingOptions
                 {
@@ -211,6 +243,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Assert
             Assert.Null(result);
             Assert.False(insertProvider.Called);
+            Assert.Equal(0, LanguageServer.RequestCount);
         }
 
         [Fact]
@@ -218,13 +251,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         {
             // Arrange
             var codeDocument = CreateCodeDocument();
-            var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
             var insertProvider = new TestOnAutoInsertProvider(">", canResolve: false, LoggerFactory);
-            var endpoint = new OnAutoInsertEndpoint(documentContextFactory, new[] { insertProvider }, TestAdhocWorkspaceFactory.Instance);
+            var razorFormattingService = Mock.Of<RazorFormattingService>(MockBehavior.Strict);
+            var providers = new[] { insertProvider };
+            var endpoint = new OnAutoInsertEndpoint(DocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
             var @params = new OnAutoInsertParamsBridge()
             {
-                TextDocument = new TextDocumentIdentifier { Uri = uri, },
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(0, 0),
                 Character = ">",
                 Options = new FormattingOptions
                 {
@@ -239,6 +276,152 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Assert
             Assert.Null(result);
             Assert.True(insertProvider.Called);
+            Assert.Equal(0, LanguageServer.RequestCount);
+        }
+
+        [Fact]
+        public async Task Handle_SingleServer_CSharpDocCommentSnippet()
+        {
+            // Arrange
+            var input = """
+                <div>
+                </div>
+
+                @functions {
+                    ///$$
+                    public void M()
+                    {
+                    }
+                }
+                """;
+
+            var expected = """
+                <div>
+                </div>
+
+                @functions {
+                    /// <summary>
+                    /// $0
+                    /// </summary>
+                    public void M()
+                    {
+                    }
+                }
+                """;
+
+            var character = "/";
+
+            await VerifyCSharpOnAutoInsertAsync(input, expected, character);
+        }
+
+        [Fact]
+        public async Task Handle_SingleServer_CSharpDocCommentNewLine()
+        {
+            // Arrange
+            var input = """
+                <div>
+                </div>
+
+                @functions {
+                    /// <summary>
+                    /// This is some text
+                    $$
+                    /// </summary>
+                    public void M()
+                    {
+                    }
+                }
+                """;
+
+            var expected = """
+                <div>
+                </div>
+
+                @functions {
+                    /// <summary>
+                    /// This is some text
+                    /// $0
+                    /// </summary>
+                    public void M()
+                    {
+                    }
+                }
+                """;
+
+            var character = "\n";
+
+            await VerifyCSharpOnAutoInsertAsync(input, expected, character);
+        }
+
+        [Fact(Skip = "Roslyn only responds to the Razor server kind for this request, but uses the C# server kind in tests")]
+        public async Task Handle_SingleServer_CSharpBraceMatching()
+        {
+            // Arrange
+            var input = """
+                <div>
+                </div>
+
+                @functions {
+                    public void M()
+                    {
+                    $$}
+                }
+                """;
+
+            var expected = """
+                <div>
+                </div>
+
+                @functions {
+                    public void M()
+                    {
+                        $0
+                    }
+                }
+                """;
+
+            var character = "\n";
+
+            await VerifyCSharpOnAutoInsertAsync(input, expected, character);
+        }
+
+        private async Task VerifyCSharpOnAutoInsertAsync(string input, string expected, string character)
+        {
+            TestFileMarkupParser.GetPosition(input, out input, out var cursorPosition);
+
+            var codeDocument = CreateCodeDocument(input);
+            var razorFilePath = "file://path/test.razor";
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
+            var insertProvider = new TestOnAutoInsertProvider("!!!", canResolve: false, LoggerFactory);
+            var razorFormattingService = TestRazorFormattingService.Instance;
+            var providers = new[] { insertProvider };
+            var endpoint = new OnAutoInsertEndpoint(DocumentContextFactory, LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, TestAdhocWorkspaceFactory.Instance, razorFormattingService, LoggerFactory);
+
+            codeDocument.GetSourceText().GetLineAndOffset(cursorPosition, out var line, out var offset);
+            var @params = new OnAutoInsertParamsBridge()
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = new Uri(razorFilePath), },
+                Position = new Position(line, offset),
+                Character = character,
+                Options = new FormattingOptions
+                {
+                    TabSize = 4,
+                    InsertSpaces = true
+                },
+            };
+
+            // Act
+            var result = await endpoint.Handle(@params, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(insertProvider.Called);
+            Assert.Equal(1, LanguageServer.RequestCount);
+
+            var edits = new[] { result!.TextEdit.AsTextChange(codeDocument.GetSourceText()) };
+            var newText = codeDocument.GetSourceText().WithChanges(edits).ToString();
+            Assert.Equal(expected, newText);
         }
 
         private class TestOnAutoInsertProvider : RazorOnAutoInsertProvider
@@ -271,11 +454,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         private static RazorCodeDocument CreateCodeDocument()
         {
-            var codeDocument = TestRazorCodeDocument.CreateEmpty();
-            var emptySourceDocument = RazorSourceDocument.Create(content: string.Empty, fileName: "testFile.razor");
-            var syntaxTree = RazorSyntaxTree.Parse(emptySourceDocument);
-            codeDocument.SetSyntaxTree(syntaxTree);
-            return codeDocument;
+            return CreateCodeDocument("");
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
@@ -34,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         internal DocumentContextFactory DocumentContextFactory { get; private set; }
         internal LanguageServerFeatureOptions LanguageServerFeatureOptions { get; private set; }
-        internal ClientNotifierServiceBase LanguageServer { get; private set; }
+        internal TestLanguageServer LanguageServer { get; private set; }
         internal RazorDocumentMappingService DocumentMappingService { get; private set; }
 
         protected async Task CreateLanguageServerAsync(RazorCodeDocument codeDocument, string razorFilePath)
@@ -57,10 +58,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             DocumentMappingService = new DefaultRazorDocumentMappingService(LanguageServerFeatureOptions, DocumentContextFactory, LoggerFactory);
         }
 
-        private class TestLanguageServer : ClientNotifierServiceBase
+        internal class TestLanguageServer : ClientNotifierServiceBase
         {
             private readonly CSharpTestLspServer _csharpServer;
             private readonly Uri _csharpDocumentUri;
+
+            public int RequestCount;
 
             public TestLanguageServer(CSharpTestLspServer csharpServer, Uri csharpDocumentUri)
             {
@@ -82,12 +85,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             public async override Task<IResponseRouterReturns> SendRequestAsync<T>(string method, T @params)
             {
+                RequestCount++;
                 return await (method switch
                 {
                     RazorLanguageServerCustomMessageTargets.RazorDefinitionEndpointName => HandleDefinitionAsync(@params),
                     RazorLanguageServerCustomMessageTargets.RazorImplementationEndpointName => HandleImplementationAsync(@params),
                     RazorLanguageServerCustomMessageTargets.RazorSignatureHelpEndpointName => HandleSignatureHelpAsync(@params),
                     RazorLanguageServerCustomMessageTargets.RazorRenameEndpointName => HandleRenameAsync(@params),
+                    RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertnEndpointName => HandleOnAutoInsertAsync(@params),
                     _ => throw new NotImplementedException($"I don't know how to handle the '{method}' method.")
                 });
             }
@@ -157,6 +162,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 };
 
                 var result = await _csharpServer.ExecuteRequestAsync<RenameParams, WorkspaceEdit>(Methods.TextDocumentRenameName, delegatedRequest, CancellationToken.None);
+
+                return new TestResponseRouterReturn(result);
+            }
+
+            private async Task<IResponseRouterReturns> HandleOnAutoInsertAsync<T>(T @params)
+            {
+                var delegatedParams = Assert.IsType<DelegatedOnAutoInsertParams>(@params);
+                var delegatedRequest = new VSInternalDocumentOnAutoInsertParams()
+                {
+                    TextDocument = new TextDocumentIdentifier()
+                    {
+                        Uri = _csharpDocumentUri
+                    },
+                    Position = delegatedParams.ProjectedPosition,
+                    Character = delegatedParams.Character,
+                    Options = delegatedParams.Options
+                };
+
+                var result = await _csharpServer.ExecuteRequestAsync<VSInternalDocumentOnAutoInsertParams, VSInternalDocumentOnAutoInsertResponseItem>(VSInternalMethods.OnAutoInsertName, delegatedRequest, CancellationToken.None);
 
                 return new TestResponseRouterReturn(result);
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     RazorLanguageServerCustomMessageTargets.RazorImplementationEndpointName => HandleImplementationAsync(@params),
                     RazorLanguageServerCustomMessageTargets.RazorSignatureHelpEndpointName => HandleSignatureHelpAsync(@params),
                     RazorLanguageServerCustomMessageTargets.RazorRenameEndpointName => HandleRenameAsync(@params),
-                    RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertnEndpointName => HandleOnAutoInsertAsync(@params),
+                    RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName => HandleOnAutoInsertAsync(@params),
                     _ => throw new NotImplementedException($"I don't know how to handle the '{method}' method.")
                 });
             }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnAutoInsertTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/OnAutoInsertTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Razor.IntegrationTests
+{
+    public class OnAutoInsertTests : AbstractRazorEditorTest
+    {
+        [IdeFact]
+        public async Task CSharp_DocumentationComments()
+        {
+            var version = await TestServices.Shell.GetVersionAsync(HangMitigatingCancellationToken);
+
+            // Open the file
+            await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+
+            await TestServices.Editor.SetTextAsync(@"
+<div>
+</div>
+
+@functions
+{
+    //
+    public void M()
+    {
+    }
+}
+
+", ControlledHangMitigatingCancellationToken);
+            await TestServices.Editor.PlaceCaretAsync("//", charsOffset: 2, ControlledHangMitigatingCancellationToken);
+
+            // Act
+            TestServices.Input.Send("/");
+
+            // Assert
+            await TestServices.Editor.WaitForCurrentLineTextAsync("/// ", ControlledHangMitigatingCancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6650

Fairly straightforward implementation, though I did need to access the original request, and the project, when handling the delegated parameters, and I had to add an opt-out of delegating (returning null from CreateDelegatedParams), and the OnAutoInsert parameters didn't inherit from TextDocumentPositionParams, but fulfils the same contract, so all-in-all there is a little churn.