### PR TITLE
Baseline editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,9 @@ insert_final_newline = true
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
+# IDE0005 - Remove unnecessary imports
+dotnet_diagnostic.IDE0005.severity = suggestion
+
 # IDE0046: If expression can be simplified
 dotnet_style_prefer_conditional_expression_over_return = false:silent
 
@@ -88,7 +91,7 @@ dotnet_style_allow_statement_immediately_after_block_experimental = false:warnin
 csharp_style_unused_value_expression_statement_preference = discard_variable:none
 
 # IDE0065
-csharp_using_directive_placement = outside_namespace
+csharp_using_directive_placement = outside_namespace:suggestion
 
 # xUnit1004: Test methods should not be skipped
 dotnet_diagnostic.xUnit1004.severity = refactoring
@@ -176,3 +179,33 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 # VSTHRD100: Avoid async void methods
 dotnet_diagnostic.VSTHRD100.severity = warning
 dotnet_diagnostic.VSTHRD101.severity = warning
+
+# Various settings that may not indicate desired style, but codify existing style
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:suggestion
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_indent_labels = one_less_than_current
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = false:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_compound_assignment = true:suggestion

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             return codeActions.Where(codeAction =>
             {
                 // Note: we may see a perf benefit from using a JsonConverter
-                var tags = ((JToken?)codeAction.Data)?["CustomTags"]?.ToObject<string[]>(); ;
+                var tags = ((JToken?)codeAction.Data)?["CustomTags"]?.ToObject<string[]>();
                 if (tags is null || tags.Length == 0)
                 {
                     return false;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactory.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             _joinableTaskContext.AssertUIThread();
 
-            var braceSmartIndenter = new BraceSmartIndenter(_joinableTaskContext, documentTracker, _codeDocumentProvider, _editorOperationsFactory); ;
+            var braceSmartIndenter = new BraceSmartIndenter(_joinableTaskContext, documentTracker, _codeDocumentProvider, _editorOperationsFactory);
             return braceSmartIndenter;
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
         private static void InitializeRazorTextViewOptions(IVsTextManager4 textManager, RazorEditorOptionsTracker optionsTracker)
         {
-            var langPrefs3 = new LANGPREFERENCES3[] { new LANGPREFERENCES3() { guidLang = RazorVisualStudioWindowsConstants.RazorLanguageServiceGuid } }; ;
+            var langPrefs3 = new LANGPREFERENCES3[] { new LANGPREFERENCES3() { guidLang = RazorVisualStudioWindowsConstants.RazorLanguageServiceGuid } };
             if (VSConstants.S_OK != textManager.GetUserPreferences4(null, langPrefs3, null))
             {
                 return;
@@ -270,7 +270,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             var insertSpaces = true;
             var tabSize = 4;
 
-            var langPrefs3 = new LANGPREFERENCES3[] { new LANGPREFERENCES3() { guidLang = RazorVisualStudioWindowsConstants.RazorLanguageServiceGuid } }; ;
+            var langPrefs3 = new LANGPREFERENCES3[] { new LANGPREFERENCES3() { guidLang = RazorVisualStudioWindowsConstants.RazorLanguageServiceGuid } };
             if (VSConstants.S_OK != textManager.GetUserPreferences4(null, langPrefs3, null))
             {
                 return new EditorSettings(indentWithTabs: !insertSpaces, tabSize);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -961,7 +961,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             documentManager.AddDocument(documentUri, documentSnapshot);
             var projectionProvider = new TestLSPProjectionProvider(LoggerFactory);
             var completionHandler = new CompletionHandler(
-                JoinableTaskContext, requestInvoker, documentManager, projectionProvider, _textStructureNavigatorSelectorService, _completionRequestContextCache, _formattingOptionsProvider, LoggerProvider); ;
+                JoinableTaskContext, requestInvoker, documentManager, projectionProvider, _textStructureNavigatorSelectorService, _completionRequestContextCache, _formattingOptionsProvider, LoggerProvider);
 
             var projectionResult = new ProjectionResult()
             {


### PR DESCRIPTION
Noticed the other day, when I tweaked my VS code style settings to investigate a bug, there were lots of errors in razor. This change adds a few things to our editorconfig file so that we're not at the mercy of different people's different VS settings. It also gives us a base to start changing as we make decisions.

This is presumably not exhaustive, it's just the changes the editorconfig editor wanted to make, but cleaned up.

Oh and I removed some double semi-colons because I'm sneaky :)