### PR TITLE
[VSCode] Use correct JsonRpc notification method

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultClientNotifierService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultClientNotifierService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         {
             await _initializedCompletionSource.Task;
 
-            await _jsonRpc.NotifyAsync(method, @params);
+            await _jsonRpc.NotifyWithParameterObjectAsync(method, @params);
         }
 
         public override async Task SendNotificationAsync(string method, CancellationToken cancellationToken)


### PR DESCRIPTION
### Summary of the changes
- We need to call `NotifyWithParameterObjectAsync()` instead of `NotifyAsync()` when we're sending notifications via JsonRpc which contain parameters. I believe this is because the [former's implementation](https://github.com/microsoft/vs-streamjsonrpc/blob/ef6e0aea98edec3987146052db696adaabe5a61a/src/StreamJsonRpc/JsonRpc.cs#L1091) specifies that we're sending named arguments (via the `isParameterObject` parameter), while the [latter's implementation](https://github.com/microsoft/vs-streamjsonrpc/blob/ef6e0aea98edec3987146052db696adaabe5a61a/src/StreamJsonRpc/JsonRpc.cs#L1069) specifies we're sending positional arguments.
- According to Dirk, only named arguments are technically allowed per the spec, so we need to be using the former implementation.
- This fixes warnings in VS Code debug console such as:
> "Notification window/logMessage defines parameters by name but received parameters by position”
> "Notification textDocument/publishDiagnostics defines parameters by name but received parameters by position”
