### PR TITLE
Clean up bad Analyzer references

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -79,7 +79,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent"  Path="Microsoft.VisualStudio.LanguageServer.ContainedLanguage.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.NET.Sdk.Razor.SourceGenerators.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.Razor.dll" />
-    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
-    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.Microsoft.AspNetCore.Razor.Language.dll" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.AspNetCore.Razor.Language.dll" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
### Summary of the changes

- Noticed that these dll's failed to load in VSMain. It's unclear to my why the error wasn't shown to us before that though.