### PR TITLE
Fix build.cmd to always pass -restore and -build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-set _args=%*
+set _args=-restore -build %*
 if "%~1"=="-?" set _args=-help
 
 powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\common\build.ps1'" %_args%

--- a/eng/restore-internal-tools.yml
+++ b/eng/restore-internal-tools.yml
@@ -4,8 +4,7 @@ steps:
       nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling'
       forceReinstallCredentialProvider: true
 
-  - script: $(Build.SourcesDirectory)\build.cmd
-            -ci
+  - script: $(Build.SourcesDirectory)/eng/CIBuild.cmd
             -restore
             -projects $(Build.SourcesDirectory)/eng/common/internal/Tools.csproj
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/RestoreInternal.binlog


### PR DESCRIPTION
Fixes #6790

This fixes an issue that was introduced with #6545 where `build.cmd` would no longer pass the `-restore` and `-build` arguments by default. Previously, `build.cmd` also passed `-pack`, but that appears to be failing, so I've chosen to leave that out for now.
