### PR TITLE
[VS Code] Remove double handler registrations

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -19,5 +19,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public override bool SingleServerCompletionSupport => false;
 
         public override bool SingleServerSupport => false;
+
+        public override bool RegisterBuiltInFeatures => false;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -19,9 +19,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         where TRequest : ITextDocumentPositionParams, IRequest<TResponse?>
     {
         private readonly DocumentContextFactory _documentContextFactory;
-        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private readonly RazorDocumentMappingService _documentMappingService;
         private readonly ClientNotifierServiceBase _languageServer;
+
+        protected readonly LanguageServerFeatureOptions LanguageServerFeatureOptions;
         protected readonly ILogger Logger;
 
         protected AbstractRazorDelegatingEndpoint(
@@ -32,10 +33,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             ILogger logger)
         {
             _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
-            _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
             _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
             _languageServer = languageServer ?? throw new ArgumentNullException(nameof(languageServer));
 
+            LanguageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -70,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         /// <summary>
         /// Returns true if the configuration supports this operation being handled, otherwise returns false. Use to
-        /// handle cases where <see cref="LanguageServerFeatureOptions"/> other than <see cref="LanguageServerFeatureOptions.SingleServerSupport"/>
+        /// handle cases where <see cref="CodeAnalysis.Razor.Workspaces.LanguageServerFeatureOptions"/> other than <see cref="LanguageServerFeatureOptions.SingleServerSupport"/>
         /// need to be checked to validate that the operation can be done.
         /// </summary>
         protected virtual bool IsSupported() => true;
@@ -110,7 +111,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return response;
             }
 
-            if (!_languageServerFeatureOptions.SingleServerSupport)
+            if (!LanguageServerFeatureOptions.SingleServerSupport)
             {
                 return default;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
         protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName;
 
-        public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
+        public RegistrationExtensionResult GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
             const string AssociatedServerCapability = "_vs_onAutoInsertProvider";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
 
         protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName;
 
-        public RegistrationExtensionResult GetRegistration(VSInternalClientCapabilities clientCapabilities)
+        public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
             const string AssociatedServerCapability = "_vs_onAutoInsertProvider";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -97,6 +97,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         {
             _supportsCodeActionResolve = clientCapabilities.TextDocument?.CodeAction?.ResolveSupport != null;
 
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "codeActionProvider";
 
             var options = new CodeActionOptions

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -97,9 +97,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         {
             _supportsCodeActionResolve = clientCapabilities.TextDocument?.CodeAction?.ResolveSupport != null;
 
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -69,9 +69,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            const string AssociatedServerCapability = "completionProvider";
-
             _clientCapabilities = clientCapabilities;
+
+            const string AssociatedServerCapability = "completionProvider";
 
             var registrationOptions = new CompletionOptions()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -69,9 +69,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            _clientCapabilities = clientCapabilities;
-
             const string AssociatedServerCapability = "completionProvider";
+
+            _clientCapabilities = clientCapabilities;
 
             var registrationOptions = new CompletionOptions()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -17,15 +18,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         private readonly ILogger _logger;
         private readonly DocumentContextFactory _documentContextFactory;
         private readonly CompletionListProvider _completionListProvider;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private VSInternalClientCapabilities? _clientCapabilities;
 
         public RazorCompletionEndpoint(
             DocumentContextFactory documentContextFactory,
             CompletionListProvider completionListProvider,
+            LanguageServerFeatureOptions languageServerFeatureOptions,
             ILoggerFactory loggerFactory)
         {
             _documentContextFactory = documentContextFactory;
             _completionListProvider = completionListProvider;
+            _languageServerFeatureOptions = languageServerFeatureOptions;
             _logger = loggerFactory.CreateLogger<RazorCompletionEndpoint>();
         }
 
@@ -34,9 +38,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             const string AssociatedServerCapability = "completionProvider";
             _clientCapabilities = clientCapabilities;
 
-            // VSCode registers built-in features by default and non-built-in features separately:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -32,8 +32,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
             const string AssociatedServerCapability = "completionProvider";
-
             _clientCapabilities = clientCapabilities;
+
+            // VSCode registers built-in features by default and non-built-in features separately:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
 
             var registrationOptions = new CompletionOptions()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -48,6 +48,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "definitionProvider";
             var option = new DefinitionOptions();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -48,9 +48,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!LanguageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -26,6 +26,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapabilities = "colorProvider";
             var options = new DocumentColorOptions();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            if (_languageServerFeatureOptions.RegisterBuiltInFeatures)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
@@ -13,8 +14,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
     internal class DocumentColorEndpoint : IDocumentColorEndpoint
     {
         private readonly ClientNotifierServiceBase _languageServer;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
-        public DocumentColorEndpoint(ClientNotifierServiceBase languageServer)
+        public DocumentColorEndpoint(ClientNotifierServiceBase languageServer, LanguageServerFeatureOptions languageServerFeatureOptions)
         {
             if (languageServer is null)
             {
@@ -22,13 +24,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
             }
 
             _languageServer = languageServer;
+            _languageServerFeatureOptions = languageServerFeatureOptions;
         }
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
@@ -30,9 +30,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentHighlighting
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!LanguageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
@@ -30,6 +30,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentHighlighting
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "documentHighlightProvider";
             var options = new DocumentHighlightOptions
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -24,6 +25,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
         private readonly RazorDocumentMappingService _documentMappingService;
         private readonly ClientNotifierServiceBase _languageServer;
         private readonly IEnumerable<RazorFoldingRangeProvider> _foldingRangeProviders;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private readonly ILogger _logger;
 
         public FoldingRangeEndpoint(
@@ -31,20 +33,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
             RazorDocumentMappingService documentMappingService,
             ClientNotifierServiceBase languageServer,
             IEnumerable<RazorFoldingRangeProvider> foldingRangeProviders,
+            LanguageServerFeatureOptions languageServerFeatureOptions,
             ILoggerFactory loggerFactory)
         {
             _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
             _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
             _languageServer = languageServer ?? throw new ArgumentNullException(nameof(languageServer));
             _foldingRangeProviders = foldingRangeProviders ?? throw new ArgumentNullException(nameof(foldingRangeProviders));
+            _languageServerFeatureOptions = languageServerFeatureOptions;
             _logger = loggerFactory.CreateLogger<FoldingRangeEndpoint>();
         }
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -42,6 +42,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Folding
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string AssociatedServerCapability = "foldingRangeProvider";
 
             var registrationOptions = new FoldingRangeOptions();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentFormattingEndpoint.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -15,11 +16,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
     {
         private readonly DocumentContextFactory _documentContextFactory;
         private readonly RazorFormattingService _razorFormattingService;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
 
         public RazorDocumentFormattingEndpoint(
             DocumentContextFactory documentContextFactory,
             RazorFormattingService razorFormattingService,
+            LanguageServerFeatureOptions languageServerFeatureOptions,
             IOptionsMonitor<RazorLSPOptions> optionsMonitor)
         {
             if (documentContextFactory is null)
@@ -39,14 +42,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             _documentContextFactory = documentContextFactory;
             _razorFormattingService = razorFormattingService;
+            _languageServerFeatureOptions = languageServerFeatureOptions;
             _optionsMonitor = optionsMonitor;
         }
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentFormattingEndpoint.cs
@@ -44,6 +44,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "documentFormattingProvider";
 
             return new RegistrationExtensionResult(ServerCapability, new DocumentFormattingOptions());

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentOnTypeFormattingEndpoint.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -23,6 +24,7 @@ internal class RazorDocumentOnTypeFormattingEndpoint : IVSDocumentOnTypeFormatti
     private readonly RazorFormattingService _razorFormattingService;
     private readonly RazorDocumentMappingService _razorDocumentMappingService;
     private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly ILogger _logger;
 
     private static readonly IReadOnlyList<string> s_csharpTriggerCharacters = new[] { "}", ";" };
@@ -34,6 +36,7 @@ internal class RazorDocumentOnTypeFormattingEndpoint : IVSDocumentOnTypeFormatti
         RazorFormattingService razorFormattingService,
         RazorDocumentMappingService razorDocumentMappingService,
         IOptionsMonitor<RazorLSPOptions> optionsMonitor,
+        LanguageServerFeatureOptions languageServerFeatureOptions,
         ILoggerFactory loggerFactory)
     {
         if (documentContextFactory is null)
@@ -65,14 +68,13 @@ internal class RazorDocumentOnTypeFormattingEndpoint : IVSDocumentOnTypeFormatti
         _razorFormattingService = razorFormattingService;
         _razorDocumentMappingService = razorDocumentMappingService;
         _optionsMonitor = optionsMonitor;
+        _languageServerFeatureOptions = languageServerFeatureOptions;
         _logger = loggerFactory.CreateLogger<RazorDocumentOnTypeFormattingEndpoint>();
     }
 
     public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
     {
-        // VSCode registers built-in features by default:
-        // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-        if (!clientCapabilities.SupportsVisualStudioExtensions)
+        if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentOnTypeFormattingEndpoint.cs
@@ -70,6 +70,13 @@ internal class RazorDocumentOnTypeFormattingEndpoint : IVSDocumentOnTypeFormatti
 
     public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
     {
+        // VSCode registers built-in features by default:
+        // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+        if (!clientCapabilities.SupportsVisualStudioExtensions)
+        {
+            return null;
+        }
+
         const string ServerCapability = "documentOnTypeFormattingProvider";
 
         return new RegistrationExtensionResult(ServerCapability,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingEndpoint.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -16,11 +17,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private readonly DocumentContextFactory _documentContextFactory;
         private readonly RazorFormattingService _razorFormattingService;
         private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
         public RazorDocumentRangeFormattingEndpoint(
             DocumentContextFactory documentContextFactory,
             RazorFormattingService razorFormattingService,
-            IOptionsMonitor<RazorLSPOptions> optionsMonitor)
+            IOptionsMonitor<RazorLSPOptions> optionsMonitor,
+            LanguageServerFeatureOptions languageServerFeatureOptions)
         {
             if (documentContextFactory is null)
             {
@@ -40,13 +43,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             _documentContextFactory = documentContextFactory;
             _razorFormattingService = razorFormattingService;
             _optionsMonitor = optionsMonitor;
+            _languageServerFeatureOptions = languageServerFeatureOptions;
         }
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorDocumentRangeFormattingEndpoint.cs
@@ -44,6 +44,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "documentRangeFormattingProvider";
 
             return new RegistrationExtensionResult(ServerCapability, new DocumentRangeFormattingOptions());

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -35,8 +35,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            const string AssociatedServerCapability = "hoverProvider";
             _clientCapabilities = clientCapabilities;
+
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
+            const string AssociatedServerCapability = "hoverProvider";
 
             var registrationOptions = new HoverOptions()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -37,9 +37,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         {
             _clientCapabilities = clientCapabilities;
 
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!LanguageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -48,6 +48,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "linkedEditingRangeProvider";
             var option = new LinkedEditingRangeOptions { };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.LinkedEditingRange;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -26,10 +27,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
         internal static readonly string WordPattern = @"!?[^ <>!\/\?\[\]=""\\@" + Environment.NewLine + "]+";
 
         private readonly DocumentContextFactory _documentContextFactory;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private readonly ILogger _logger;
 
         public LinkedEditingRangeEndpoint(
             DocumentContextFactory documentContextFactory,
+            LanguageServerFeatureOptions languageServerFeatureOptions,
             ILoggerFactory loggerFactory)
         {
             if (documentContextFactory is null)
@@ -43,14 +46,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange
             }
 
             _documentContextFactory = documentContextFactory;
+            _languageServerFeatureOptions = languageServerFeatureOptions;
             _logger = loggerFactory.CreateLogger<LinkedEditingRangeEndpoint>();
         }
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -54,6 +54,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "renameProvider";
             var options = new RenameOptions
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -54,9 +54,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!LanguageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -16,9 +17,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
     {
         private readonly ILogger _logger;
         private readonly RazorSemanticTokensInfoService _semanticTokensInfoService;
+        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
         public RazorSemanticTokensEndpoint(
             RazorSemanticTokensInfoService semanticTokensInfoService,
+            LanguageServerFeatureOptions languageServerFeatureOptions,
             ILoggerFactory loggerFactory)
         {
             if (semanticTokensInfoService is null)
@@ -32,6 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
             }
 
             _semanticTokensInfoService = semanticTokensInfoService;
+            _languageServerFeatureOptions = languageServerFeatureOptions;
             _logger = loggerFactory.CreateLogger<RazorSemanticTokensEndpoint>();
         }
 
@@ -58,9 +62,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
-            // VSCode registers built-in features by default:
-            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
-            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            if (!_languageServerFeatureOptions.RegisterBuiltInFeatures)
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/RazorSemanticTokensEndpoint.cs
@@ -58,6 +58,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
 
         public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
         {
+            // VSCode registers built-in features by default:
+            // https://github.com/microsoft/vscode-languageserver-node/blob/ed6a6d7da0ad64ebea0b55e4b2f339a1ec7f511f/client/src/common/client.ts#L1615
+            if (!clientCapabilities.SupportsVisualStudioExtensions)
+            {
+                return null;
+            }
+
             const string ServerCapability = "semanticTokensProvider";
 
             return new RegistrationExtensionResult(ServerCapability,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpLanguageServerFeatureOptions.cs
@@ -8,8 +8,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
 {
     public class OmniSharpLanguageServerFeatureOptions
     {
-        private LanguageServerFeatureOptions _internalLanguageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
-
-        internal LanguageServerFeatureOptions InternalLanguageServerFeatureOptions => _internalLanguageServerFeatureOptions;
+        internal LanguageServerFeatureOptions InternalLanguageServerFeatureOptions { get; } = new DefaultLanguageServerFeatureOptions();
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguage.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguage.ts
@@ -9,5 +9,5 @@ export class RazorLanguage {
     public static id = 'aspnetcorerazor';
     public static fileExtensions = [ 'cshtml', 'razor' ];
     public static globbingPattern = `**/*.{${RazorLanguage.fileExtensions.join(',')}}`;
-    public static documentSelector: vscode.DocumentSelector = { pattern: RazorLanguage.globbingPattern };
+    public static documentSelector: vscode.DocumentSelector = { language: this.id, pattern: RazorLanguage.globbingPattern };
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServerClient.ts
@@ -236,11 +236,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
             args.push('--debug');
         }
 
-        this.serverOptions = {
-            run: { command, args },
-            debug: { command, args },
-        };
-
+        this.serverOptions = { command, args };
         this.client = new LanguageClient('razorLanguageServer', 'Razor Language Server', this.serverOptions, this.clientOptions);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -19,6 +19,11 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
         public abstract bool SingleServerSupport { get; }
 
+        /// <summary>
+        /// This is a temporary workaround to account for the fact that both O# and Razor register handlers.
+        /// It can be removed once we switch over to CLaSP:
+        /// https://github.com/dotnet/razor-tooling/issues/6871
+        /// </summary>
         public abstract bool RegisterBuiltInFeatures { get; }
 
         public string GetRazorCSharpFilePath(string razorFilePath) => razorFilePath + CSharpVirtualDocumentSuffix;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -19,6 +19,8 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
         public abstract bool SingleServerSupport { get; }
 
+        public abstract bool RegisterBuiltInFeatures { get; }
+
         public string GetRazorCSharpFilePath(string razorFilePath) => razorFilePath + CSharpVirtualDocumentSuffix;
 
         public string GetRazorHtmlFilePath(string razorFilePath) => razorFilePath + HtmlVirtualDocumentSuffix;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -58,6 +58,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public override bool SingleServerSupport => _singleServerSupport.Value;
 
+        public override bool RegisterBuiltInFeatures => true;
+
         private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -37,6 +37,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public override bool SingleServerSupport => false;
 
+        public override bool RegisterBuiltInFeatures => true;
+
         private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -21,8 +21,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
             var documentPath = "C:/path/to/document.cshtml";
             var documentContextFactory = new TestDocumentContextFactory();
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var completionEndpoint = new RazorCompletionEndpoint(
-                documentContextFactory, completionListProvider: null, LoggerFactory);
+                documentContextFactory, completionListProvider: null, languageServerFeatureOptions, LoggerFactory);
             var request = new VSCompletionParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
@@ -25,8 +25,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
-                EmptyDocumentContextFactory, formattingService, documentMappingService, optionsMonitor, LoggerFactory);
+                EmptyDocumentContextFactory, formattingService, documentMappingService, optionsMonitor, languageServerFeatureOptions, LoggerFactory);
             var @params = new DocumentOnTypeFormattingParamsBridge { TextDocument = new TextDocumentIdentifier { Uri = uri, } };
 
             // Act
@@ -51,8 +52,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
-                documentResolver, formattingService, documentMappingService, optionsMonitor, LoggerFactory);
+                documentResolver, formattingService, documentMappingService, optionsMonitor, languageServerFeatureOptions, LoggerFactory);
             var @params = new DocumentOnTypeFormattingParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -83,8 +85,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
-                documentResolver, formattingService, documentMappingService, optionsMonitor, LoggerFactory);
+                documentResolver, formattingService, documentMappingService, optionsMonitor, languageServerFeatureOptions, LoggerFactory);
             var @params = new DocumentOnTypeFormattingParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -116,8 +119,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentMappingService = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
             documentMappingService.Setup(s => s.GetLanguageKind(codeDocument, 17, false)).Returns(RazorLanguageKind.Html);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
-                documentResolver, formattingService, documentMappingService.Object, optionsMonitor, LoggerFactory);
+                documentResolver, formattingService, documentMappingService.Object, optionsMonitor, languageServerFeatureOptions, LoggerFactory);
             var @params = new DocumentOnTypeFormattingParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -149,8 +153,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentMappingService = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
             documentMappingService.Setup(s => s.GetLanguageKind(codeDocument, 17, false)).Returns(RazorLanguageKind.Razor);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
-                documentResolver, formattingService, documentMappingService.Object, optionsMonitor, LoggerFactory);
+                documentResolver, formattingService, documentMappingService.Object, optionsMonitor, languageServerFeatureOptions, LoggerFactory);
             var @params = new DocumentOnTypeFormattingParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -181,8 +186,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var formattingService = new DummyRazorFormattingService();
             var documentMappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, documentResolver, LoggerFactory);
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentOnTypeFormattingEndpoint(
-                documentResolver, formattingService, documentMappingService, optionsMonitor, LoggerFactory);
+                documentResolver, formattingService, documentMappingService, optionsMonitor, languageServerFeatureOptions, LoggerFactory);
             var @params = new DocumentOnTypeFormattingParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, },

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
@@ -23,8 +23,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
             var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
