### PR TITLE
Add endpoint to handle breakpoint validation requests, and forward them to Roslyn

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/RazorLanguageServerCustomMessageTargets.cs
@@ -42,5 +42,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public const string RazorImplementationEndpointName = "razor/implementation";
 
         public const string RazorOnAutoInsertEndpointName = "razor/onAutoInsert";
+
+        public const string RazorValidateBreakpointRangeName = "razor/validateBreakpointRange";
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -14,6 +14,11 @@ internal record DelegatedPositionParams(
     Position ProjectedPosition,
     RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
+internal record DelegatedValidateBreakpointRangeParams(
+    VersionedTextDocumentIdentifier HostDocument,
+    Range ProjectedRange,
+    RazorLanguageKind ProjectedKind) : IDelegatedParams;
+
 internal record DelegatedOnAutoInsertParams(
     VersionedTextDocumentIdentifier HostDocument,
     Position ProjectedPosition,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 return default;
             }
 
-            var delegatedParams = await CreateDelegatedParams(request, context, projection, cancellationToken);
+            var delegatedParams = await CreateDelegatedParamsAsync(request, context, projection, cancellationToken);
 
             if (delegatedParams is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -112,28 +112,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert
             return null;
         }
 
-        protected override IDelegatedParams? CreateDelegatedParams(OnAutoInsertParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
+        protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(OnAutoInsertParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
         {
             var documentContext = requestContext.GetRequiredDocumentContext();
             if (projection.LanguageKind == RazorLanguageKind.Html &&
                !s_htmlAllowedTriggerCharacters.Contains(request.Character))
             {
                 Logger.LogInformation("Inapplicable HTML trigger char {request.Character}.", request.Character);
-                return null;
+                return Task.FromResult<IDelegatedParams?>(null);
             }
             else if (projection.LanguageKind == RazorLanguageKind.CSharp &&
                 !s_cSharpAllowedTriggerCharacters.Contains(request.Character))
             {
                 Logger.LogInformation("Inapplicable C# trigger char {request.Character}.", request.Character);
-                return null;
+                return Task.FromResult<IDelegatedParams?>(null);
             }
 
-            return new DelegatedOnAutoInsertParams(
+            return Task.FromResult<IDelegatedParams?>(new DelegatedOnAutoInsertParams(
                 documentContext.Identifier,
                 projection.Position,
                 projection.LanguageKind,
                 request.Character,
-                request.Options);
+                request.Options));
         }
 
         protected override async Task<VSInternalDocumentOnAutoInsertResponseItem?> HandleDelegatedResponseAsync(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging
+{
+    internal class ValidateBreakpointRangeEndpoint : AbstractRazorDelegatingEndpoint<ValidateBreakpointRangeParamsBridge, Range?>, IValidateBreakpointRangeEndpoint
+    {
+        private readonly RazorDocumentMappingService _documentMappingService;
+
+        public ValidateBreakpointRangeEndpoint(
+            DocumentContextFactory documentContextFactory,
+            RazorDocumentMappingService documentMappingService,
+            LanguageServerFeatureOptions languageServerFeatureOptions,
+            ClientNotifierServiceBase languageServer,
+            ILoggerFactory loggerFactory)
+            : base(documentContextFactory, languageServerFeatureOptions, documentMappingService, languageServer, loggerFactory.CreateLogger<ValidateBreakpointRangeEndpoint>())
+        {
+            _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
+        }
+
+        protected override bool OnlySingleServer => false;
+
+        protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorValidateBreakpointRangeName;
+
+        public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
+        {
+            const string ServerCapability = "_vs_breakableRangeProvider";
+
+            return new RegistrationExtensionResult(ServerCapability, true);
+        }
+
+        protected override Task<Range?> TryHandleAsync(ValidateBreakpointRangeParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        {
+            // no such thing as Razor breakpoints (yet?!)
+            return Task.FromResult<Range?>(null);
+        }
+
+        protected async override Task<IDelegatedParams?> CreateDelegatedParamsAsync(ValidateBreakpointRangeParamsBridge request, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        {
+            // only C# supports breakpoints
+            if (projection.LanguageKind != RazorLanguageKind.CSharp)
+            {
+                return null;
+            }
+
+            var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
+            if (!_documentMappingService.TryMapToProjectedDocumentRange(codeDocument, request.Range, out var projectedRange))
+            {
+                return null;
+            }
+
+            return new DelegatedValidateBreakpointRangeParams(
+                documentContext.Identifier,
+                projectedRange,
+                projection.LanguageKind);
+        }
+
+        protected async override Task<Range?> HandleDelegatedResponseAsync(Range? response, ValidateBreakpointRangeParamsBridge originalRequest, DocumentContext documentContext, Projection projection, CancellationToken cancellationToken)
+        {
+            if (response is null)
+            {
+                return null;
+            }
+
+            var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
+            if (_documentMappingService.TryMapFromProjectedDocumentRange(codeDocument, response, out var projectedRange))
+            {
+                return projectedRange;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/RazorDefinitionEndpoint.cs
@@ -99,13 +99,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             };
         }
 
-        protected override IDelegatedParams CreateDelegatedParams(TextDocumentPositionParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
+        protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(TextDocumentPositionParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
         {
             var documentContext = requestContext.GetRequiredDocumentContext();
-            return new DelegatedPositionParams(
+            return Task.FromResult<IDelegatedParams?>(new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
-                    projection.LanguageKind);
+                    projection.LanguageKind));
         }
 
         protected async override Task<DefinitionResult?> HandleDelegatedResponseAsync(DefinitionResult? response, TextDocumentPositionParamsBridge originalRequest, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentHighlighting/DocumentHighlightEndpoint.cs
@@ -49,14 +49,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentHighlighting
         }
 
         /// <inheritdoc/>
-        protected override IDelegatedParams CreateDelegatedParams(DocumentHighlightParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
+        protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(DocumentHighlightParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
         {
             var documentContext = requestContext.GetRequiredDocumentContext();
-            return new DelegatedPositionParams(
+            return Task.FromResult<IDelegatedParams?>(new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
-                    projection.LanguageKind);
+                    projection.LanguageKind));
         }
+
         /// <inheritdoc/>
         protected override async Task<DocumentHighlight[]?> HandleDelegatedResponseAsync(DocumentHighlight[]? response, DocumentHighlightParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IValidateBreakpointRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IValidateBreakpointRangeEndpoint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    [Parallel, Method(VSInternalMethods.TextDocumentValidateBreakableRangeName)]
+    internal interface IValidateBreakpointRangeEndpoint : IJsonRpcRequestHandler<ValidateBreakpointRangeParamsBridge, Range?>,
+        IRegistrationExtension
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IValidateBreakpointRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IValidateBreakpointRangeEndpoint.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
-    [Parallel, Method(VSInternalMethods.TextDocumentValidateBreakableRangeName)]
-    internal interface IValidateBreakpointRangeEndpoint : IJsonRpcRequestHandler<ValidateBreakpointRangeParamsBridge, Range?>,
+    [LanguageServerEndpoint(VSInternalMethods.TextDocumentValidateBreakableRangeName)]
+    internal interface IValidateBreakpointRangeEndpoint : IRazorRequestHandler<ValidateBreakpointRangeParamsBridge, Range?>,
         IRegistrationExtension
     {
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ValidateBreakpointRangeParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ValidateBreakpointRangeParamsBridge.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using MediatR;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
+{
+    internal class ValidateBreakpointRangeParamsBridge : VSInternalValidateBreakableRangeParams, IRequest<Range?>, ITextDocumentPositionParams
+    {
+        public Position Position
+        {
+            get { return Range.Start; }
+            set { throw new NotImplementedException(); }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ValidateBreakpointRangeParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/ValidateBreakpointRangeParamsBridge.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using MediatR;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
-    internal class ValidateBreakpointRangeParamsBridge : VSInternalValidateBreakableRangeParams, IRequest<Range?>, ITextDocumentPositionParams
+    internal class ValidateBreakpointRangeParamsBridge : VSInternalValidateBreakableRangeParams, ITextDocumentPositionParams
     {
         public Position Position
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/RazorHoverEndpoint.cs
@@ -49,13 +49,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover
         protected override string CustomMessageTarget => RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName;
 
         /// <inheritdoc/>
-        protected override IDelegatedParams CreateDelegatedParams(TextDocumentPositionParamsBridge request, RazorRequestContext razorRequestContext, Projection projection, CancellationToken cancellationToken)
+        protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(TextDocumentPositionParamsBridge request, RazorRequestContext razorRequestContext, Projection projection, CancellationToken cancellationToken)
         {
             var documentContext = razorRequestContext.GetRequiredDocumentContext();
-            return new DelegatedPositionParams(
+            return Task.FromResult<IDelegatedParams?>(new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
-                    projection.LanguageKind);
+                    projection.LanguageKind));
         }
 
         /// <inheritdoc/>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
@@ -40,13 +40,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Implementation
             return new RegistrationExtensionResult(ServerCapability, option);
         }
 
-        protected override IDelegatedParams CreateDelegatedParams(TextDocumentPositionParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
+        protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(TextDocumentPositionParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
         {
             var documentContext = requestContext.GetRequiredDocumentContext();
-            return new DelegatedPositionParams(
+            return Task.FromResult<IDelegatedParams?>(new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
-                    projection.LanguageKind);
+                    projection.LanguageKind));
         }
 
         protected async override Task<ImplementationResult> HandleDelegatedResponseAsync(ImplementationResult delegatedResponse, TextDocumentPositionParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -142,7 +142,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
             services.AddHandler<RazorProximityExpressionsEndpoint>();
             services.AddRegisteringHandler<DocumentColorEndpoint>();
             services.AddRegisteringHandler<FoldingRangeEndpoint>();
-            services.AddRegisteringHandler<ValidateBreakpointRangeEndpoint>()
+            services.AddRegisteringHandler<ValidateBreakpointRangeEndpoint>();
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -142,6 +142,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
             services.AddHandler<RazorProximityExpressionsEndpoint>();
             services.AddRegisteringHandler<DocumentColorEndpoint>();
             services.AddRegisteringHandler<FoldingRangeEndpoint>();
+            services.AddRegisteringHandler<ValidateBreakpointRangeEndpoint>()
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -89,14 +89,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring
             => _languageServerFeatureOptions.SupportsFileManipulation;
 
         /// <inheritdoc/>
-        protected override IDelegatedParams CreateDelegatedParams(RenameParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
+        protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(RenameParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
         {
             var documentContext = requestContext.GetRequiredDocumentContext();
-            return new DelegatedRenameParams(
+            return Task.FromResult<IDelegatedParams?>(new DelegatedRenameParams(
                     documentContext.Identifier,
                     projection.Position,
                     projection.LanguageKind,
-                    request.NewName);
+                    request.NewName));
         }
 
         /// <inheritdoc/>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
@@ -39,13 +40,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp
         }
 
         /// <inheritdoc />
-        protected override IDelegatedParams CreateDelegatedParams(SignatureHelpParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
+        protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(SignatureHelpParamsBridge request, RazorRequestContext requestContext, Projection projection, CancellationToken cancellationToken)
         {
             var documentContext = requestContext.GetRequiredDocumentContext();
-            return new DelegatedPositionParams(
+            return Task.FromResult<IDelegatedParams?>(new DelegatedPositionParams(
                     documentContext.Identifier,
                     projection.Position,
-                    projection.LanguageKind);
+                    projection.LanguageKind));
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1083,11 +1083,11 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             };
 
             var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalValidateBreakableRangeParams, Range?>(
-               delegationDetails.Value.TextBuffer,
-               VSInternalMethods.TextDocumentValidateBreakableRangeName,
-               delegationDetails.Value.LanguageServerName,
-               validateBreakpointRangeParams,
-               cancellationToken).ConfigureAwait(false);
+                delegationDetails.Value.TextBuffer,
+                VSInternalMethods.TextDocumentValidateBreakableRangeName,
+                delegationDetails.Value.LanguageServerName,
+                validateBreakpointRangeParams,
+                cancellationToken).ConfigureAwait(false);
             return response?.Response;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1065,6 +1065,32 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             return response?.Response;
         }
 
+        public override async Task<Range?> ValidateBreakpointRangeAsync(DelegatedValidateBreakpointRangeParams request, CancellationToken cancellationToken)
+        {
+            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+            if (delegationDetails is null)
+            {
+                return default;
+            }
+
+            var validateBreakpointRangeParams = new VSInternalValidateBreakableRangeParams
+            {
+                TextDocument = new TextDocumentIdentifier()
+                {
+                    Uri = delegationDetails.Value.ProjectedUri,
+                },
+                Range = request.ProjectedRange
+            };
+
+            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalValidateBreakableRangeParams, Range?>(
+               delegationDetails.Value.TextBuffer,
+               VSInternalMethods.TextDocumentValidateBreakableRangeName,
+               delegationDetails.Value.LanguageServerName,
+               validateBreakpointRangeParams,
+               cancellationToken).ConfigureAwait(false);
+            return response?.Response;
+        }
+
         public override Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
             => DelegateTextDocumentPositionRequestAsync<VSInternalHover>(request, Methods.TextDocumentHoverName, cancellationToken);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -114,5 +114,8 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
         [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName, UseSingleObjectParameterDeserialization = true)]
         public abstract Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken);
+
+        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorValidateBreakpointRangeName, UseSingleObjectParameterDeserialization = true)]
+        public abstract Task<Range?> ValidateBreakpointRangeAsync(DelegatedValidateBreakpointRangeParams request, CancellationToken cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging
+{
+    public class ValidateBreakpointRangeEndpointTest : SingleServerDelegatingEndpointTestBase
+    {
+        [Fact]
+        public async Task Handle_CSharp_ValidBreakpoint()
+        {
+            var input = """
+                <div></div>
+
+                @{
+                    {|breakpoint:{|expected:var x = GetX();|}|}
+                }
+                """;
+
+            await VerifyBreakpointRangeAsync(input);
+        }
+
+        [Fact]
+        public async Task Handle_CSharp_InvalidBreakpointRemoved()
+        {
+            var input = """
+                <div></div>
+
+                @{
+                    //{|breakpoint:var x = GetX();|}
+                }
+                """;
+
+            await VerifyBreakpointRangeAsync(input);
+        }
+
+        [Fact]
+        public async Task Handle_CSharp_ValidBreakpointMoved()
+        {
+            var input = """
+                <div></div>
+
+                @{
+                    {|breakpoint:{|expected:var x = Goo;|}
+                    Goo;|}
+                }
+                """;
+
+            await VerifyBreakpointRangeAsync(input);
+        }
+
+        [Fact]
+        public async Task Handle_Html_BreakpointRemoved()
+        {
+            var input = """
+                {|breakpoint:<div></div>|}
+
+                @{
+                    var x = GetX();
+                }
+                """;
+
+            await VerifyBreakpointRangeAsync(input);
+        }
+
+        private async Task VerifyBreakpointRangeAsync(string input)
+        {
+            // Arrange
+            TestFileMarkupParser.GetSpans(input, out var output, out ImmutableDictionary<string, ImmutableArray<TextSpan>> spans);
+
+            Assert.True(spans.TryGetValue("breakpoint", out var breakpointSpans), "Test authoring failure: Expected at least one span named 'breakpoint'.");
+            Assert.True(breakpointSpans.Length == 1, "Test authoring failure: Expected only one 'breakpoint' span.");
+
+            var codeDocument = CreateCodeDocument(output);
+            var razorFilePath = "C:/path/to/file.razor";
+
+            // Act
+            var result = await GetBreakpointRangeAsync(codeDocument, razorFilePath, breakpointSpans[0]);
+
+            // Assert
+            if (result is null)
+            {
+                Assert.False(spans.ContainsKey("expected"), "No breakpoint was returned from LSP, but there is a span named 'expected'.");
+                return;
+            }
+
+            Assert.True(spans.TryGetValue("expected", out var expectedSpans), "Expected at least one span named 'expected'.");
+            Assert.True(expectedSpans.Length == 1, "Expected only one 'expected' span.");
+
+            var expectedRange = expectedSpans[0].AsRange(codeDocument.GetSourceText());
+            Assert.Equal(expectedRange, result);
+        }
+
+        private async Task<Range> GetBreakpointRangeAsync(RazorCodeDocument codeDocument, string razorFilePath, TextSpan breakpointSpan)
+        {
+            await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
+            var endpoint = new ValidateBreakpointRangeEndpoint(DocumentContextFactory, DocumentMappingService, LanguageServerFeatureOptions, LanguageServer, TestLoggerFactory.Instance);
+
+            var request = new ValidateBreakpointRangeParamsBridge
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = new Uri(razorFilePath)
+                },
+                Range = breakpointSpan.AsRange(codeDocument.GetSourceText())
+            };
+
+            return await endpoint.Handle(request, CancellationToken.None);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
@@ -82,6 +82,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     RazorLanguageServerCustomMessageTargets.RazorSignatureHelpEndpointName => await HandleSignatureHelpAsync(@params),
                     RazorLanguageServerCustomMessageTargets.RazorRenameEndpointName => await HandleRenameAsync(@params),
                     RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName => await HandleOnAutoInsertAsync(@params),
+                    RazorLanguageServerCustomMessageTargets.RazorValidateBreakpointRangeName => await HandleValidateBreakpointRangeAsync(@params),
                     _ => throw new NotImplementedException($"I don't know how to handle the '{method}' method.")
                 };
 
@@ -184,6 +185,23 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             public override Task SendNotificationAsync(string method, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
+            }
+
+            private async Task<IResponseRouterReturns> HandleValidateBreakpointRangeAsync<T>(T @params)
+            {
+                var delegatedParams = Assert.IsType<DelegatedValidateBreakpointRangeParams>(@params);
+                var delegatedRequest = new VSInternalValidateBreakableRangeParams()
+                {
+                    TextDocument = new TextDocumentIdentifier()
+                    {
+                        Uri = _csharpDocumentUri
+                    },
+                    Range = delegatedParams.ProjectedRange,
+                };
+
+                var result = await _csharpServer.ExecuteRequestAsync<VSInternalValidateBreakableRangeParams, Range>(VSInternalMethods.TextDocumentValidateBreakableRangeName, delegatedRequest, CancellationToken.None);
+
+                return new TestResponseRouterReturn(result);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 throw new NotImplementedException();
             }
 
-            private async Task<IResponseRouterReturns> HandleValidateBreakpointRangeAsync<T>(T @params)
+            private async Task<Range> HandleValidateBreakpointRangeAsync<T>(T @params)
             {
                 var delegatedParams = Assert.IsType<DelegatedValidateBreakpointRangeParams>(@params);
                 var delegatedRequest = new VSInternalValidateBreakableRangeParams()
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
                 var result = await _csharpServer.ExecuteRequestAsync<VSInternalValidateBreakableRangeParams, Range>(VSInternalMethods.TextDocumentValidateBreakableRangeName, delegatedRequest, CancellationToken.None);
 
-                return new TestResponseRouterReturn(result);
+                return result;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6825

Fairly boring really... though it turns out that the initial breakpoint placement still uses the old COM stuff, so I can't delete any code like I was hoping to :(

We could make that COM stuff call through to LSP, but eventually the debugger will do that for us, so unless there are known issues with it, I don't think we gain anything (and we potentially introduce perf issues as the LSP call to Roslyn would have to block the UI thread)