### PR TITLE
Add route string syntax to Razor pages and Blazor

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=Route
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
 global::System.Object __typeHelper = "/About";
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (492:14,0 [41] )
 
 Source Location: (6:0,6 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |"/About"|
-Generated Location: (1108:25,37 [8] )
+Generated Location: (1127:26,37 [8] )
 |"/About"|
 
 Source Location: (25:2,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |NewModel|
-Generated Location: (1313:33,0 [8] )
+Generated Location: (1332:34,0 [8] )
 |NewModel|
 
 Source Location: (213:12,18 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |Model.Name|
-Generated Location: (1831:48,18 [10] )
+Generated Location: (1850:49,18 [10] )
 |Model.Name|
 
 Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
@@ -25,7 +25,7 @@ Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrat
         public string Name { get; set; }
     }
 |
-Generated Location: (2039:55,12 [97] )
+Generated Location: (2058:56,12 [97] )
 |
     public class NewModel : PageModel
     {

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -27,6 +27,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=Route
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml"
 global::System.Object __typeHelper = "*, AppCode";
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
@@ -5,12 +5,12 @@ Generated Location: (487:14,0 [41] )
 
 Source Location: (23:2,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |"*, AppCode"|
-Generated Location: (1443:30,37 [12] )
+Generated Location: (1462:31,37 [12] )
 |"*, AppCode"|
 
 Source Location: (566:24,47 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (2113:47,47 [4] )
+Generated Location: (2132:48,47 [4] )
 |Name|
 
 Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
@@ -28,7 +28,7 @@ Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegra
         public string Name { get; set; }
     }
 |
-Generated Location: (2898:62,12 [283] )
+Generated Location: (2917:63,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -35,6 +35,7 @@ NewModel __typeHelper = default;
         }
         ))();
         ((System.Action)(() => {
+// language=Route
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
 global::System.Object __typeHelper = "*, AppCode";
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -10,12 +10,12 @@ Generated Location: (1370:30,0 [8] )
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (1618:38,37 [12] )
+Generated Location: (1637:39,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (2276:55,47 [10] )
+Generated Location: (2295:56,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (3055:70,12 [360] )
+Generated Location: (3074:71,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=Route
 #nullable restore
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
 global::System.Object __typeHelper = "/About";

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (511:15,0 [41] )
 
 Source Location: (6:0,6 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |"/About"|
-Generated Location: (1488:32,37 [8] )
+Generated Location: (1507:33,37 [8] )
 |"/About"|
 
 Source Location: (25:2,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |NewModel|
-Generated Location: (1731:42,0 [8] )
+Generated Location: (1750:43,0 [8] )
 |NewModel|
 
 Source Location: (213:12,18 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |Model.Name|
-Generated Location: (2288:59,18 [10] )
+Generated Location: (2307:60,18 [10] )
 |Model.Name|
 
 Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
@@ -25,7 +25,7 @@ Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrat
         public string Name { get; set; }
     }
 |
-Generated Location: (2534:68,12 [97] )
+Generated Location: (2553:69,12 [97] )
 |
     public class NewModel : PageModel
     {

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -33,6 +33,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=Route
 #nullable restore
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml"
 global::System.Object __typeHelper = "*, AppCode";

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
@@ -5,12 +5,12 @@ Generated Location: (506:15,0 [41] )
 
 Source Location: (23:2,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |"*, AppCode"|
-Generated Location: (1818:37,37 [12] )
+Generated Location: (1837:38,37 [12] )
 |"*, AppCode"|
 
 Source Location: (566:24,47 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (2526:56,47 [4] )
+Generated Location: (2545:57,47 [4] )
 |Name|
 
 Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
@@ -28,7 +28,7 @@ Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegra
         public string Name { get; set; }
     }
 |
-Generated Location: (3349:73,12 [283] )
+Generated Location: (3368:74,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -43,6 +43,7 @@ NewModel __typeHelper = default!;
         }
         ))();
         ((System.Action)(() => {
+// language=Route
 #nullable restore
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
 global::System.Object __typeHelper = "*, AppCode";

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -10,12 +10,12 @@ Generated Location: (1733:37,0 [8] )
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (2020:47,37 [12] )
+Generated Location: (2039:48,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (2716:66,47 [10] )
+Generated Location: (2735:67,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (3533:83,12 [360] )
+Generated Location: (3552:84,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/DefaultCodeRenderingContext.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/DefaultCodeRenderingContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/DefaultCodeRenderingContext.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/DefaultCodeRenderingContext.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -90,7 +90,7 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
 
     public override RazorDiagnosticCollection Diagnostics { get; }
 
-    public override string DocumentKind { get; }
+    public override string DocumentKind => _documentNode.DocumentKind;
 
     public override ItemCollection Items { get; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -152,6 +152,17 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
 
                 case DirectiveTokenKind.String:
 
+                    var stringSyntax = context.DocumentKind switch
+                    {
+                        "mvc.1.0.razor-page" => "Route",
+                        "component.1.0" => "ComponentRoute",
+                        _ => null
+                    };
+                    if (stringSyntax is not null)
+                    {
+                        context.CodeWriter.Write("// language=").Write(stringSyntax);
+                    }
+
                     // global::System.Object __typeHelper = "{node.Content}";
                     using (context.CodeWriter.BuildLinePragma(node.Source, context))
                     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -152,6 +152,9 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
 
                 case DirectiveTokenKind.String:
 
+                    // Add a string syntax to the directive if the document is a Razor page or a Blazor component.
+                    // language=Route tells Roslyn that this string is a route template. A classifier that's
+                    // part of ASP.NET Core will run that colorizes the route string.
                     var stringSyntax = context.DocumentKind switch
                     {
                         "mvc.1.0.razor-page" => "Route",

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
@@ -15,6 +15,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/MyPage";
@@ -25,6 +26,7 @@ global::System.Object __typeHelper = "/MyPage";
         }
         ))();
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/AnotherRoute/{id}";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (6:0,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/MyPage"|
-Generated Location: (745:19,37 [9] )
+Generated Location: (773:20,37 [9] )
 |"/MyPage"|
 
 Source Location: (23:1,6 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/AnotherRoute/{id}"|
-Generated Location: (974:29,37 [20] )
+Generated Location: (1030:31,37 [20] )
 |"/AnotherRoute/{id}"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
@@ -22,6 +22,7 @@ using Test2;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/MyPage";
@@ -32,6 +33,7 @@ global::System.Object __typeHelper = "/MyPage";
         }
         ))();
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/AnotherRoute/{id}";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (320:12,0 [11] )
 
 Source Location: (6:0,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/MyPage"|
-Generated Location: (879:26,37 [9] )
+Generated Location: (907:27,37 [9] )
 |"/MyPage"|
 
 Source Location: (23:1,6 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/AnotherRoute/{id}"|
-Generated Location: (1108:36,37 [20] )
+Generated Location: (1164:38,37 [20] )
 |"/AnotherRoute/{id}"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -14,6 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/my/url";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (24:2,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/my/url"|
-Generated Location: (661:18,37 [9] )
+Generated Location: (689:19,37 [9] )
 |"/my/url"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
@@ -14,6 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (6:0,6 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/"|
-Generated Location: (655:18,37 [3] )
+Generated Location: (683:19,37 [3] )
 |"/"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
@@ -14,6 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (6:0,6 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/"|
-Generated Location: (655:18,37 [3] )
+Generated Location: (683:19,37 [3] )
 |"/"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -14,6 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+// language=ComponentRoute
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/my/url";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (24:2,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/my/url"|
-Generated Location: (661:18,37 [9] )
+Generated Location: (689:19,37 [9] )
 |"/my/url"|
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-compiler/issues/352

I've hacked this in. There are things todo:
1. Is this the right way to detect whether a Razor document is a Razor Page or Blazor page?
2. I was surprised when I ran the unit tests and nothing failed. It appears the razor compiler unit tests aren't in the solution file? If they're somewhere in the repo then I still need to update them.