### PR TITLE
CLaSP: CodeAction, Completion, and LinkedEditRange tests

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
@@ -183,15 +183,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         private static ClientNotifierServiceBase CreateLanguageServer(CodeAction resolvedCodeAction)
         {
-            var responseRouterReturns = new Mock<IResponseRouterReturns>(MockBehavior.Strict);
-            responseRouterReturns
-                .Setup(l => l.Returning<CodeAction>(It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(resolvedCodeAction));
-
             var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
             languageServer
-                .Setup(l => l.SendRequestAsync(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>()))
-                .Returns(Task.FromResult(responseRouterReturns.Object));
+                .Setup(l => l.SendRequestAsync<RazorResolveCodeActionParams, CodeAction>(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(resolvedCodeAction));
 
             return languageServer.Object;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json.Linq;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             {
                 _supportsCodeActionResolve = false
             };
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             {
                 _supportsCodeActionResolve = false
             };
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             {
                 _supportsCodeActionResolve = false
             };
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -327,7 +327,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -369,7 +369,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -405,7 +405,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = true
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -451,7 +451,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 _supportsCodeActionResolve = false
             };
 
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
             var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
             var selectionRange = new Range { Start = new Position(0, 5), End = new Position(0, 5) };
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = initialRange,
@@ -507,7 +507,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             // Act
-            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext, default);
+            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
 
             // Assert
             Assert.NotNull(razorCodeActionContext);
@@ -534,7 +534,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = initialRange,
@@ -545,7 +545,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             // Act
-            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext, default);
+            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
 
             // Assert
             Assert.NotNull(razorCodeActionContext);
@@ -576,14 +576,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = initialRange,
                 Context = new VSInternalCodeActionContext()
             };
 
-            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext, default);
+            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
 
             // Act
             var results = await codeActionEndpoint.GetCSharpCodeActionsFromLanguageServerAsync(context, default);
@@ -616,7 +616,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-            var request = new CodeActionParamsBridge()
+            var request = new CodeActionParams()
             {
                 TextDocument = new TextDocumentIdentifier { Uri = documentPath },
                 Range = initialRange,
@@ -626,7 +626,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 }
             };
 
-            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext, default);
+            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
 
             // Act
             var results = await codeActionEndpoint.GetCSharpCodeActionsFromLanguageServerAsync(context, default);
@@ -728,7 +728,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 
         private class TestLanguageServer : ClientNotifierServiceBase
         {
-            public override Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken) => Task.CompletedTask;
+            public override Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+                => Task.CompletedTask;
 
             public override Task SendNotificationAsync<TParams>(string method, TParams @params, CancellationToken cancellationToken)
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     Uri = new Uri("C:/path/to/Page.razor")
                 }
             };
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     RazorFileUri = new Uri("C:/path/to/Page.razor"),
                 })
             };
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     RazorFileUri = new Uri("C:/path/to/Page.razor"),
                 })
             };
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     Uri = new Uri("C:/path/to/Page.razor")
                 }
             };
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     RazorFileUri = new Uri("C:/path/to/Page.razor"),
                 })
             };
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)
@@ -214,7 +214,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     Uri = new Uri("C:/path/to/Page.razor")
                 }
             };
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     RazorFileUri = new Uri("C:/path/to/Page.razor"),
                 })
             };
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)
@@ -438,7 +438,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 Data = JToken.FromObject(new WorkspaceEdit())
             };
 
-            var request = new CodeActionBridge()
+            var request = new CodeAction()
             {
                 Title = "Valid request",
                 Data = JToken.FromObject(requestParams)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -149,9 +149,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.True(editCodeDocumentChange.TryGetFirst(out var textDocumentEdit1));
             var editCodeDocumentEdit = textDocumentEdit1!.Edits.First();
-            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeStart));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeStart));
             Assert.Equal(actionParams.RemoveStart, removeStart);
-            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeEnd));
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeEnd));
             Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];
@@ -198,9 +198,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.True(editCodeDocumentChange.TryGetFirst(out var editCodeDocument));
             var editCodeDocumentEdit = editCodeDocument!.Edits.First();
-            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeStart));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeStart));
             Assert.Equal(actionParams.RemoveStart, removeStart);
-            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeEnd));
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeEnd));
             Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];
@@ -247,9 +247,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var editCodeDocumentChange = documentChanges[1];
             Assert.True(editCodeDocumentChange.TryGetFirst(out var editCodeDocument));
             var editCodeDocumentEdit = editCodeDocument!.Edits.First();
-            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeStart));
+            Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeStart));
             Assert.Equal(actionParams.RemoveStart, removeStart);
