### PR TITLE
[VSCode] Update VS LSP protocol version (main)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,7 +77,7 @@
     <MicrosoftVisualStudioShellPackagesVersion>17.2.32330.158</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.3.133-preview</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.4.0-2.22424.2</RoslynPackageVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.4.1004-preview</VisualStudioLanguageServerProtocolVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.4.1008-preview</VisualStudioLanguageServerProtocolVersion>
     <MicrosoftNetCompilersToolsetVersion>4.4.0-1.final</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">


### PR DESCRIPTION
Same as https://github.com/dotnet/razor-tooling/pull/6880 but targeted towards main since the LSP client merged a breaking change today.