### PR TITLE
Classify <c> tags the same as <code> tags, and clean up regex usage a little

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
                 var cref = crefMatches[i];
                 if (cref.Success)
                 {
-                    var value = cref.Groups[2].Value;
+                    var value = cref.Groups[TagContentGroupName].Value;
                     var reducedValue = ReduceCrefValue(value);
                     reducedValue = reducedValue.Replace("{", "<").Replace("}", ">");
                     summaryBuilder.Remove(cref.Index, cref.Length);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
                     ClassifyExistingTextRun(runs, currentTextRun);
 
                     // We've processed the existing string, now we can process the code block.
-                    var value = currentCodeMatch.Groups[1].Value;
+                    var value = currentCodeMatch.Groups[TagContentGroupName].Value;
                     if (value.Length != 0)
                     {
                         runs.Add(new ClassifiedTextRun(VSPredefinedClassificationTypeNames.Text, value.ToString(), ClassifiedTextRunStyle.UseClassificationFont));
@@ -386,7 +386,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
                     ClassifyExistingTextRun(runs, currentTextRun);
 
                     // We've processed the existing string, now we can process the actual cref.
-                    var value = currentCrefMatch.Groups[2].Value;
+                    var value = currentCrefMatch.Groups[TagContentGroupName].Value;
                     var reducedValue = ReduceCrefValue(value);
                     reducedValue = reducedValue.Replace("{", "<").Replace("}", ">").Replace("`1", "<>");
                     ClassifyTypeName(runs, reducedValue);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
@@ -11,6 +11,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 {
     internal abstract class TagHelperTooltipFactoryBase
     {
+        protected static readonly string TagContentGroupName = "content";
+        private static readonly Regex s_codeRegex = new Regex($"""<(?:c|code)>(?<{TagContentGroupName}>.*?)<\/(?:c|code)>""", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+        private static readonly Regex s_crefRegex = new Regex($"""<(?:see|seealso)[\s]+cref="(?<{TagContentGroupName}>[^">]+)"[^>]*>""", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
         private static readonly IReadOnlyList<char> s_newLineChars = new char[] { '\n', '\r' };
 
         // Internal for testing
@@ -89,15 +93,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
 
         internal static List<Match> ExtractCodeMatches(string summaryContent)
         {
-            var codeRegex = new Regex(@"<code>(.*?)<\/code>", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-            var successfulMatches = ExtractSuccessfulMatches(codeRegex, summaryContent);
+            var successfulMatches = ExtractSuccessfulMatches(s_codeRegex, summaryContent);
             return successfulMatches;
         }
 
         internal static List<Match> ExtractCrefMatches(string summaryContent)
         {
-            var crefRegex = new Regex("<(see|seealso)[\\s]+cref=\"([^\">]+)\"[^>]*>", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-            var successfulMatches = ExtractSuccessfulMatches(crefRegex, summaryContent);
+            var successfulMatches = ExtractSuccessfulMatches(s_crefRegex, summaryContent);
             return successfulMatches;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -116,6 +116,28 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip
         }
 
         [Fact]
+        public void CleanSummaryContent_ClassifiedTextElement_ClassifiesCBlocks()
+        {
+            // Arrange
+            var runs = new List<ClassifiedTextRun>();
+            var summary = @"code: <c>This is code</c> and <c>This is some other code</c>.";
+
+            // Act
+            CleanAndClassifySummaryContent(runs, summary);
+
+            // Assert
+
+            // Expected output:
+            //     code: This is code and This is some other code.
+            Assert.Collection(runs,
+                run => AssertExpectedClassification(run, "code: ", VSPredefinedClassificationTypeNames.Text),
+                run => AssertExpectedClassification(run, "This is code", VSPredefinedClassificationTypeNames.Text, ClassifiedTextRunStyle.UseClassificationFont),
+                run => AssertExpectedClassification(run, " and ", VSPredefinedClassificationTypeNames.Text),
+                run => AssertExpectedClassification(run, "This is some other code", VSPredefinedClassificationTypeNames.Text, ClassifiedTextRunStyle.UseClassificationFont),
+                run => AssertExpectedClassification(run, ".", VSPredefinedClassificationTypeNames.Text));
+        }
+
+        [Fact]
         public void CleanSummaryContent_ClassifiedTextElement_ParasCreateNewLines()
         {
             // Arrange

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/HoverTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/HoverTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests
             var hoverString = await TestServices.Editor.GetHoverStringAsync(position, ControlledHangMitigatingCancellationToken);
 
             // Assert
-            const string ExpectedResult = "Microsoft.AspNetCore.Components.Web.PageTitleEnables rendering an HTML <c><title></c> to a HeadOutlet component.";
+            const string ExpectedResult = "Microsoft.AspNetCore.Components.Web.PageTitleEnables rendering an HTML <title> to a HeadOutlet component.";
             Assert.Equal(ExpectedResult, hoverString);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6047

Adds support for `<c>`, and uses named groups in the regex instead of hard-coding array indexes, and stops capturing groups we don't need, stores the regexes statically, and uses raw string literals because they're objectively good.