### PR TITLE
CLaSP: AutoInsert, WorkspaceDirectoryPathResolver, MonitorProjectConf…

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultWorkspaceDirectoryPathResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultWorkspaceDirectoryPathResolverTest.cs
@@ -18,10 +18,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             // Arrange
             var expectedWorkspaceDirectory = "/testpath";
+#pragma warning disable CS0618 // Type or member is obsolete
             var clientSettings = new InitializeParams()
             {
                 RootPath = expectedWorkspaceDirectory
             };
+#pragma warning restore CS0618 // Type or member is obsolete
             var server = new Mock<IInitializeManager<InitializeParams, InitializeResult>>(MockBehavior.Strict);
             server.Setup(m => m.GetInitializeParams()).Returns(clientSettings);
             var workspaceDirectoryPathResolver = new DefaultWorkspaceDirectoryPathResolver(server.Object);
@@ -44,11 +46,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Host = null,
                 Path = initialWorkspaceDirectory,
             };
+#pragma warning disable CS0618 // Type or member is obsolete
             var clientSettings = new InitializeParams()
             {
                 RootPath = "/somethingelse",
                 RootUri = uriBuilder.Uri,
             };
+#pragma warning restore CS0618 // Type or member is obsolete
             var server = new Mock<IInitializeManager<InitializeParams, InitializeResult>>(MockBehavior.Strict);
             server.Setup(s => s.GetInitializeParams()).Returns(clientSettings);
             var workspaceDirectoryPathResolver = new DefaultWorkspaceDirectoryPathResolver(server.Object);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsEndpointTest.cs
