### PR TITLE
[VSCode] Pass in document selector so Razor documents can be recognized

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -44,7 +44,7 @@
     "workspaceContains:**/*.csx",
     "workspaceContains:**/*.cake"
   ],
-  "main": "./dist/extension",
+  "main": "../Microsoft.AspNetCore.Razor.VSCode.Extension/dist/extension.js",
   "contributes": {
     "breakpoints": [
       {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/src/extension.ts
@@ -20,7 +20,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const config = process.env.config ? process.env.config : 'Debug';
 
     const languageServerDir = path.join(
-        __dirname, '..', '..', '..', '..', '..', 'artifacts', 'bin', 'rzls', config, 'net6.0');
+        __dirname, '..', '..', '..', '..', '..', 'artifacts', 'bin', 'rzls', config, 'net7.0');
 
     if (!fs.existsSync(languageServerDir)) {
         vscode.window.showErrorMessage(`The Razor Language Server project has not yet been built - could not find ${languageServerDir}`);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ProvisionalCompletionOrchestrator.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/ProvisionalCompletionOrchestrator.ts
@@ -156,7 +156,7 @@ export class ProvisionalCompletionOrchestrator {
             this.projectedCSharpProvider.ensureDocumentContent(projectedDocument.uri);
 
             if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(`Ensured removalof provisional completion on ${projectedDocument.uri}.`);
+                this.logger.logVerbose(`Ensured removal of provisional completion on ${projectedDocument.uri}.`);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -14,6 +14,7 @@ import {
     ServerOptions,
     State,
 } from 'vscode-languageclient/lib/main';
+import { RazorLanguage } from './RazorLanguage';
 import { RazorLanguageServerOptions } from './RazorLanguageServerOptions';
 import { resolveRazorLanguageServerOptions } from './RazorLanguageServerOptionsResolver';
 import { resolveRazorLanguageServerTrace } from './RazorLanguageServerTraceResolver';
@@ -220,6 +221,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
 
         this.clientOptions = {
             outputChannel: options.outputChannel,
+            documentSelector: [ { language: RazorLanguage.id, pattern: RazorLanguage.globbingPattern } ],
         };
 
         const args: string[] = [];


### PR DESCRIPTION
(See last commit only)

Passes in a document selector to client options so that Razor documents can be recognized. I believe this was previously done within the language server itself, but was taken out of the server logic within the past year as we did more refactoring.