### PR TITLE
CLaSP: DocumentSync tests, Semantic Refresh, WrapWithTag, and DocRang…

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -111,6 +111,15 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
             return documentFound ? TestDocumentContext.From(documentPath.GetAbsoluteOrUNCPath(), codeDocument, hostDocumentVersion: 1337) : null;
         }
 
+        internal static string GetString(SourceText sourceText)
+        {
+            var sourceChars = new char[sourceText.Length];
+            sourceText.CopyTo(0, sourceChars, 0, sourceText.Length);
+            var sourceString = new string(sourceChars);
+
+            return sourceString;
+        }
+
         internal static DocumentContextFactory CreateDocumentContextFactory(
             Uri documentPath,
             RazorCodeDocument codeDocument,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentRangeFormattingEndpointTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(
                 formattingService, optionsMonitor);
-            var @params = new DocumentRangeFormattingParamsBridge()
+            var @params = new DocumentRangeFormattingParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, }
             };
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(formattingService, optionsMonitor);
             var uri = new Uri("file://path/test.razor");
-            var @params = new DocumentRangeFormattingParamsBridge()
+            var @params = new DocumentRangeFormattingParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, }
             };
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(formattingService, optionsMonitor);
-            var @params = new DocumentRangeFormattingParamsBridge()
+            var @params = new DocumentRangeFormattingParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri, }
             };
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var formattingService = new DummyRazorFormattingService();
             var optionsMonitor = GetOptionsMonitor(enableFormatting: false);
             var endpoint = new RazorDocumentRangeFormattingEndpoint(formattingService, optionsMonitor);
-            var @params = new DocumentRangeFormattingParamsBridge();
+            var @params = new DocumentRangeFormattingParams();
             var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDidCloseTextDocumentEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDidCloseTextDocumentEndpointTest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.DocumentSynchronization;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorDidCloseTextDocumentEndpointTest : LanguageServerTestBase