@@ -4,18 +4,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
@@ -34,20 +33,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         {
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
-            var documentContextFactory = new Mock<DocumentContextFactory>(MockBehavior.Strict);
-            documentContextFactory.Setup(resolver => resolver.TryCreateAsync(documentPath, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(value: null);
 
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory.Object, MappingService, LoggerFactory);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
                 RazorDocumentUri = documentPath,
                 Diagnostics = Array.Empty<VSDiagnostic>()
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act & Assert
-            await Assert.ThrowsAnyAsync<Exception>(async () => await Task.Run(() => diagnosticsEndpoint.Handle(request, default)));
+            await Assert.ThrowsAnyAsync<Exception>(async () => await diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
         }
 
         [Fact]
@@ -63,9 +60,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument, documentFound: false);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument, documentFound: false);
 
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -73,9 +70,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 RazorDocumentUri = documentPath,
             };
             var expectedRange = new Range { Start = new Position(0, 4), End = new Position(0, 16) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Null(response.Diagnostics);
@@ -95,8 +93,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -104,9 +102,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 RazorDocumentUri = documentPath,
             };
             var expectedRange = new Range { Start = new Position(0, 4), End = new Position(0, 16) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(expectedRange, response.Diagnostics![0].Range);
@@ -127,8 +126,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(2, 15),
                         new SourceSpan(2, 15))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -138,9 +137,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 RazorDocumentUri = documentPath,
             };
             var expectedRange = new Range { Start = new Position(0, 3), End = new Position(0, 16) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(expectedRange, response.Diagnostics![0].Range);
@@ -161,8 +161,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(1, 25),
                         new SourceSpan(6, 25))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -172,9 +172,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 RazorDocumentUri = documentPath,
             };
             var expectedRange = new Range { Start = new Position(0, 13), End = new Position(0, 23) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(expectedRange, response.Diagnostics![0].Range);
@@ -200,8 +201,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(28, 14),
                         new SourceSpan(15, 13))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -211,9 +212,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 RazorDocumentUri = documentPath,
             };
             var expectedRange = new Range { Start = new Position(0, 1), End = new Position(0, 43) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(expectedRange, response.Diagnostics![0].Range);
@@ -233,8 +235,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -247,10 +249,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
-            var expectedRange = new Range { Start = new Position(0, 8),End =  new Position(0, 15) };
+            var expectedRange = new Range { Start = new Position(0, 8), End = new Position(0, 15) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -269,8 +272,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(26, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -283,9 +286,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -304,8 +308,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -318,10 +322,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
-            var expectedRange = new Range { Start = new Position(0, 8),End =  new Position(0, 15)};
+            var expectedRange = new Range { Start = new Position(0, 8), End = new Position(0, 15) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -340,8 +345,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -354,10 +359,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
-                var expectedRange = new Range { Start = new Position(0, 4),End =  new Position(0, 16)};
+            var expectedRange = new Range { Start = new Position(0, 4), End = new Position(0, 16) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -377,8 +383,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -390,9 +396,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Null(response.Diagnostics![0].Range);
@@ -412,8 +419,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -426,10 +433,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
-            var expectedRange = new Range { Start = new Position(0, 4),End =  new Position(0, 16)};
+            var expectedRange = new Range { Start = new Position(0, 4), End = new Position(0, 16) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(expectedRange, response.Diagnostics![0].Range);
@@ -449,8 +457,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -462,9 +470,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -484,8 +493,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -497,9 +506,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(RangeExtensions.UndefinedRange, response.Diagnostics![0].Range);
@@ -515,8 +525,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 "<p @onabort=\"\"></p>",
                 "__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );",
                 sourceMappings: Array.Empty<SourceMapping>());
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithoutRazorDiagnostic(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithoutRazorDiagnostic(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -529,9 +539,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(RangeExtensions.UndefinedRange, response.Diagnostics![0].Range);
@@ -547,8 +558,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 "<p @onabort=\"\"></p>",
                 "__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );",
                 sourceMappings: Array.Empty<SourceMapping>());
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithRazorDiagnostic(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithRazorDiagnostic(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -561,9 +572,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -583,8 +595,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(4, 13),
                         new SourceSpan(10, 13))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -597,10 +609,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
-            var expectedRange = new Range { Start = new Position(0, 6), End = new Position(0, 7)};
+            var expectedRange = new Range { Start = new Position(0, 6), End = new Position(0, 7) };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(expectedRange, response.Diagnostics![0].Range);
@@ -613,17 +626,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[] { new VSDiagnostic() { Range = new Range { Start = new Position(0, 16),End =  new Position(0, 20)} } },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(request.Diagnostics[0].Range, response.Diagnostics![0].Range);
@@ -636,17 +650,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Razor,
                 Diagnostics = new[] { new VSDiagnostic() { Range = new Range { Start = new Position(0, 1),End =  new Position(0, 3)} } },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Equal(request.Diagnostics[0].Range, response.Diagnostics![0].Range);
@@ -667,17 +682,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(10, 12))
                 });
             codeDocument.SetUnsupported();
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.CSharp,
                 Diagnostics = new[] { new VSDiagnostic() { Range = new Range { Start = new Position(0, 10), End = new Position(0, 22)} } },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -696,17 +712,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 {
                     GetButtonTagHelperDescriptor().Build()
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[] { new VSDiagnostic() { Range = new Range { Start = new Position(1, 1),End =  new Position(1, 7)} } },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -725,17 +742,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 {
                     GetButtonTagHelperDescriptor().Build()
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[] { new VSDiagnostic() { Range = new Range { Start = new Position(1, 10),End =  new Position(1, 17)} } },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -755,17 +773,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(20, 14),
                         new SourceSpan(10, 14))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
                 Diagnostics = new[] { new VSDiagnostic() { Range = new Range { Start = new Position(0, 18),End =  new Position(0, 19)} } },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -785,8 +804,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                         new SourceSpan(24, 14),
                         new SourceSpan(10, 14))
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -800,9 +819,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Collection(response.Diagnostics,
@@ -835,8 +855,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 new[] {
                     descriptor.Build()
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -847,9 +867,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -881,8 +902,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 new[] {
                     descriptor.Build()
                 });
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -901,9 +922,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             var d = Assert.Single(response.Diagnostics);
@@ -917,8 +939,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now");
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -932,9 +954,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             var returnedDiagnostic = Assert.Single(response.Diagnostics);
@@ -949,8 +972,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Arrange
             var documentPath = new Uri("C:/path/to/document.razor");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now", kind: FileKinds.Component);
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -964,9 +987,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -978,8 +1002,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Arrange
             var documentPath = new Uri("C:/path/to/document.razor");
             var codeDocument = CreateCodeDocument("<!body></body>", kind: FileKinds.Component);
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -993,9 +1017,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             var diagnostic = Assert.Single(response.Diagnostics);
@@ -1010,8 +1035,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Arrange
             var documentPath = new Uri("C:/path/to/document.razor");
             var codeDocument = CreateCodeDocument("<html><!body><div></div></!body></html>", kind: FileKinds.Component);
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -1036,9 +1061,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -1050,8 +1076,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
             // Arrange
             var documentPath = new Uri("C:/path/to/document.razor");
             var codeDocument = CreateCodeDocument("<!body></!body>", kind: FileKinds.Component);
-            var documentContextFactory = CreateDocumentContextFactory(documentPath, codeDocument);
-            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(documentContextFactory, MappingService, LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var diagnosticsEndpoint = new RazorDiagnosticsEndpoint(MappingService, LoggerFactory);
             var request = new RazorDiagnosticsParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -1065,9 +1091,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
                 },
                 RazorDocumentUri = documentPath,
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => diagnosticsEndpoint.Handle(request, default));
+            var response = await Task.Run(() => diagnosticsEndpoint.HandleRequestAsync(request, requestContext, default));
 
             // Assert
             Assert.Empty(response.Diagnostics);
@@ -1115,10 +1142,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         class TestRazorDiagnosticsEndpointWithRazorDiagnostic : RazorDiagnosticsEndpoint
         {
             public TestRazorDiagnosticsEndpointWithRazorDiagnostic(
-                DocumentContextFactory documentContextFactory,
                 RazorDocumentMappingService documentMappingService,
                 ILoggerFactory loggerFactory)
-                : base(documentContextFactory, documentMappingService, loggerFactory)
+                : base(documentMappingService, loggerFactory)
             {
             }
 
@@ -1131,10 +1157,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics
         class TestRazorDiagnosticsEndpointWithoutRazorDiagnostic : RazorDiagnosticsEndpoint
         {
             public TestRazorDiagnosticsEndpointWithoutRazorDiagnostic(
-                DocumentContextFactory documentContextFactory,
                 RazorDocumentMappingService documentMappingService,
                 ILoggerFactory loggerFactory)
-                : base(documentContextFactory, documentMappingService, loggerFactory)
+                : base(documentMappingService, loggerFactory)
             {
             }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.Extensions.Logging;
@@ -47,9 +48,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = "C:/dir/project.csproj",
                 ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.json",
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act & Assert
-            await configurationFileEndpoint.Handle(request, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(request, requestContext, CancellationToken.None);
         }
 
         [Fact]
@@ -71,9 +73,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = "C:/dir/project.csproj",
                 ConfigurationFilePath = null,
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act & Assert
-            await configurationFileEndpoint.Handle(request, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(request, requestContext, CancellationToken.None);
         }
 
         [Fact]
@@ -93,7 +96,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = "C:/dir/project.csproj",
                 ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.json",
             };
-            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
+            var requestContext = CreateRazorRequestContext(documentContext: null);
+            await configurationFileEndpoint.HandleNotificationAsync(startRequest, requestContext, CancellationToken.None);
             var stopRequest = new MonitorProjectConfigurationFilePathParams()
             {
                 ProjectFilePath = "C:/dir/project.csproj",
@@ -101,7 +105,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             };
 
             // Act
-            await configurationFileEndpoint.Handle(stopRequest, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(stopRequest, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(1, detector.StartCount);
@@ -125,9 +129,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = "C:/dir/project.csproj",
                 ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.json",
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
-            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(startRequest, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(0, detector.StartCount);
@@ -150,10 +155,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = "C:/dir/project.csproj",
                 ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.json",
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
-            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
-            await configurationFileEndpoint.Handle(startRequest, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(startRequest, requestContext, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(startRequest, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(1, detector.StartCount);
@@ -182,10 +188,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = debugOutputPath.ProjectFilePath,
                 ConfigurationFilePath = "C:\\externaldir\\obj\\Release\\project.razor.json",
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
-            await configurationFileEndpoint.Handle(debugOutputPath, CancellationToken.None);
-            await configurationFileEndpoint.Handle(releaseOutputPath, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(debugOutputPath, requestContext, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(releaseOutputPath, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(new[] { "C:\\externaldir\\obj\\Debug", "C:\\externaldir\\obj\\Release" }, detector.StartedWithDirectory);
@@ -214,10 +221,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = externalRequest.ProjectFilePath,
                 ConfigurationFilePath = "C:\\dir\\obj\\Release\\project.razor.json",
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
-            await configurationFileEndpoint.Handle(externalRequest, CancellationToken.None);
-            await configurationFileEndpoint.Handle(internalRequest, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(externalRequest, requestContext, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(internalRequest, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(new[] { "C:\\externaldir\\obj\\Debug" }, detector.StartedWithDirectory);
@@ -250,17 +258,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = debugOutputPath.ProjectFilePath,
                 ConfigurationFilePath = "C:\\externaldir1\\obj\\Release\\project.razor.json",
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
 
             // Project opened, defaults to Debug output path
-            await configurationFileEndpoint.Handle(debugOutputPath, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(debugOutputPath, requestContext, CancellationToken.None);
 
             // Project published (temporarily moves to release output path)
-            await configurationFileEndpoint.Handle(releaseOutputPath, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(releaseOutputPath, requestContext, CancellationToken.None);
 
             // Project publish finished (moves back to debug output path)
-            await configurationFileEndpoint.Handle(debugOutputPath, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(debugOutputPath, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(1, projectOpenDebugDetector.StartCount);
@@ -302,11 +311,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectFilePath = "C:\\dir\\project2.csproj",
                 ConfigurationFilePath = "C:\\externaldir2\\obj\\Debug\\project.razor.json",
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
-            await configurationFileEndpoint.Handle(debugOutputPath1, CancellationToken.None);
-            await configurationFileEndpoint.Handle(debugOutputPath2, CancellationToken.None);
-            await configurationFileEndpoint.Handle(releaseOutputPath1, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(debugOutputPath1, requestContext, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(debugOutputPath2, requestContext, CancellationToken.None);
+            await configurationFileEndpoint.HandleNotificationAsync(releaseOutputPath1, requestContext, CancellationToken.None);
 
             // Assert
             Assert.Equal(1, debug1Detector.StartCount);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -8,14 +8,14 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
-using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public RazorLanguageEndpointTest()
         {
             MappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
+
         }
 
         private RazorDocumentMappingService MappingService { get; }
@@ -42,8 +43,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -52,8 +53,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             };
             var expectedRange = new Range { Start = new Position(0, 4), End = new Position(0, 16) };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.NotNull(response);
@@ -74,8 +77,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -83,8 +86,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.NotNull(response);
@@ -105,8 +110,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -114,8 +119,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.NotNull(response);
@@ -136,8 +143,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(4, 12),
                         new SourceSpan(10, 12))
                 });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -145,8 +152,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.NotNull(response);
@@ -160,8 +169,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.Html,
@@ -169,8 +178,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.NotNull(response);
@@ -184,8 +195,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.Razor,
@@ -193,8 +204,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.NotNull(response);
@@ -216,8 +229,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         new SourceSpan(10, 12))
                 });
             codeDocument.SetUnsupported();
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorMapToDocumentRangesEndpoint(MappingService);
             var request = new RazorMapToDocumentRangesParams()
             {
                 Kind = RazorLanguageKind.CSharp,
@@ -225,8 +238,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 RazorDocumentUri = documentPath,
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.NotNull(response);
@@ -240,16 +255,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("@{}");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 1),
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Razor, response.Kind);
@@ -264,16 +281,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentPath = new Uri("C:/path/to/document.cshtml");
             var codeDocument = CreateCodeDocument("<s");
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 2),
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, response.Kind);
@@ -291,16 +310,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 "@",
                 "/* CSharp */",
                 new[] { new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12)) });
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 1),
             };
+            var requestContext = CreateRazorRequestContext(documentContext);
 
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.Equal(RazorLanguageKind.CSharp, response.Kind);
@@ -320,16 +340,18 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 "/* CSharp */",
                 new[] { new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12)) });
             codeDocument.SetUnsupported();
-            var documentResolver = CreateDocumentContextFactory(documentPath, codeDocument);
-            var languageEndpoint = new RazorLanguageEndpoint(documentResolver, MappingService, Mock.Of<RazorFormattingService>(MockBehavior.Strict), LoggerFactory);
+            var documentContext = CreateDocumentContext(documentPath, codeDocument);
+            var languageEndpoint = new RazorLanguageQueryEndpoint(MappingService);
             var request = new RazorLanguageQueryParams()
             {
                 Uri = documentPath,
                 Position = new Position(0, 1),
             };
 
+            var requestContext = CreateRazorRequestContext(documentContext);
+
             // Act
-            var response = await Task.Run(() => languageEndpoint.Handle(request, default));
+            var response = await languageEndpoint.HandleRequestAsync(request, requestContext, default);
 
             // Assert
             Assert.Equal(RazorLanguageKind.Html, response.Kind);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageEndpointTest.cs
@@ -24,7 +24,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public RazorLanguageEndpointTest()
         {
             MappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
-
         }
 
         private RazorDocumentMappingService MappingService { get; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -72,9 +72,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
                 Position = new Position(line, offset),
                 NewName = newName
             };
+            var requestContext = CreateRazorRequestContext(documentContext: null);
 
             // Act
-            var result = await endpoint.Handle(request, CancellationToken.None);
+            var result = await endpoint.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
             // Assert
             var edits = result.DocumentChanges.Value.First.FirstOrDefault().Edits.Select(e => e.AsTextChange(codeDocument.GetSourceText()));


### PR DESCRIPTION
…igurationFilePath, RazorFileChangeDetectorManager, RazorLanguage, and Rename tests

### Summary of the changes

- Move AutoInsert, WorkspaceDirectoryPathResolver, MonitorProjectConfigurationFilePath, RazorFileChangeDetectorManager, RazorLanguage, and Rename tests to CLaSP.
