### PR TITLE
[VSCode] Remove O# double registration workaround

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -19,7 +19,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public override bool SingleServerCompletionSupport => false;
 
         public override bool SingleServerSupport => false;
-
-        public override bool RegisterBuiltInFeatures => false;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -19,13 +19,6 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
 
         public abstract bool SingleServerSupport { get; }
 
-        /// <summary>
-        /// This is a temporary workaround to account for the fact that both O# and Razor register handlers.
-        /// It can be removed once we switch over to CLaSP:
-        /// https://github.com/dotnet/razor-tooling/issues/6871
-        /// </summary>
-        public abstract bool RegisterBuiltInFeatures { get; }
-
         public string GetRazorCSharpFilePath(string razorFilePath) => razorFilePath + CSharpVirtualDocumentSuffix;
 
         public string GetRazorHtmlFilePath(string razorFilePath) => razorFilePath + HtmlVirtualDocumentSuffix;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -58,8 +58,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public override bool SingleServerSupport => _singleServerSupport.Value;
 
-        public override bool RegisterBuiltInFeatures => true;
-
         private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -37,8 +37,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public override bool SingleServerSupport => false;
 
-        public override bool RegisterBuiltInFeatures => true;
-
         private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -730,9 +730,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Hover
                 options.SupportsFileManipulation == true &&
                 options.SingleServerSupport == true &&
                 options.CSharpVirtualDocumentSuffix == ".g.cs" &&
-                options.HtmlVirtualDocumentSuffix == ".g.html" &&
-                options.RegisterBuiltInFeatures == true
-                , MockBehavior.Strict);
+                options.HtmlVirtualDocumentSuffix == ".g.html",
+                MockBehavior.Strict);
             var languageServer = new HoverLanguageServer(csharpServer, csharpDocumentUri, DisposalToken);
             var documentMappingService = new DefaultRazorDocumentMappingService(languageServerFeatureOptions, documentContextFactory, LoggerFactory);
             var projectSnapshotManager = Mock.Of<ProjectSnapshotManagerBase>(p => p.Projects == new[] { Mock.Of<ProjectSnapshot>(MockBehavior.Strict) }, MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -24,7 +24,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public override bool SingleServerCompletionSupport => false;
 
         public override bool SingleServerSupport => false;
-
-        public override bool RegisterBuiltInFeatures => true;
     }
 }


### PR DESCRIPTION
### Summary of the changes
- Now that we no longer depend on O#, we can remove the workaround to stop double registering features. The bulk of this removal was actually included as part #6951, this is just the remaining cleanup.

Fixes https://github.com/dotnet/razor-tooling/issues/6871
