### PR TITLE
Update minimatch to 3.0.5

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -57,6 +57,7 @@
     "@typescript-eslint/parser": "^4.9.0",
     "extract-zip": "^2.0.1",
     "glob": "^7.1.6",
+    "minimatch": "3.0.5",
     "mocha": "^8.1.3",
     "node-fetch": "^2.6.7",
     "rimraf": "2.6.3",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/yarn.lock
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/yarn.lock
@@ -832,6 +832,13 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -508,6 +508,7 @@
     "@types/vscode": "1.45.1",
     "cross-env": "^5.2.0",
     "js-yaml": ">=3.13.1",
+    "minimatch": "3.0.5",
     "rimraf": "2.6.3",
     "tslint": "^5.11.0",
     "typescript": "^4.5.4"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/yarn.lock
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/yarn.lock
@@ -226,6 +226,13 @@ js-yaml@^3.13.1:
     vscode-languageclient "5.2.1"
     vscode-languageserver-textdocument "^1.0.3"
 
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/.npmrc
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/.npmrc
@@ -1,2 +1,3 @@
 # Auto generated file from Gardener Plugin CentralFeedServiceAdoptionPlugin
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+always-auth=true

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^10.9.4",
     "@types/vscode": "1.45.1",
     "js-yaml": ">=3.13.1",
+    "minimatch": "3.0.5",
     "rimraf": "2.6.3",
     "tslint": "^5.11.0",
     "typescript": "~4.5.2"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/yarn.lock
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/yarn.lock
@@ -190,6 +190,13 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/package.json
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^9.4.7",
     "jest": "^24.9.0",
     "jsdom": "16.5.0",
+    "minimatch": "3.0.5",
     "node-notifier": "8.0.1",
     "rimraf": "2.6.3",
     "ts-jest": "^24.0.0",

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/yarn.lock
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/yarn.lock
@@ -2551,6 +2551,13 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.51.0"
 
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/package.json
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^10.9.4",
     "@types/vscode": "1.45.1",
     "jest": "^27.3.1",
+    "minimatch": "3.0.5",
     "minimist": "1.2.6",
     "rimraf": "2.6.3",
     "ts-jest": "^27.0.7",

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/yarn.lock
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Test/yarn.lock
@@ -2149,12 +2149,8 @@ micromatch@^4.0.4:
     picomatch "^2.2.3"
 
 "microsoft.aspnetcore.razor.vscode@link:../../src/Microsoft.AspNetCore.Razor.VSCode":
-  version "0.0.1"
-  dependencies:
-    ps-list "^7.0.0"
-    vscode-html-languageservice "^4.2.1"
-    vscode-languageclient "5.2.1"
-    vscode-languageserver-textdocument "^1.0.3"
+  version "0.0.0"
+  uid ""
 
 mime-db@1.43.0:
   version "1.43.0"
@@ -2172,6 +2168,13 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimatch@^3.0.4:
   version "3.0.4"

--- a/src/Razor/test/VSCode.FunctionalTest/package.json
+++ b/src/Razor/test/VSCode.FunctionalTest/package.json
@@ -20,6 +20,7 @@
         "@types/rimraf": "2.0.2",
         "@types/vscode": "1.45.1",
         "glob": "^7.1.4",
+        "minimatch": "3.0.5",
         "minimist": "1.2.6",
         "mocha": "^6.1.4",
         "rimraf": "2.6.3",

--- a/src/Razor/test/VSCode.FunctionalTest/yarn.lock
+++ b/src/Razor/test/VSCode.FunctionalTest/yarn.lock
@@ -466,6 +466,13 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"


### PR DESCRIPTION
Closes https://github.com/dotnet/razor-tooling/security/dependabot/49
Closes https://github.com/dotnet/razor-tooling/security/dependabot/48
Closes https://github.com/dotnet/razor-tooling/security/dependabot/47
Closes https://github.com/dotnet/razor-tooling/security/dependabot/46
Closes https://github.com/dotnet/razor-tooling/security/dependabot/45
Closes https://github.com/dotnet/razor-tooling/security/dependabot/44
