### PR TITLE
Register our experimental language server capabilities

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -42,6 +42,8 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<IInitializeManager<InitializeParams, InitializeResult>, CapabilitiesManager>();
         services.AddSingleton<IRequestContextFactory<RazorRequestContext>, RazorRequestContextFactory>();
 
+        services.AddSingleton<IRegistrationExtension, RazorLanguageServerCapability>();
+
         services.AddSingleton<IOnInitialized>(serverManager);
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerCapability.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerCapability.cs
@@ -1,39 +1,35 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
-    internal record RazorLanguageServerCapability(
-        bool LanguageQuery,
-        bool RangeMapping,
-        bool EditMapping,
-        bool MonitorProjectConfigurationFilePath,
-        bool BreakpointSpan,
-        bool ProximityExpressions)
+    internal class RazorLanguageServerCapability : IRegistrationExtension
     {
         private const string RazorCapabilityKey = "razor";
-        private static readonly RazorLanguageServerCapability s_default = new RazorLanguageServerCapability(
-            LanguageQuery: true,
-            RangeMapping: true,
-            EditMapping: true,
-            MonitorProjectConfigurationFilePath: true,
-            BreakpointSpan: true,
-            ProximityExpressions: true);
-
-        public static void AddTo(ServerCapabilities capabilities)
+        private static readonly RazorLanguageServerCapability s_default = new RazorLanguageServerCapability
         {
-            // We have to use the experimental capabilities bucket here because not all platforms maintain custom capabilities. For instance
-            // in Visual Studio scenarios it will deserialize server capabilties into what it believes is "valid" and then will re-pass said
-            // server capabilities to our client side code having lost the information of the custom capabilities. To avoid this we use the
-            // experimental bag since it's part of the official LSP spec. This approach enables us to work with any client.
-            capabilities.Experimental ??= new Dictionary<string, JToken> {
-                { RazorCapabilityKey, JToken.FromObject(s_default) }
-            };
+            LanguageQuery = true,
+            RangeMapping = true,
+            EditMapping = true,
+            MonitorProjectConfigurationFilePath = true,
+            BreakpointSpan = true,
+            ProximityExpressions = true
+        };
+
+        public bool LanguageQuery { get; set; }
+        public bool RangeMapping { get; set; }
+        public bool EditMapping { get; set; }
+        public bool MonitorProjectConfigurationFilePath { get; set; }
+        public bool BreakpointSpan { get; set; }
+        public bool ProximityExpressions { get; set; }
+
+        public RegistrationExtensionResult GetRegistration(VSInternalClientCapabilities clientCapabilities)
+        {
+            return new RegistrationExtensionResult(RazorCapabilityKey, JToken.FromObject(s_default));
         }
 
         public static bool TryGet(JToken token, [NotNullWhen(true)] out RazorLanguageServerCapability? razorCapability)


### PR DESCRIPTION
Fixes breakpoint placement, plus presumably lots of other things, after the CLaSP merge.

Seems like when changing the `RazorLanguageServer` we lost the registration of our experimental capabilities.
https://github.com/dotnet/razor-tooling/commit/3cbeebf4b8e31c1f3a0d6de932bcc4a3f94ad111#diff-71cce0492ca142b27d35547a8056029bdfd5bd92720d32d9265193dbaefb98e0L116

Decided to also change it to be a bit more "standard" and DI (though I would have _loved_ if I could have just put `[Export(typeof(IRegistrationExtension))]` on it 😛) since previously it was a record that was only accessed statically, which just seemed odd.