-            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), _logger, out var removeEnd));
+            Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeEnd));
             Assert.Equal(actionParams.RemoveEnd, removeEnd);
 
             var editCodeBehindChange = documentChanges[2];

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -348,7 +348,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentContext = CreateDocumentContext(documentPath, codeDocument);
             var completionEndpoint = new LegacyRazorCompletionEndpoint(CompletionFactsService, CompletionListCache);
             completionEndpoint.GetRegistration(ClientCapabilities);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
@@ -377,7 +377,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentContext = CreateDocumentContext(documentPath, codeDocument);
             var completionEndpoint = new LegacyRazorCompletionEndpoint(CompletionFactsService, CompletionListCache);
             completionEndpoint.GetRegistration(ClientCapabilities);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
@@ -420,7 +420,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentContext = CreateDocumentContext(documentPath, codeDocument);
             var completionEndpoint = new LegacyRazorCompletionEndpoint(CompletionFactsService, CompletionListCache);
             completionEndpoint.GetRegistration(ClientCapabilities);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentContext = CreateDocumentContext(documentPath, codeDocument);
             var completionEndpoint = new LegacyRazorCompletionEndpoint(CompletionFactsService, CompletionListCache);
             completionEndpoint.GetRegistration(ClientCapabilities);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
@@ -500,7 +500,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentContext = CreateDocumentContext(documentPath, codeDocument);
             var completionEndpoint = new LegacyRazorCompletionEndpoint(CompletionFactsService, CompletionListCache);
             completionEndpoint.GetRegistration(ClientCapabilities);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
@@ -544,7 +544,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentContext = CreateDocumentContext(documentPath, codeDocument);
             var completionEndpoint = new LegacyRazorCompletionEndpoint(CompletionFactsService, CompletionListCache);
             completionEndpoint.GetRegistration(ClientCapabilities);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {
@@ -584,7 +584,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             var documentContext = CreateDocumentContext(documentPath, codeDocument);
             var completionEndpoint = new LegacyRazorCompletionEndpoint(CompletionFactsService, CompletionListCache);
             completionEndpoint.GetRegistration(ClientCapabilities);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion
             // Arrange
             var documentPath = "C:/path/to/document.cshtml";
             var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null);
-            var request = new VSCompletionParamsBridge()
+            var request = new CompletionParams()
             {
                 TextDocument = new TextDocumentIdentifier()
                 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
@@ -25,15 +25,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
             var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument, documentFound: false);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <te[||]st1></test1>
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Null(result);
@@ -46,9 +47,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <te[||]st1></test1>
@@ -67,9 +68,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
                     End = new Position { Line = 1, Character = 14 }
                 }
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(expectedRanges, result.Ranges);
@@ -83,9 +85,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 6 } // <test1[||]></test1>
@@ -104,9 +106,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
                     End = new Position { Line = 1, Character = 14 }
                 }
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(expectedRanges, result.Ranges);
@@ -120,9 +123,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 9 } // <test1></[||]test1>
@@ -141,9 +144,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
                     End = new Position { Line = 1, Character = 14 }
                 }
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(expectedRanges, result.Ranges);
@@ -157,16 +161,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 0, Character = 1 } // @[||]addTagHelper *
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Null(result);
@@ -179,16 +184,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <te[||]st1 />
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Null(result);
@@ -201,9 +207,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><test1></test1></test1>";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 1 } // <[||]test1><test1></test1></test1>
@@ -222,9 +228,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
                     End = new Position { Line = 1, Character = 29 }
                 }
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(expectedRanges, result.Ranges);
@@ -238,9 +245,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<body></body>";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <bo[||]dy></body>
@@ -259,9 +266,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
                     End = new Position { Line = 1, Character = 12 }
                 }
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(expectedRanges, result.Ranges);
@@ -275,9 +283,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<body></body>";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 8 } // <body></[||]body>
@@ -296,9 +304,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
                     End = new Position { Line = 1, Character = 12 }
                 }
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(expectedRanges, result.Ranges);
@@ -312,16 +321,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.LinkedEditingRange
             var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<body />";
             var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
             var uri = new Uri("file://path/test.razor");
-            var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-            var endpoint = new LinkedEditingRangeEndpoint(documentContextFactory, LoggerFactory);
-            var request = new LinkedEditingRangeParamsBridge
+            var documentContext = CreateDocumentContext(uri, codeDocument);
+            var endpoint = new LinkedEditingRangeEndpoint(LoggerFactory);
+            var request = new LinkedEditingRangeParams
             {
                 TextDocument = new TextDocumentIdentifier { Uri = uri },
                 Position = new Position { Line = 1, Character = 3 } // <bo[||]dy />
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Null(result);


### PR DESCRIPTION
### Summary of the changes

- Move CodeAction, Completion, and LinkedEditRange tests to CLaSP.