### PR TITLE
Remove XML doc comment files from VSIX ServiceHubCore folder

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
@@ -27,6 +27,7 @@
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.AspNetCore.*" />
 
       <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Extension)' == '.pdb'" />
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Extension)' == '.xml'" />
 
       <!-- Set TargetPath -->
       <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />


### PR DESCRIPTION
Fixes #7026

The XML doc comment files for our binaries are unnecessarily copied to our VSIX's ServiceHubCore folder, but they're just unnecessary bytes and noise for that scenario.