### PR TITLE
Don't run tests on RichNav

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -49,16 +49,17 @@ stages:
             command: custom
             arguments: 'locals all -clear'
 
-        - script: eng\common\build.ps1
-            -restore
-            -build
-            -sign
-            -pack
-            -publish
-            -ci
-            -configuration Debug
-            -msbuildEngine dotnet
-            -prepareMachine
-          name: Build
+        - task: PowerShell@2
           displayName: Build
           condition: succeeded()
+          inputs:
+            filePath: eng/common/build.ps1
+            arguments: -ci
+                       -restore
+                       -build
+                       -sign
+                       -pack
+                       -publish
+                       -configuration Debug
+                       -msbuildEngine dotnet
+                       -prepareMachine

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -49,7 +49,13 @@ stages:
             command: custom
             arguments: 'locals all -clear'
 
-        - script: eng\common\cibuild.cmd
+        - script: eng\common\build.ps1
+            -restore
+            -build
+            -sign
+            -pack
+            -publish
+            -ci
             -configuration Debug
             -msbuildEngine dotnet
             -prepareMachine


### PR DESCRIPTION
### Summary of the changes

- cibuild.cmd includes tests, so let's not use that for RichNav, where we don't want tests.
- This should save us ~5 minutes per RichNav build

Fixes: https://github.com/dotnet/razor-tooling/issues/6984
