### PR TITLE
[VSCode] Completion commit fix for Razor comments

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Completion/RazorCompletionItemProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Completion/RazorCompletionItemProvider.ts
@@ -80,10 +80,10 @@ export class RazorCompletionItemProvider
 
                 if (triggerCharacter === '@' &&
                     completionItem.commitCharacters) {
-                    // We remove `{` and '(' from the commit characters to prevent auto-completing the first completion item
-                    // with a curly brace when a user intended to type `@{}` or `@()`.
+                    // We remove `{`, '(', and '*' from the commit characters to prevent auto-completing the first
+                    // completion item with a curly brace when a user intended to type `@{}` or `@()`.
                     completionItem.commitCharacters = completionItem.commitCharacters.filter(
-                        commitChar => commitChar !== '{' && commitChar !== '(');
+                        commitChar => commitChar !== '{' && commitChar !== '(' && commitChar !== '*');
                 }
             }
 


### PR DESCRIPTION
### Summary of the changes

- See gif in original issue. We need to handle Razor comments specially so we don't accidentally commit an item when typing the comment syntax.

Fixes #4566
