### PR TITLE
Clean up Logging

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer
             }
         }
 
-        private class NoopLogger : ILspLogger, ILogger
+        private class NoopLogger : IRazorLogger
         {
             public IDisposable BeginScope<TState>(TState state)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/AbstractTextDocumentPresentationEndpointBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/AbstractTextDocumentPresentationEndpointBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation
             var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
             if (codeDocument.IsUnsupported())
             {
-                requestContext.LspLogger.LogWarning("Failed to retrieve generated output for document {request.TextDocument.Uri}.", request.TextDocument.Uri);
+                requestContext.Logger.LogWarning("Failed to retrieve generated output for document {request.TextDocument.Uri}.", request.TextDocument.Uri);
                 return null;
             }
 
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation
 
             if (languageKind is not (RazorLanguageKind.CSharp or RazorLanguageKind.Html))
             {
-                requestContext.LspLogger.LogInformation("Unsupported language {languageKind}.", languageKind);
+                requestContext.Logger.LogInformation("Unsupported language {languageKind}.", languageKind);
                 return null;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSynchronization/RazorDidSaveTextDocumentEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSynchronization/RazorDidSaveTextDocumentEndpoint.cs
@@ -20,7 +20,7 @@ internal class RazorDidSaveTextDocumentEndpoint : IVSDidSaveTextDocumentEndpoint
 
     public Task HandleNotificationAsync(DidSaveTextDocumentParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {
-        requestContext.LspLogger.LogInformation($"Saved Document {request.TextDocument.Uri.GetAbsoluteOrUNCPath()}");
+        requestContext.Logger.LogInformation($"Saved Document {request.TextDocument.Uri.GetAbsoluteOrUNCPath()}");
 
         return Task.CompletedTask;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorRequestContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorRequestContext.cs
@@ -3,25 +3,21 @@
 
 using System;
 using Microsoft.CommonLanguageServerProtocol.Framework;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 
 internal readonly struct RazorRequestContext
 {
     public readonly DocumentContext? DocumentContext;
-    public readonly ILspLogger LspLogger;
-    public readonly ILogger Logger;
+    public readonly IRazorLogger Logger;
     public readonly ILspServices LspServices;
 
     public RazorRequestContext(
         DocumentContext? documentContext,
-        ILspLogger lspLoger,
-        ILogger logger,
+        IRazorLogger logger,
         ILspServices lspServices)
     {
         DocumentContext = documentContext;
-        LspLogger = lspLoger;
         LspServices = lspServices;
         Logger = logger;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLogger.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorLogger.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+public interface IRazorLogger : ILogger, ILspLogger
+{
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LoggerAdapter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LoggerAdapter.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 // We unify the ILspLogger and ILogger systems here because the ILspLogger class does not match the ILogger class used by Razor,
 // but we did not want to migrate them all at once
-public class LoggerAdapter : ILspLogger, ILogger
+public class LoggerAdapter : IRazorLogger
 {
     private readonly ILogger _logger;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Threading;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class LspLogger : ILspLogger, ILogger
+internal class LspLogger : IRazorLogger
 {
     private readonly LogLevel _logLevel;
     private ClientNotifierServiceBase? _serviceBase;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Serialization;
@@ -35,20 +34,7 @@ internal sealed class RazorLanguageServerWrapper : IAsyncDisposable
     public static RazorLanguageServerWrapper Create(
         Stream input,
         Stream output,
-        Trace trace,
-        ProjectSnapshotManagerDispatcher? projectSnapshotManagerDispatcher = null,
-        Action<IServiceCollection>? configure = null,
-        LanguageServerFeatureOptions? featureOptions = null)
-    {
-        var logger = new LspLogger(trace);
-
-        return Create(input, output, logger, projectSnapshotManagerDispatcher, configure, featureOptions);
-    }
-
-    public static RazorLanguageServerWrapper Create(
-        Stream input,
-        Stream output,
-        ILspLogger razorLogger,
+        IRazorLogger razorLogger,
         ProjectSnapshotManagerDispatcher? projectSnapshotManagerDispatcher = null,
         Action<IServiceCollection>? configure = null,
         LanguageServerFeatureOptions? featureOptions = null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -49,11 +49,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 documentContext = await documentContextFactory.TryCreateAsync(uri, cancellationToken);
             }
 
-            var lspLogger = _lspServices.GetRequiredService<ILspLogger>();
             var loggerFactory = _lspServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger(queueItem.MethodName);
+            var lspLogger = new LoggerAdapter(logger);
 
-            var requestContext = new RazorRequestContext(documentContext, lspLogger, logger, _lspServices);
+            var requestContext = new RazorRequestContext(documentContext, lspLogger, _lspServices);
 
             return requestContext;
         }

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -44,10 +44,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 }
             }
 
+            var logger = new LspLogger(trace);
             var server = RazorLanguageServerWrapper.Create(
                 Console.OpenStandardInput(),
                 Console.OpenStandardOutput(),
-                trace);
+                logger);
             await server.WaitForExitAsync();
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
-using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.Logging;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor;
@@ -44,8 +43,6 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
 
         protected JsonSerializer Serializer { get; }
 
-        protected ILspLogger LspLogger { get; }
-
         public LanguageServerTestBase(ITestOutputHelper testOutput)
             : base(testOutput)
         {
@@ -59,8 +56,6 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
             FilePathNormalizer = new FilePathNormalizer();
             SpanMappingService = new ThrowingRazorSpanMappingService();
 
-            LspLogger = Logger.AsLspLogger();
-
             Serializer = new JsonSerializer();
             Serializer.Converters.RegisterRazorConverters();
             Serializer.AddVSInternalExtensionConverters();
@@ -71,7 +66,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
         {
             lspServices ??= new Mock<ILspServices>(MockBehavior.Strict).Object;
 
-            var requestContext = new RazorRequestContext(documentContext, LspLogger, Logger, lspServices);
+            var requestContext = new RazorRequestContext(documentContext, Logger, lspServices);
 
             return requestContext;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Logging/LoggerExtensions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Logging/LoggerExtensions.cs
@@ -12,9 +12,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.Logging
 {
     internal static class LoggerExtensions
     {
-        public static ILspLogger AsLspLogger(this ILogger logger)
-            => new TestLspLogger(logger);
-
         private class TestLspLogger : ILspLogger
         {
             private readonly ILogger _logger;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.ComponentShim\Microsoft.AspNetCore.Razor.Test.ComponentShim.csproj" />
   </ItemGroup>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Threading;
@@ -63,12 +64,12 @@ public abstract class TestBase : IAsyncLifetime
     /// </summary>
     protected ILoggerFactory LoggerFactory { get; }
 
-    private ILogger? _logger;
+    private IRazorLogger? _logger;
 
     /// <summary>
-    ///  An <see cref="ILogger"/> for the currently running test.
+    ///  An <see cref="IRazorLogger"/> for the currently running test.
     /// </summary>
-    protected ILogger Logger => _logger ??= LoggerFactory.CreateLogger(GetType());
+    protected IRazorLogger Logger => _logger ??= new LoggerAdapter(LoggerFactory.CreateLogger(GetType()));
 
     protected TestBase(ITestOutputHelper testOutput)
     {


### PR DESCRIPTION
### Summary of the changes

- Clean up some of the Logging in Razor so that we're not passing two logging objects around (especially since they both lead to the same place).
- The current state of our logging seems to be that for VS we log to LogHub and in rzls scenarios we use window/log. Does this track with everyone's expectations?

Fixes: https://github.com/dotnet/razor-tooling/issues/6843