### PR TITLE
Fix serialization naming

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorLanguageQueryParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorLanguageQueryParams.cs
@@ -2,14 +2,18 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.Serialization;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
+    [DataContract]
     internal class RazorLanguageQueryParams
     {
+        [DataMember(Name = "uri")]
         public required Uri Uri { get; set; }
 
+        [DataMember(Name ="position")]
         public required Position Position { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentEditsParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentEditsParams.cs
@@ -2,21 +2,28 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
+    // Note: This type should be kept in sync with the one in Razor.HtmlCSharp assembly.
     internal class RazorMapToDocumentEditsParams
     {
+        [DataMember(Name = "kind")]
         public RazorLanguageKind Kind { get; init; }
 
+        [DataMember(Name = "razorDocumentUri")]
         public required Uri RazorDocumentUri { get; init; }
 
+        [DataMember(Name = "projectedTextEdits")]
         public required TextEdit[] ProjectedTextEdits { get; init; }
 
+        [DataMember(Name = "textEditKind")]
         public TextEditKind TextEditKind { get; init; }
 
+        [DataMember(Name = "formattingOptions")]
         public required FormattingOptions FormattingOptions { get; init; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentEditsParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentEditsParams.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
     // Note: This type should be kept in sync with the one in Razor.HtmlCSharp assembly.
+    [DataContract]
     internal class RazorMapToDocumentEditsParams
     {
         [DataMember(Name = "kind")]

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentEditsResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentEditsResponse.cs
@@ -1,14 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Runtime.Serialization;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
+    [DataContract]
     internal class RazorMapToDocumentEditsResponse
     {
+        [DataMember(Name = "textEdits")]
         public required TextEdit[] TextEdits { get; init; }
 
+        [DataMember(Name = "hostDocumentVersion")]
         public int? HostDocumentVersion { get; init; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentRangesParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentRangesParams.cs
@@ -2,19 +2,25 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
     // Note: This type should be kept in sync with the one in VisualStudio.LanguageServerClient assembly.
+    [DataContract]
     internal class RazorMapToDocumentRangesParams
     {
+        [DataMember(Name = "kind")]
         public RazorLanguageKind Kind { get; init; }
 
+        [DataMember(Name = "razorDocumentUri")]
         public required Uri RazorDocumentUri { get; init; }
 
+        [DataMember(Name = "projectedRanges")]
         public required Range[] ProjectedRanges { get; init; }
 
+        [DataMember(Name = "mappingBehavior")]
         public MappingBehavior MappingBehavior { get; init; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentRangesResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorMapToDocumentRangesResponse.cs
@@ -1,14 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Runtime.Serialization;
+
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts
 {
     // NOTE: Changes here MUST be copied over to
     // Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp.RazorMapToDocumentRangesResponse
+    [DataContract]
     internal class RazorMapToDocumentRangesResponse
     {
+        [DataMember(Name = "ranges")]
         public required Range[] Ranges { get; init; }
 
+        [DataMember(Name = "hostDocumentVersion")]
         public int? HostDocumentVersion { get; init; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -146,7 +146,9 @@ internal static class IServiceCollectionExtensions
         services.AddHandler<RazorDidOpenTextDocumentEndpoint>();
         services.AddHandler<RazorDidSaveTextDocumentEndpoint>();
 
+        services.AddHandler<RazorMapToDocumentEditsEndpoint>();
         services.AddHandler<RazorMapToDocumentRangesEndpoint>();
+        services.AddHandler<RazorLanguageQueryEndpoint>();
     }
 
     public static void AddOptionsServices(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageQueryResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageQueryResponse.cs
@@ -1,19 +1,25 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
+    [DataContract]
     internal class RazorLanguageQueryResponse
     {
+        [DataMember(Name = "kind")]
         public RazorLanguageKind Kind { get; set; }
 
+        [DataMember(Name = "positionIndex")]
         public int PositionIndex { get; set; }
 
+        [DataMember(Name = "position")]
         public required Position Position { get; set; }
 
+        [DataMember(Name = "hostDocumentVersion")]
         public int? HostDocumentVersion { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json.Serialization;
 using StreamJsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -72,6 +73,7 @@ internal sealed class RazorLanguageServerWrapper : IAsyncDisposable
         var messageFormatter = new JsonMessageFormatter();
         messageFormatter.JsonSerializer.AddVSInternalExtensionConverters();
         messageFormatter.JsonSerializer.Converters.RegisterRazorConverters();
+        messageFormatter.JsonSerializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
 
         var jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(output, input, messageFormatter));
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentEditsParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentEditsParams.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
+    [DataContract]
     internal class RazorMapToDocumentEditsParams : IEquatable<RazorMapToDocumentEditsParams>
     {
         [DataMember(Name = "kind")]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentEditsParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentEditsParams.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.Extensions.Internal;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -12,14 +13,19 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
     internal class RazorMapToDocumentEditsParams : IEquatable<RazorMapToDocumentEditsParams>
     {
+        [DataMember(Name = "kind")]
         public RazorLanguageKind Kind { get; init; }
 
+        [DataMember(Name = "razorDocumentUri")]
         public required Uri RazorDocumentUri { get; init; }
 
+        [DataMember(Name = "projectedTextEdits")]
         public required TextEdit[] ProjectedTextEdits { get; init; }
 
+        [DataMember(Name = "textEditKind")]
         public TextEditKind TextEditKind { get; init; }
 
+        [DataMember(Name = "formattingOptions")]
         public required FormattingOptions? FormattingOptions { get; init; }
 
         // Everything below this is for testing purposes only.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         [DataMember(Name = "razorDocumentUri")]
         public required Uri RazorDocumentUri { get; init; }
 
-        [DataMember(Name = "projectedRanges")]]
+        [DataMember(Name = "projectedRanges")]
         public required Range[] ProjectedRanges { get; init; }
 
         [DataMember(Name = "mappingBehavior")]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
@@ -3,22 +3,28 @@
 
 using System;
 using System.Linq;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
+    [DataContract]
     internal class RazorMapToDocumentRangesParams : IEquatable<RazorMapToDocumentRangesParams>
     {
+        [DataMember(Name = "kind")]
         public RazorLanguageKind Kind { get; init; }
 
+        [DataMember(Name = "razorDocumentUri")]
         public required Uri RazorDocumentUri { get; init; }
 
+        [DataMember(Name = "projectedRanges")]]
         public required Range[] ProjectedRanges { get; init; }
 
+        [DataMember(Name = "mappingBehavior")]
         public LanguageServerMappingBehavior MappingBehavior { get; init; }
-
+=
         public bool Equals(RazorMapToDocumentRangesParams? other)
         {
             return

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesParams.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
         [DataMember(Name = "mappingBehavior")]
         public LanguageServerMappingBehavior MappingBehavior { get; init; }
-=
+
         public bool Equals(RazorMapToDocumentRangesParams? other)
         {
             return

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
     [DataContract]
     internal class RazorMapToDocumentRangesResponse
     {
-        [DataMember(Name = "Ranges")]
+        [DataMember(Name = "ranges")]
         public required Range[] Ranges { get; init; }
 
         [DataMember(Name = "hostDocumentVersion")]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/RazorMapToDocumentRangesResponse.cs
@@ -1,13 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Runtime.Serialization;
+
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 {
     // Note: This type should be kept in sync with the one in Razor.LanguageServer assembly.
+    [DataContract]
     internal class RazorMapToDocumentRangesResponse
     {
+        [DataMember(Name = "Ranges")]
         public required Range[] Ranges { get; init; }
 
+        [DataMember(Name = "hostDocumentVersion")]
         public int? HostDocumentVersion { get; init; }
     }
 }


### PR DESCRIPTION
### Summary of the changes

- @ryanbrandenburg and I were pair debugging through some serialization issues in VSCode and noticed a few issues:
- (1) Some endpoints were not being registered to the language server.
- (2) The naming of some properties sent over the wire to the VSCode side had incorrect naming (e.g. `Position` instead of `position`).
- (1) is a pretty simple fix. To address (2), we added a `CamelCasePropertyNamesContractResolver` to our JSON serializer. As a secondary measure, we thought it would also be good to label our custom requests and responses with the `DataContract` attribute (which is how the VS LSP client does things today).
