### PR TITLE
More Go to Definition attribute tests

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointTest.cs
@@ -227,6 +227,38 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition
             await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
         }
 
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_MinimizedPropertyAttributeEdge1()
+        {
+            var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 $$bool-val></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+            await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
+        }
+
+        [Fact]
+        public async Task GetOriginTagHelperBindingAsync_TagHelper_MinimizedPropertyAttributeEdge2()
+        {
+            var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 bool-val$$></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+            await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/razor-tooling/issues/6775")]
         public async Task GetOriginTagHelperBindingAsync_TagHelper_PropertyAttributeEdge()
         {


### PR DESCRIPTION
I thought we already had coverage for this, but after the tests got ported to be readable, it was clear we didn't, so adding it just in case.