### PR TITLE
Don't rely on assembly version

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -131,11 +131,10 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
                 throw new NotImplementedException($"Integration test did not load extension");
             }
 
-            var version = assembly.GetName().Version;
-
-            if (!version.Equals(new Version(42, 42, 42, 42)) || !assembly.Location.StartsWith(localAppData, StringComparison.OrdinalIgnoreCase))
+            if (!assembly.Location.StartsWith(localAppData, StringComparison.OrdinalIgnoreCase))
             {
-                throw new NotImplementedException($"Integration test not running against Experimental Extension {assembly.Location}");
+                var version = assembly.GetName().Version;
+                throw new NotImplementedException($"Integration test not running against Experimental Extension assembly: {assembly.Location} verion: {version}");
             }
 
             void CurrentDomain_AssemblyLoad(object sender, AssemblyLoadEventArgs args)


### PR DESCRIPTION
### Summary of the changes

- In the official build our assembly version will not be the fake "42.42.42.42". IIRC that was just me being extra paranoid though and the AppDataLocal check should b e enough.