### PR TITLE
Take new CLaSP version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,7 +53,7 @@
 
   -->
   <!-- TODO: https://github.com/dotnet/razor-tooling/issues/6760 -->
-  <PropertyGroup Label="Automated">  
+  <PropertyGroup Label="Automated">
     <MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>7.0.0-preview.5.22364.1</MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>
     <MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>7.0.0-preview.5.22364.1</MicrosoftAspNetCoreRazorSymbolsTransportPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>7.0.0-preview.5.22364.1</MicrosoftAspNetCoreMvcRazorExtensionsToolingInternalPackageVersion>
@@ -81,7 +81,7 @@
     <RoslynPackageVersion>4.4.0-2.22424.2</RoslynPackageVersion>
     <VisualStudioLanguageServerProtocolVersion>17.4.1008-preview</VisualStudioLanguageServerProtocolVersion>
     <MicrosoftNetCompilersToolsetVersion>4.4.0-1.final</MicrosoftNetCompilersToolsetVersion>
-    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.5.0-1.22480.13</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
+    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.5.0-1.22513.3</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <!-- dotnet/runtime packages -->

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -32,7 +32,6 @@ internal static class IServiceCollectionExtensions
     {
         services.AddHandler<RazorInitializeEndpoint>();
         services.AddHandler<RazorInitializedEndpoint>();
-        services.AddHandler<ExitHandler<RazorRequestContext>>();
         services.AddHandler<ShutdownHandler<RazorRequestContext>>();
 
         var razorLifeCycleManager = new RazorLifeCycleManager(razorLanguageServer);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageServerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageServerTest.cs
@@ -33,10 +33,15 @@ public class RazorLanguageServerTest : TestBase
         var handlerTypes = typeof(RazorLanguageServerWrapper).Assembly.GetTypes()
             .Where(t => typeof(IMethodHandler).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface);
 
-        if (registeredMethods.Length != handlerTypes.Count())
+        // We turn this into a Set to handle cases like Completion where we have two handlers, only one of which will be registered
+        // CLaSP will throw if two handlers register for the same method, so if THAT doesn't hold it's a CLaSP bug, not a Razor bug.
+        var typeMethods = handlerTypes.Select(t => GetMethodFromType(t)).ToHashSet();
+        // The shutdown handler is outside of our assembly.
+        typeMethods.Add("shutdown");
+        if (registeredMethods.Length != typeMethods.Count)
         {
-            var unregisteredHandlers = handlerTypes.Where(t => !registeredMethods.Any(m => m.MethodName == GetMethodFromType(t)));
-            Assert.True(false, $"Unregistered handlers: {string.Join(";", unregisteredHandlers.Select(t => t.Name))}");
+            var unregisteredHandlers = typeMethods.Where(t => !registeredMethods.Any(m => m.MethodName == t));
+            Assert.True(false, $"Unregistered handlers: {string.Join(";", unregisteredHandlers.Select(t => t))}");
         }
 
         static string GetMethodFromType(Type t)


### PR DESCRIPTION
### Summary of the changes

- There was a breaking change in CLaSP in order to fix https://github.com/dotnet/roslyn/pull/64583. Now that Roslyn has merged that fix we must react.
- Thankfully it's very simple, we just need to stop referencing the ExitHandler since it's gone now. CLaSP now auto-registers that method itself (exit has special handling properties since it's the only method that can be run after shutdown).