-                documentContextFactory, formattingService, optionsMonitor);
+                documentContextFactory, formattingService, optionsMonitor, languageServerFeatureOptions);
             var @params = new DocumentRangeFormattingParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, }
@@ -44,8 +45,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Arrange
             var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
-                EmptyDocumentContextFactory, formattingService, optionsMonitor);
+                EmptyDocumentContextFactory, formattingService, optionsMonitor, languageServerFeatureOptions);
             var uri = new Uri("file://path/test.razor");
             var @params = new DocumentRangeFormattingParamsBridge()
             {
@@ -69,8 +71,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
             var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
-                documentContextFactory, formattingService, optionsMonitor);
+                documentContextFactory, formattingService, optionsMonitor, languageServerFeatureOptions);
             var @params = new DocumentRangeFormattingParamsBridge()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, }
@@ -89,8 +92,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             // Arrange
             var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
-                EmptyDocumentContextFactory, formattingService, optionsMonitor);
+                EmptyDocumentContextFactory, formattingService, optionsMonitor, languageServerFeatureOptions);
             var @params = new DocumentRangeFormattingParamsBridge();
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -649,7 +649,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
                 options.SupportsFileManipulation == true &&
                 options.SingleServerSupport == true &&
                 options.CSharpVirtualDocumentSuffix == ".g.cs" &&