+    {
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
+        public async Task Handle_DidCloseTextDocument_ClosesDocument()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
+            projectService.Setup(service => service.CloseDocument(It.IsAny<string>()))
+                .Callback<string>((path) => Assert.Equal(documentPath, path));
+            var endpoint = new RazorDidCloseTextDocumentEndpoint(Dispatcher, projectService.Object);
+            var request = new DidCloseTextDocumentParams()
+            {
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = new Uri(documentPath)
+                }
+            };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
+
+            // Act
+            await endpoint.HandleNotificationAsync(request, requestContext, default);
+
+            // Assert
+            projectService.VerifyAll();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDidOpenTextDocumentEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDidOpenTextDocumentEndpointTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.DocumentSynchronization;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer
+{
+    public class RazorDidOpenTextDocumentEndpointTest : LanguageServerTestBase
+    {
+        // This is more of an integration test to validate that all the pieces work together
+        [Fact]
+        public async Task Handle_DidOpenTextDocument_AddsDocument()
+        {
+            // Arrange
+            var documentPath = "C:/path/to/document.cshtml";
+            var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
+            projectService.Setup(service => service.OpenDocument(It.IsAny<string>(), It.IsAny<SourceText>(), It.IsAny<int>()))
+                .Callback<string, SourceText, int>((path, text, version) =>
+                {
+                    var resultString = GetString(text);
+                    Assert.Equal("hello", resultString);
+                    Assert.Equal(documentPath, path);
+                    Assert.Equal(1337, version);
+                });
+            var endpoint = new RazorDidOpenTextDocumentEndpoint(Dispatcher, projectService.Object);
+            var request = new DidOpenTextDocumentParams()
+            {
+                TextDocument = new TextDocumentItem()
+                {
+                    Text = "hello",
+                    Uri = new Uri(documentPath),
+                    Version = 1337,
+                }
+            };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
+
+            // Act
+            await endpoint.HandleNotificationAsync(request, requestContext, default);
+
+            // Assert
+            projectService.VerifyAll();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -8,14 +8,13 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Moq;
 using Xunit;
-using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -24,6 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public RazorLanguageEndpointTest()
         {
             MappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
+
         }
 
         private RazorDocumentMappingService MappingService { get; }
@@ -42,8 +42,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -52,8 +52,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             };
             var expectedRange = new Range { Start = new Position(0, 4), End = new Position(0, 16) };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.NotNull(response);
@@ -74,8 +76,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -83,8 +85,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.NotNull(response);
@@ -105,8 +109,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -114,8 +118,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.NotNull(response);
@@ -136,8 +142,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -145,8 +151,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.NotNull(response);
@@ -160,8 +168,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -169,8 +177,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.NotNull(response);
@@ -184,8 +194,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.Razor,
@@ -193,8 +203,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.NotNull(response);
@@ -216,8 +228,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             codeDocument.SetUnsupported();
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -225,8 +237,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.NotNull(response);
@@ -240,16 +254,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("@{}");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 1),
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(RazorLanguageKind.Razor, response.Kind);
@@ -264,16 +280,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<s");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 2),
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, response.Kind);
@@ -291,16 +309,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 "@",
                 "/* CSharp */",
                 new[] { new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12)) });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 1),
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, response.Kind);
@@ -320,16 +339,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 "/* CSharp */",
                 new[] { new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12)) });
             codeDocument.SetUnsupported();
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 1),
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await Task.Run(() => languageEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, response.Kind);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public RazorLanguageEndpointTest()
         {
             MappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
-
         }
 
         private RazorDocumentMappingService MappingService { get; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensRefreshEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensRefreshEndpointTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Semantic
             var errorReporter = new TestErrorReporter();
             using var semanticTokensRefreshPublisher = new DefaultWorkspaceSemanticTokensRefreshPublisher(clientSettingsManager.Object, serverClient, errorReporter);
             var refreshEndpoint = new SemanticTokensRefreshEndpoint(semanticTokensRefreshPublisher);
-            var refreshParams = new SemanticTokensRefreshParamsBridge();
+            var refreshParams = new SemanticTokensRefreshParams();
             var requestContext = new RazorRequestContext();
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
 
             var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
             languageServer
-                .Setup(l => l.SendRequestAsync<WrapWithTagParams, WrapWithTagResponse>(LanguageServerConstants.RazorWrapWithTagEndpoint, It.IsAny<WrapWithTagParamsBridge>(), It.IsAny<CancellationToken>()))
+                .Setup(l => l.SendRequestAsync<WrapWithTagParams, WrapWithTagResponse>(LanguageServerConstants.RazorWrapWithTagEndpoint, It.IsAny<WrapWithTagParams>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
             var documentMappingService = Mock.Of<RazorDocumentMappingService>(
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
                 languageServer.Object,
                 documentMappingService);
 
-            var wrapWithDivParams = new WrapWithTagParamsBridge(new TextDocumentIdentifier { Uri = uri })
+            var wrapWithDivParams = new WrapWithTagParams(new TextDocumentIdentifier { Uri = uri })
             {
                 Range = new Range { Start = new Position(0, 0), End = new Position(0, 2) },
             };
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
 
             var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
             languageServer
-                .Setup(l => l.SendRequestAsync<WrapWithTagParams, WrapWithTagResponse>(LanguageServerConstants.RazorWrapWithTagEndpoint, It.IsAny<WrapWithTagParamsBridge>(), It.IsAny<CancellationToken>()))
+                .Setup(l => l.SendRequestAsync<WrapWithTagParams, WrapWithTagResponse>(LanguageServerConstants.RazorWrapWithTagEndpoint, It.IsAny<WrapWithTagParams>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
             var documentMappingService = Mock.Of<RazorDocumentMappingService>(
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
                 languageServer.Object,
                 documentMappingService);
 
-            var wrapWithDivParams = new WrapWithTagParamsBridge(new TextDocumentIdentifier { Uri = uri })
+            var wrapWithDivParams = new WrapWithTagParams(new TextDocumentIdentifier { Uri = uri })
             {
                 Range = new Range { Start = new Position(0, 0), End = new Position(0, 2) },
             };
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
                 s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
             var endpoint = new WrapWithTagEndpoint(languageServer.Object, documentMappingService);
 
-            var wrapWithDivParams = new WrapWithTagParamsBridge(new TextDocumentIdentifier { Uri = missingUri })
+            var wrapWithDivParams = new WrapWithTagParams(new TextDocumentIdentifier { Uri = missingUri })
             {
                 Range = new Range { Start = new Position(0, 0), End = new Position(0, 2) },
             };
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag
                 s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
             var endpoint = new WrapWithTagEndpoint(languageServer.Object, documentMappingService);
 
-            var wrapWithDivParams = new WrapWithTagParamsBridge(new TextDocumentIdentifier { Uri = uri })
+            var wrapWithDivParams = new WrapWithTagParams(new TextDocumentIdentifier { Uri = uri })
             {
                 Range = new Range { Start = new Position(0, 0), End = new Position(0, 2) },
             };


### PR DESCRIPTION
### Summary of the changes

- Move DocumentSync tests, Semantic Refresh, WrapWithTag, and DocRange Tests to CLaSP.
