### PR TITLE
Don't show tag helper completions if the attribute rules aren't satisfied

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerTagHelperCompletionService.cs
@@ -222,7 +222,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
                         addRuleCompletions = true;
                     }
 
-                    if (addRuleCompletions)
+                    // If we think this completion should be added based on tag name, thats great, but lets also make sure the attributes are correct
+                    if (addRuleCompletions && TagHelperMatchingConventions.SatisfiesAttributes(completionContext.Attributes.ToList(), rule))
                     {
                         UpdateCompletions(prefix + rule.TagName, possibleDescriptor);
                     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerTagHelperCompletionService.cs
@@ -175,6 +175,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return emptyResult;
             }
 
+            var tagAttributes = completionContext.Attributes.ToList();
+
             var catchAllDescriptors = new HashSet<TagHelperDescriptor>();
             var prefix = completionContext.DocumentContext.Prefix ?? string.Empty;
             var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingParentTagName);
@@ -223,7 +225,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     }
 
                     // If we think this completion should be added based on tag name, thats great, but lets also make sure the attributes are correct
-                    if (addRuleCompletions && TagHelperMatchingConventions.SatisfiesAttributes(completionContext.Attributes.ToList(), rule))
+                    if (addRuleCompletions && TagHelperMatchingConventions.SatisfiesAttributes(tagAttributes, rule))
                     {
                         UpdateCompletions(prefix + rule.TagName, possibleDescriptor);
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/6824
This is also the proper fix for https://github.com/dotnet/razor-tooling/issues/6583 IMO

The story is, previously we would inconsistently show tag helper completion for some HTML elements, namely we wouldn't show `form` but would show `script`. https://github.com/dotnet/razor-tooling/pull/6823 fixed that by making things consistent, and show now we always show `form` and `script`. Unfortunately that was not actually correct, as we would show the `script` tag helper completion, but then upon completing that item, the tag wouldn't be classified as a tag helper. This fixes that, and only shows a tag helper in completion if the attribute rules it has, if any, are also satisfied. This means we now don't show `form` or `script`, as tag helper completions, and just show them as HTML tag completions, unless they actually would be classified as tag helpers on commit.

Best illustrated with a picture. Notice that only one `link` completion item is available at first, the HTML tag. It is only after adding `href="~/` to the tag, which is what the tag helper is triggered by, that we show `link` as a tag helper completion item too.

![TagHelperCompletion](https://user-images.githubusercontent.com/754264/196105417-8b284a0a-5b6a-40a7-8be8-6a262f26b2e9.gif)