-                options.HtmlVirtualDocumentSuffix == ".g.html"
+                options.HtmlVirtualDocumentSuffix == ".g.html" &&
+                options.RegisterBuiltInFeatures == true
                 , MockBehavior.Strict);
             var languageServer = new HoverLanguageServer(csharpServer, csharpDocumentUri);
             var documentMappingService = new DefaultRazorDocumentMappingService(languageServerFeatureOptions, documentContextFactory, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
@@ -25,7 +25,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument, documentFound: false);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -47,7 +48,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -84,7 +86,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -121,7 +124,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -158,7 +162,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -180,7 +185,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -202,7 +208,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -239,7 +246,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -276,7 +284,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
@@ -313,7 +322,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
+            var languageServerFeatureOptions = new DefaultLanguageServerFeatureOptions();
+            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, languageServerFeatureOptions, LoggerFactory);
             var request = new LinkedEditingRangeParamsBridge
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -24,5 +24,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public override bool SingleServerCompletionSupport => false;
 
         public override bool SingleServerSupport => false;
+
+        public override bool RegisterBuiltInFeatures => true;
     }
 }


### PR DESCRIPTION
### Summary of the changes
- We were seeing issues with double registrations of handlers, which resulted in issues such as double hover.
- Previously, I debugged through the client code and had _thought_ this was a bug on the VS Code client side. However, after discussing with Dirk + debugging through some more, this actually seems to be a probable bug in O#.
- Essentially, O# [registers the handlers it recognizes](https://github.com/OmniSharp/csharp-language-server-protocol/blob/e0cc2012b63757ebf779bf4e86e8835e400b034f/src/Server/LanguageServerHelpers.cs#L147). However, since Razor also registers handlers, this results in some handlers being registered twice.
- This is likely not an issue in VS since it doesn't look like the VS client supports direct registration requests via `client/registerCapability`. Instead, VS only recognizes handlers via initialize requests.
- Since we're switching away from O# once CLaSP is merged, this should be a non-issue soon. I created a tracking issue so we can eventually remove this workaround: https://github.com/dotnet/razor-tooling/issues/6871
