### PR TITLE
Fix spelling mistakes

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -2180,7 +2180,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
             // Otherwise, there will be no source mapping when someone types an `@` leading to no intellisense.
             if (node.FirstAncestorOrSelf<SyntaxNode>(n => n is MarkupStartTagSyntax || n is MarkupEndTagSyntax) != null)
             {
-                // We don't care about implicit expresssion in attributes.
+                // We don't care about implicit expression in attributes.
                 return;
             }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/IRazorDocumentClassifierPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/IRazorDocumentClassifierPhase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Razor.Language;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The first phase of intermediate node procesing is document classification. Passes in this phase should classify the
+/// The first phase of intermediate node processing is document classification. Passes in this phase should classify the
 /// document according to any relevant criteria (project configuration, file extension, directive) and modify
 /// the intermediate node document to suit the desired document shape. Document classifiers should also set
 /// <see cref="DocumentIntermediateNode.DocumentKind"/> to prevent other classifiers from running. If no classifier

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
@@ -1866,7 +1866,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
         }
         else
         {
-            // Setup the Span to be an async implicit expression (an implicit expresison that allows spaces).
+            // Setup the Span to be an async implicit expression (an implicit expression that allows spaces).
             // Spaces are allowed because of "@await Foo()".
             var implicitExpressionBody = ParseImplicitExpressionBody(async: true);
             builder.Add(SyntaxFactory.CSharpImplicitExpression(transition, implicitExpressionBody));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocumentExtensions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocumentExtensions.cs
@@ -286,7 +286,7 @@ public static class RazorCodeDocumentExtensions
 
         StringSegment relativePath = document.Source.RelativePath;
 
-        // If there are multiple @namespace directives in the heirarchy,
+        // If there are multiple @namespace directives in the hierarchy,
         // we want to pick the closest one to the current document.
         if (!string.IsNullOrEmpty(lastNamespaceContent))
         {
@@ -303,7 +303,7 @@ public static class RazorCodeDocumentExtensions
             }
             else
             {
-                // We know that the document containing the namespace directive is in the current document's heirarchy.
+                // We know that the document containing the namespace directive is in the current document's hierarchy.
                 // Let's compute the actual relative path that we'll use to compute the namespace suffix.
                 relativePath = sourceFilePath.Subsegment(directiveLocationDirectory.Length);
             }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
@@ -86,11 +86,11 @@ public abstract class RazorCodeGenerationOptions
 
     /// <summary>
     /// Gets a value that indicates whether to suppress the default <c>#pragma checksum</c> directive in the
-    /// generated C# code. If <c>false</c> the checkum directive will be included, otherwise it will not be
+    /// generated C# code. If <c>false</c> the checksum directive will be included, otherwise it will not be
     /// generated. Defaults to <c>false</c>, meaning that the checksum will be included.
     /// </summary>
     /// <remarks>
-    /// The <c>#pragma checksum</c> is required to enable debugging and should only be supressed for testing
+    /// The <c>#pragma checksum</c> is required to enable debugging and should only be suppressed for testing
     /// purposes.
     /// </remarks>
     public abstract bool SuppressChecksum { get; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
@@ -24,17 +24,17 @@ public abstract class RazorCodeGenerationOptionsBuilder
 
     /// <summary>
     /// Gets or sets a value that indicates whether to suppress the default <c>#pragma checksum</c> directive in the
-    /// generated C# code. If <c>false</c> the checkum directive will be included, otherwise it will not be
+    /// generated C# code. If <c>false</c> the checksum directive will be included, otherwise it will not be
     /// generated. Defaults to <c>false</c>, meaning that the checksum will be included.
     /// </summary>
     /// <remarks>
-    /// The <c>#pragma checksum</c> is required to enable debugging and should only be supressed for testing
+    /// The <c>#pragma checksum</c> is required to enable debugging and should only be suppressed for testing
     /// purposes.
     /// </remarks>
     public abstract bool SuppressChecksum { get; set; }
 
     /// <summary>
-    /// Gets or setsa value that indicates whether to suppress the default metadata attributes in the generated
+    /// Gets or sets a value that indicates whether to suppress the default metadata attributes in the generated
     /// C# code. If <c>false</c> the default attributes will be included, otherwise they will not be generated.
     /// Defaults to <c>false</c> at run time, meaning that the attributes will be included. Defaults to
     /// <c>true</c> at design time, meaning that the attributes will not be included.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
@@ -105,7 +105,7 @@ public abstract class RazorProjectEngine
 
         var builder = new DefaultRazorProjectEngineBuilder(configuration, fileSystem);
 
-        // The intialization order is somewhat important.
+        // The initialization order is somewhat important.
         //
         // Defaults -> Extensions -> Additional customization
         //

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorSourceDocument.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorSourceDocument.cs
@@ -30,7 +30,7 @@ public abstract class RazorSourceDocument
     public abstract Encoding Encoding { get; }
 
     /// <summary>
-    /// Gets the file path of the orginal source document.
+    /// Gets the file path of the original source document.
     /// </summary>
     /// <remarks>
     /// The file path may be either an absolute path or project-relative path. An absolute path is required

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorSourceDocumentProperties.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorSourceDocumentProperties.cs
@@ -33,7 +33,7 @@ public sealed class RazorSourceDocumentProperties
     /// </param>
     public RazorSourceDocumentProperties(string filePath, string relativePath)
     {
-        // We don't do any magic or validation here since we don't need to do any I/O or interation
+        // We don't do any magic or validation here since we don't need to do any I/O or interaction
         // with the file system. We didn't validate anything in 2.0 so we don't want any compat risk.
         FilePath = filePath;
         RelativePath = relativePath;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/SourceLocation.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/SourceLocation.cs
@@ -77,7 +77,7 @@ public struct SourceLocation : IEquatable<SourceLocation>
     /// Creates a new instance of <see cref="SourceLocation"/> from the provided span.
     /// </summary>
     /// <param name="span">
-    /// The souce span. If <c>null</c>, <see cref="SourceLocation.Undefined"/> will be returned.
+    /// The source span. If <c>null</c>, <see cref="SourceLocation.Undefined"/> will be returned.
     /// </param>
     /// <remarks>A <see cref="SourceLocation"/> that corresponds to the beginning of the span.</remarks>
     public static SourceLocation FromSpan(SourceSpan? span)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -328,7 +328,7 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
             pb.Metadata[ComponentMetadata.Component.TypeParameterKey] = bool.TrueString;
             pb.Metadata[ComponentMetadata.Component.TypeParameterIsCascadingKey] = cascade.ToString();
 
-            // Type constraints (like "Image" or "Foo") are stored indepenently of
+            // Type constraints (like "Image" or "Foo") are stored independently of
             // things like constructor constraints and not null constraints in the
             // type parameter so we create a single string representation of all the constraints
             // here.

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Hosting/RazorCompiledItem.cs
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Hosting/RazorCompiledItem.cs
@@ -15,7 +15,7 @@ public abstract class RazorCompiledItem
 {
     /// <summary>
     /// Gets the identifier associated with the compiled item. The identifier is used programmatically to locate
-    /// a specific item of a specific kind and should be uniqure within the assembly.
+    /// a specific item of a specific kind and should be unique within the assembly.
     /// </summary>
     public abstract string Identifier { get; }
 

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Hosting/RazorCompiledItemAttribute.cs
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.MvcShim/Microsoft.AspNetCore.Razor.Hosting/RazorCompiledItemAttribute.cs
@@ -49,7 +49,7 @@ public sealed class RazorCompiledItemAttribute : Attribute
 
     /// <summary>
     /// Gets the identifier associated with the compiled item. The identifier is used programmatically to locate
-    /// a specific item of a specific kind and should be uniqure within the assembly.
+    /// a specific item of a specific kind and should be unique within the assembly.
     /// </summary>
     public string Identifier { get; }
 


### PR DESCRIPTION
### Summary of the changes

There is not much to it. Found a few spelling mistakes in the public API xmldocs while working with the Razor compiler.
I fixed a few comments as well since I was already in the document.
