### PR TITLE
Make FilePathNormalizer a static class

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
@@ -12,19 +12,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
     public class DefaultRemoteTextLoaderFactory : RemoteTextLoaderFactory
     {
-        private readonly FilePathNormalizer _filePathNormalizer;
-
-        public DefaultRemoteTextLoaderFactory(
-            FilePathNormalizer filePathNormalizer)
-        {
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
-            }
-
-            _filePathNormalizer = filePathNormalizer;
-        }
-
         public override TextLoader Create(string filePath)
         {
             if (filePath is null)
@@ -32,7 +19,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
                 throw new ArgumentNullException(nameof(filePath));
             }
 
-            var normalizedPath = _filePathNormalizer.Normalize(filePath);
+            var normalizedPath = FilePathNormalizer.Normalize(filePath);
             return new RemoteTextLoader(normalizedPath);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -8,11 +8,9 @@ using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
 {
-    public class FilePathNormalizer
+    public static class FilePathNormalizer
     {
-        public static readonly FilePathNormalizer Instance = new FilePathNormalizer();
-
-        public string NormalizeDirectory(string directoryFilePath)
+        public static string NormalizeDirectory(string directoryFilePath)
         {
             var normalized = Normalize(directoryFilePath);
 
@@ -24,7 +22,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             return normalized;
         }
 
-        public string Normalize(string filePath)
+        public static string Normalize(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))
             {
@@ -49,13 +47,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             return normalized;
         }
 
-        public Uri Normalize(Uri uri)
+        public static Uri Normalize(Uri uri)
         {
             var normalized = Normalize(uri.OriginalString);
             return new Uri(normalized);
         }
 
-        public string GetDirectory(string filePath)
+        public static string GetDirectory(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))
             {
@@ -69,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
             return directory;
         }
 
-        public bool FilePathsEquivalent(string filePath1, string filePath2)
+        public static bool FilePathsEquivalent(string filePath1, string filePath2)
         {
             var normalizedFilePath1 = Normalize(filePath1);
             var normalizedFilePath2 = Normalize(filePath2);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -26,14 +26,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         private static readonly Task<IReadOnlyList<RazorVSInternalCodeAction>?> s_emptyResult = Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(null);
 
         private readonly TagHelperFactsService _tagHelperFactsService;
-        private readonly FilePathNormalizer _filePathNormalizer;
 
-        public ComponentAccessibilityCodeActionProvider(
-            TagHelperFactsService tagHelperFactsService,
-            FilePathNormalizer filePathNormalizer)
+        public ComponentAccessibilityCodeActionProvider(TagHelperFactsService tagHelperFactsService)
         {
             _tagHelperFactsService = tagHelperFactsService ?? throw new ArgumentNullException(nameof(tagHelperFactsService));
-            _filePathNormalizer = filePathNormalizer ?? throw new ArgumentNullException(nameof(filePathNormalizer));
         }
 
         public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
@@ -99,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             }
 
             var path = context.Request.TextDocument.Uri.GetAbsoluteOrUNCPath();
-            path = _filePathNormalizer.Normalize(path);
+            path = FilePathNormalizer.Normalize(path);
             var newComponentPath = Path.Combine(Path.GetDirectoryName(path), $"{startTag.Name.Content}.razor");
             if (File.Exists(newComponentPath))
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -28,14 +28,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
     internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
     {
         private readonly DocumentContextFactory _documentContextFactory;
-        private readonly FilePathNormalizer _filePathNormalizer;
 
-        public ExtractToCodeBehindCodeActionResolver(
-            DocumentContextFactory documentContextFactory,
-            FilePathNormalizer filePathNormalizer)
+        public ExtractToCodeBehindCodeActionResolver(DocumentContextFactory documentContextFactory)
         {
             _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
-            _filePathNormalizer = filePathNormalizer ?? throw new ArgumentNullException(nameof(filePathNormalizer));
         }
 
         public override string Action => LanguageServerConstants.CodeActions.ExtractToCodeBehindAction;
@@ -53,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 return null;
             }
 
-            var path = _filePathNormalizer.Normalize(actionParams.Uri.GetAbsoluteOrUNCPath());
+            var path = FilePathNormalizer.Normalize(actionParams.Uri.GetAbsoluteOrUNCPath());
 
             var documentContext = await _documentContextFactory.TryCreateAsync(actionParams.Uri, cancellationToken).ConfigureAwait(false);
             if (documentContext is null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultProjectSnapshotManagerAccessor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.Options;
@@ -14,7 +13,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
         private readonly IEnumerable<ProjectSnapshotChangeTrigger> _changeTriggers;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
         private readonly AdhocWorkspaceFactory _workspaceFactory;
         private ProjectSnapshotManagerBase? _instance;
@@ -23,7 +21,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public DefaultProjectSnapshotManagerAccessor(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
             IEnumerable<ProjectSnapshotChangeTrigger> changeTriggers,
-            FilePathNormalizer filePathNormalizer,
             IOptionsMonitor<RazorLSPOptions> optionsMonitor,
             AdhocWorkspaceFactory workspaceFactory)
         {
@@ -35,11 +32,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (changeTriggers is null)
             {
                 throw new ArgumentNullException(nameof(changeTriggers));
-            }
-
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
             }
 
             if (optionsMonitor is null)
@@ -54,7 +46,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
             _changeTriggers = changeTriggers;
-            _filePathNormalizer = filePathNormalizer;
             _optionsMonitor = optionsMonitor;
             _workspaceFactory = workspaceFactory;
         }
@@ -68,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                     var workspace = _workspaceFactory.Create(
                         workspaceServices: new[]
                         {
-                            new RemoteProjectSnapshotProjectEngineFactory(_filePathNormalizer, _optionsMonitor)
+                            new RemoteProjectSnapshotProjectEngineFactory(_optionsMonitor)
                         });
                     _instance = new DefaultProjectSnapshotManager(
                         _projectSnapshotManagerDispatcher,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -18,7 +18,6 @@ using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
-using Microsoft.CommonLanguageServerProtocol.Framework.Handlers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.Editor.Razor;
@@ -161,7 +160,6 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<GeneratedDocumentPublisher, DefaultGeneratedDocumentPublisher>();
         services.AddSingleton<ProjectSnapshotChangeTrigger>((services) => services.GetRequiredService<GeneratedDocumentPublisher>());
         services.AddSingleton<DocumentContextFactory, DefaultDocumentContextFactory>();
-        services.AddSingleton<FilePathNormalizer>();
 
         services.AddSingleton<DocumentVersionCache, DefaultDocumentVersionCache>();
         services.AddSingleton<ProjectSnapshotChangeTrigger>((services) => services.GetRequiredService<DocumentVersionCache>());

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
@@ -25,13 +25,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
         private const string MarkerId = "RazorMarker";
 
         private readonly RazorDocumentMappingService _documentMappingService;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly ClientNotifierServiceBase _server;
 
         public CSharpFormatter(
             RazorDocumentMappingService documentMappingService,
-            ClientNotifierServiceBase languageServer,
-            FilePathNormalizer filePathNormalizer)
+            ClientNotifierServiceBase languageServer)
         {
             if (documentMappingService is null)
             {
@@ -43,14 +41,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                 throw new ArgumentNullException(nameof(languageServer));
             }
 
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
-            }
-
             _documentMappingService = documentMappingService;
             _server = languageServer;
-            _filePathNormalizer = filePathNormalizer;
         }
 
         public async Task<TextEdit[]> FormatAsync(
@@ -120,7 +112,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 Kind = RazorLanguageKind.CSharp,
                 ProjectedRange = projectedRange,
-                HostDocumentFilePath = _filePathNormalizer.Normalize(context.Uri.GetAbsoluteOrUNCPath()),
+                HostDocumentFilePath = FilePathNormalizer.Normalize(context.Uri.GetAbsoluteOrUNCPath()),
                 Options = context.Options
             };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.Extensions.Logging;
@@ -22,10 +21,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public CSharpFormattingPass(
             RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
             ClientNotifierServiceBase server,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, filePathNormalizer, server)
+            : base(documentMappingService, server)
         {
             if (loggerFactory is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
@@ -20,10 +19,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal abstract class CSharpFormattingPassBase : FormattingPassBase
     {
-        protected CSharpFormattingPassBase(RazorDocumentMappingService documentMappingService, FilePathNormalizer filePathNormalizer, ClientNotifierServiceBase server)
-            : base(documentMappingService, filePathNormalizer, server)
+        protected CSharpFormattingPassBase(RazorDocumentMappingService documentMappingService, ClientNotifierServiceBase server)
+            : base(documentMappingService, server)
         {
-            CSharpFormatter = new CSharpFormatter(documentMappingService, server, filePathNormalizer);
+            CSharpFormatter = new CSharpFormatter(documentMappingService, server);
         }
 
         protected CSharpFormatter CSharpFormatter { get; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis;
@@ -32,10 +31,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public CSharpOnTypeFormattingPass(
             RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
             ClientNotifierServiceBase server,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, filePathNormalizer, server)
+            : base(documentMappingService, server)
         {
             if (loggerFactory is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.Extensions.Logging;
@@ -20,10 +19,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public FormattingContentValidationPass(
             RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
             ClientNotifierServiceBase server,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, filePathNormalizer, server)
+            : base(documentMappingService, server)
         {
             if (loggerFactory is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.Extensions.Logging;
@@ -22,10 +21,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public FormattingDiagnosticValidationPass(
             RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
             ClientNotifierServiceBase server,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, filePathNormalizer, server)
+            : base(documentMappingService, server)
         {
             if (loggerFactory is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -18,17 +17,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public FormattingPassBase(
             RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
             ClientNotifierServiceBase server)
         {
             if (documentMappingService is null)
             {
                 throw new ArgumentNullException(nameof(documentMappingService));
-            }
-
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
             }
 
             if (server is null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             var @params = new VersionedDocumentFormattingParams()
             {
                 TextDocument = new TextDocumentIdentifier {
-                    Uri = FilePathNormalizer.Instance.Normalize(context.Uri),
+                    Uri = FilePathNormalizer.Normalize(context.Uri),
                 },
                 HostDocumentVersion = documentVersion.Value,
                 Options = context.Options
@@ -70,13 +70,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             {
                 Position = new Position(line, col),
                 Character = context.TriggerCharacter.ToString(),
-                TextDocument = new TextDocumentIdentifier { Uri = FilePathNormalizer.Instance.Normalize(context.Uri) },
+                TextDocument = new TextDocumentIdentifier { Uri = FilePathNormalizer.Normalize(context.Uri) },
                 Options = context.Options,
                 HostDocumentVersion = documentVersion.Value,
             };
 
             var result = await _server.SendRequestAsync<RazorDocumentOnTypeFormattingParams, RazorDocumentFormattingResponse?>(
-                Common.LanguageServerConstants.RazorDocumentOnTypeFormattingEndpoint,
+                LanguageServerConstants.RazorDocumentOnTypeFormattingEndpoint,
                 @params,
                 cancellationToken);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Text;
@@ -25,11 +24,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public HtmlFormattingPass(
             RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
             ClientNotifierServiceBase server,
             DocumentVersionCache documentVersionCache,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, filePathNormalizer, server)
+            : base(documentMappingService, server)
         {
             if (loggerFactory is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -22,10 +21,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
         public RazorFormattingPass(
             RazorDocumentMappingService documentMappingService,
-            FilePathNormalizer filePathNormalizer,
             ClientNotifierServiceBase server,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, filePathNormalizer, server)
+            : base(documentMappingService, server)
         {
             if (loggerFactory is null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MonitorProjectConfigurationFilePathEndpoint.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal class MonitorProjectConfigurationFilePathEndpoint : IMonitorProjectConfigurationFilePathHandler, IDisposable
     {
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver;
         private readonly IEnumerable<IProjectConfigurationFileChangeListener> _listeners;
         private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
@@ -31,7 +30,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public MonitorProjectConfigurationFilePathEndpoint(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            FilePathNormalizer filePathNormalizer,
             WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
             IEnumerable<IProjectConfigurationFileChangeListener> listeners,
             LanguageServerFeatureOptions languageServerFeatureOptions,
@@ -43,7 +41,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
-            _filePathNormalizer = filePathNormalizer;
             _workspaceDirectoryPathResolver = workspaceDirectoryPathResolver;
             _listeners = listeners;
             _languageServerFeatureOptions = languageServerFeatureOptions;
@@ -82,9 +79,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             var configurationDirectory = Path.GetDirectoryName(request.ConfigurationFilePath);
-            var normalizedConfigurationDirectory = _filePathNormalizer.NormalizeDirectory(configurationDirectory);
+            var normalizedConfigurationDirectory = FilePathNormalizer.NormalizeDirectory(configurationDirectory);
             var workspaceDirectory = _workspaceDirectoryPathResolver.Resolve();
-            var normalizedWorkspaceDirectory = _filePathNormalizer.NormalizeDirectory(workspaceDirectory);
+            var normalizedWorkspaceDirectory = FilePathNormalizer.NormalizeDirectory(workspaceDirectory);
 
             var previousMonitorExists = _outputPathMonitors.TryGetValue(request.ProjectFilePath, out var entry);
 
@@ -191,7 +188,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         // Protected virtual for testing
         protected virtual IFileChangeDetector CreateFileChangeDetector() => new ProjectConfigurationFileChangeDetector(
             _projectSnapshotManagerDispatcher,
-            _filePathNormalizer,
             _listeners,
             _languageServerFeatureOptions);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeDetector.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal class ProjectConfigurationFileChangeDetector : IFileChangeDetector
     {
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly IEnumerable<IProjectConfigurationFileChangeListener> _listeners;
         private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
         private readonly ILogger? _logger;
@@ -31,7 +30,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public ProjectConfigurationFileChangeDetector(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            FilePathNormalizer filePathNormalizer,
             IEnumerable<IProjectConfigurationFileChangeListener> listeners,
             LanguageServerFeatureOptions languageServerFeatureOptions,
             ILoggerFactory? loggerFactory = null)
@@ -39,11 +37,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             if (projectSnapshotManagerDispatcher is null)
             {
                 throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
-            }
-
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
             }
 
             if (listeners is null)
@@ -57,7 +50,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
-            _filePathNormalizer = filePathNormalizer;
             _listeners = listeners;
             _languageServerFeatureOptions = languageServerFeatureOptions;
             _logger = loggerFactory?.CreateLogger<ProjectConfigurationFileChangeDetector>();
@@ -72,7 +64,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Dive through existing project configuration files and fabricate "added" events so listeners can accurately listen to state changes for them.
 
-            workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
+            workspaceDirectory = FilePathNormalizer.Normalize(workspaceDirectory);
             var existingConfigurationFiles = GetExistingConfigurationFiles(workspaceDirectory);
 
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
@@ -72,8 +72,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                         return false;
                     }
 
-                    var normalizedSerializedFilePath = FilePathNormalizer.Instance.Normalize(deserializedProjectRazorJson.SerializedFilePath);
-                    var normalizedDetectedFilePath = FilePathNormalizer.Instance.Normalize(ConfigurationFilePath);
+                    var normalizedSerializedFilePath = FilePathNormalizer.Normalize(deserializedProjectRazorJson.SerializedFilePath);
+                    var normalizedDetectedFilePath = FilePathNormalizer.Normalize(ConfigurationFilePath);
                     if (string.Equals(normalizedSerializedFilePath, normalizedDetectedFilePath, FilePathComparison.Instance))
                     {
                         _projectRazorJson = deserializedProjectRazorJson;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectFileChangeDetector.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         private const string ProjectFileExtension = ".csproj";
         private const string ProjectFileExtensionPattern = "*" + ProjectFileExtension;
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly IEnumerable<IProjectFileChangeListener> _listeners;
         private FileSystemWatcher? _watcher;
 
@@ -29,17 +28,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public ProjectFileChangeDetector(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            FilePathNormalizer filePathNormalizer,
             IEnumerable<IProjectFileChangeListener> listeners)
         {
             if (projectSnapshotManagerDispatcher is null)
             {
                 throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
-            }
-
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
             }
 
             if (listeners is null)
@@ -48,7 +41,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
-            _filePathNormalizer = filePathNormalizer;
             _listeners = listeners;
         }
 
@@ -61,7 +53,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Dive through existing project files and fabricate "added" events so listeners can accurately listen to state changes for them.
 
-            workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
+            workspaceDirectory = FilePathNormalizer.Normalize(workspaceDirectory);
             var existingProjectFiles = GetExistingProjectFiles(workspaceDirectory);
 
             await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultDocumentResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultDocumentResolver.cs
@@ -13,12 +13,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
     {
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
         private readonly ProjectResolver _projectResolver;
-        private readonly FilePathNormalizer _filePathNormalizer;
 
         public DefaultDocumentResolver(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            ProjectResolver projectResolver,
-            FilePathNormalizer filePathNormalizer)
+            ProjectResolver projectResolver)
         {
             if (projectSnapshotManagerDispatcher is null)
             {
@@ -30,21 +28,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                 throw new ArgumentNullException(nameof(projectResolver));
             }
 
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
-            }
-
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
             _projectResolver = projectResolver;
-            _filePathNormalizer = filePathNormalizer;
         }
 
         public override bool TryResolveDocument(string documentFilePath, [NotNullWhen(true)] out DocumentSnapshot? document)
         {
             _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-            var normalizedPath = _filePathNormalizer.Normalize(documentFilePath);
+            var normalizedPath = FilePathNormalizer.Normalize(documentFilePath);
             if (!_projectResolver.TryResolveProject(normalizedPath, out var project))
             {
                 // Neither the potential project determined by file path,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultProjectResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultProjectResolver.cs
@@ -16,22 +16,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
         protected internal readonly HostProject MiscellaneousHostProject;
 
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly ProjectSnapshotManagerAccessor _projectSnapshotManagerAccessor;
 
         public DefaultProjectResolver(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            FilePathNormalizer filePathNormalizer,
             ProjectSnapshotManagerAccessor projectSnapshotManagerAccessor)
         {
             if (projectSnapshotManagerDispatcher is null)
             {
                 throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
-            }
-
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
             }
 
             if (projectSnapshotManagerAccessor is null)
@@ -40,7 +33,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
             }
 
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
-            _filePathNormalizer = filePathNormalizer;
             _projectSnapshotManagerAccessor = projectSnapshotManagerAccessor;
 
             var miscellaneousProjectPath = Path.Combine(TempDirectory.Instance.DirectoryPath, "__MISC_RAZOR_PROJECT__");
@@ -56,7 +48,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
 
             _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-            var normalizedDocumentPath = _filePathNormalizer.Normalize(documentFilePath);
+            var normalizedDocumentPath = FilePathNormalizer.Normalize(documentFilePath);
             var projects = _projectSnapshotManagerAccessor.Instance.Projects;
             for (var i = 0; i < projects.Count; i++)
             {
@@ -73,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem
                     continue;
                 }
 
-                var projectDirectory = _filePathNormalizer.GetDirectory(projectSnapshot.FilePath);
+                var projectDirectory = FilePathNormalizer.GetDirectory(projectSnapshot.FilePath);
                 if (normalizedDocumentPath.StartsWith(projectDirectory, FilePathComparison.Instance) &&
                     (!enforceDocumentInProject || IsDocumentInProject(projectSnapshot, documentFilePath)))
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         internal readonly Dictionary<string, DelayedFileChangeNotification> PendingNotifications;
 
         private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly IEnumerable<IRazorFileChangeListener> _listeners;
         private readonly List<FileSystemWatcher> _watchers;
         private readonly object _pendingNotificationsLock = new();
@@ -33,17 +32,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         public RazorFileChangeDetector(
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-            FilePathNormalizer filePathNormalizer,
             IEnumerable<IRazorFileChangeListener> listeners)
         {
             if (projectSnapshotManagerDispatcher is null)
             {
                 throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
-            }
-
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
             }
 
             if (listeners is null)
@@ -52,7 +45,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
 
             _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
-            _filePathNormalizer = filePathNormalizer;
             _listeners = listeners;
             _watchers = new List<FileSystemWatcher>(s_razorFileExtensions.Count);
             PendingNotifications = new Dictionary<string, DelayedFileChangeNotification>(FilePathComparer.Instance);
@@ -76,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             // Dive through existing Razor files and fabricate "added" events so listeners can accurately listen to state changes for them.
 
-            workspaceDirectory = _filePathNormalizer.Normalize(workspaceDirectory);
+            workspaceDirectory = FilePathNormalizer.Normalize(workspaceDirectory);
 
             var existingRazorFiles = GetExistingRazorFiles(workspaceDirectory);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteProjectSnapshotProjectEngineFactory.cs
@@ -14,23 +14,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     {
         public static readonly IFallbackProjectEngineFactory FallbackProjectEngineFactory = new FallbackProjectEngineFactory();
 
-        private readonly FilePathNormalizer _filePathNormalizer;
         private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
 
-        public RemoteProjectSnapshotProjectEngineFactory(FilePathNormalizer filePathNormalizer, IOptionsMonitor<RazorLSPOptions> optionsMonitor)
+        public RemoteProjectSnapshotProjectEngineFactory(IOptionsMonitor<RazorLSPOptions> optionsMonitor)
             : base(FallbackProjectEngineFactory, ProjectEngineFactories.Factories)
         {
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
-            }
-
             if (optionsMonitor is null)
             {
                 throw new ArgumentNullException(nameof(optionsMonitor));
             }
 
-            _filePathNormalizer = filePathNormalizer;
             _optionsMonitor = optionsMonitor;
         }
 
@@ -39,13 +32,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             RazorProjectFileSystem fileSystem,
             Action<RazorProjectEngineBuilder> configure)
         {
-            if (!(fileSystem is DefaultRazorProjectFileSystem defaultFileSystem))
+            if (fileSystem is not DefaultRazorProjectFileSystem defaultFileSystem)
             {
                 Debug.Fail("Unexpected file system.");
                 return null;
             }
 
-            var remoteFileSystem = new RemoteRazorProjectFileSystem(defaultFileSystem.Root, _filePathNormalizer);
+            var remoteFileSystem = new RemoteRazorProjectFileSystem(defaultFileSystem.Root);
             return base.Create(configuration, remoteFileSystem, Configure);
 
             void Configure(RazorProjectEngineBuilder builder)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RemoteRazorProjectFileSystem.cs
@@ -14,25 +14,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
     internal class RemoteRazorProjectFileSystem : RazorProjectFileSystem
     {
         private readonly string _root;
-        private readonly FilePathNormalizer _filePathNormalizer;
 
-        public RemoteRazorProjectFileSystem(
-            string root,
-            FilePathNormalizer filePathNormalizer)
+        public RemoteRazorProjectFileSystem(string root)
         {
             if (root is null)
             {
                 throw new ArgumentNullException(nameof(root));
             }
 
-            if (filePathNormalizer is null)
-            {
-                throw new ArgumentNullException(nameof(filePathNormalizer));
-            }
-
-            _root = filePathNormalizer.NormalizeDirectory(root);
-
-            _filePathNormalizer = filePathNormalizer;
+            _root = FilePathNormalizer.NormalizeDirectory(root);
         }
 
         public override IEnumerable<RazorProjectItem> EnumerateItems(string basePath)
@@ -87,7 +77,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 absolutePath = _root + path;
             }
 
-            absolutePath = _filePathNormalizer.Normalize(absolutePath);
+            absolutePath = FilePathNormalizer.Normalize(absolutePath);
             return absolutePath;
 
             static bool IsPathRootedForPlatform(string path)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/OmniSharpStrongNamedExports.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/OmniSharpStrongNamedExports.cs
@@ -17,12 +17,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     // named plugin assembly.
 
     [Shared]
-    [Export(typeof(FilePathNormalizer))]
-    public class ExportedFilePathNormalizer : FilePathNormalizer
-    {
-    }
-
-    [Shared]
     [Export(typeof(OmniSharpProjectSnapshotManagerDispatcher))]
     internal class ExportOmniSharpProjectSnapshotManagerDispatcher : DefaultOmniSharpProjectSnapshotManagerDispatcher
     {
@@ -32,10 +26,6 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
     [Export(typeof(RemoteTextLoaderFactory))]
     internal class ExportRemoteTextLoaderFactory : DefaultRemoteTextLoaderFactory
     {
-        [ImportingConstructor]
-        public ExportRemoteTextLoaderFactory(FilePathNormalizer filePathNormalizer) : base(filePathNormalizer)
-        {
-        }
     }
 
     [Shared]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Common.Test/FilePathNormalizerTest.cs
@@ -20,11 +20,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void Normalize_Windows_StripsPrecedingSlash()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var path = "/c:/path/to/something";
 
             // Act
-            path = filePathNormalizer.Normalize(path);
+            path = FilePathNormalizer.Normalize(path);
 
             // Assert
             Assert.Equal("c:/path/to/something", path);
@@ -34,11 +33,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void Normalize_IgnoresUNCPaths()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var path = "//ComputerName/path/to/something";
 
             // Act
-            path = filePathNormalizer.Normalize(path);
+            path = FilePathNormalizer.Normalize(path);
 
             // Assert
             Assert.Equal("//ComputerName/path/to/something", path);
@@ -48,11 +46,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void NormalizeDirectory_EndsWithSlash()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var directory = "C:\\path\\to\\directory\\";
 
             // Act
-            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+            var normalized = FilePathNormalizer.NormalizeDirectory(directory);
 
             // Assert
             Assert.Equal("C:/path/to/directory/", normalized);
@@ -62,11 +59,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void NormalizeDirectory_EndsWithoutSlash()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var directory = "C:\\path\\to\\directory";
 
             // Act
-            var normalized = filePathNormalizer.NormalizeDirectory(directory);
+            var normalized = FilePathNormalizer.NormalizeDirectory(directory);
 
             // Assert
             Assert.Equal("C:/path/to/directory/", normalized);
@@ -76,12 +72,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void FilePathsEquivalent_NotEqualPaths_ReturnsFalse()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath1 = "path/to/document.cshtml";
             var filePath2 = "path\\to\\different\\document.cshtml";
 
             // Act
-            var result = filePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
+            var result = FilePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
 
             // Assert
             Assert.False(result);
@@ -91,12 +86,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void FilePathsEquivalent_NormalizesPathsBeforeComparison_ReturnsTrue()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath1 = "path/to/document.cshtml";
             var filePath2 = "path\\to\\document.cshtml";
 
             // Act
-            var result = filePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
+            var result = FilePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
 
             // Assert
             Assert.True(result);
@@ -106,11 +100,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void GetDirectory_IncludesTrailingSlash()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath = "C:/path/to/document.cshtml";
 
             // Act
-            var normalized = filePathNormalizer.GetDirectory(filePath);
+            var normalized = FilePathNormalizer.GetDirectory(filePath);
 
             // Assert
             Assert.Equal("C:/path/to/", normalized);
@@ -120,11 +113,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void GetDirectory_NoDirectory_ReturnsRoot()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath = "C:/document.cshtml";
 
             // Act
-            var normalized = filePathNormalizer.GetDirectory(filePath);
+            var normalized = FilePathNormalizer.GetDirectory(filePath);
 
             // Assert
             Assert.Equal("C:/", normalized);
@@ -133,11 +125,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         [Fact]
         public void Normalize_NullFilePath_ReturnsForwardSlash()
         {
-            // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
-
             // Act
-            var normalized = filePathNormalizer.Normalize((string)null);
+            var normalized = FilePathNormalizer.Normalize((string)null);
 
             // Assert
             Assert.Equal("/", normalized);
@@ -146,11 +135,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         [Fact]
         public void Normalize_EmptyFilePath_ReturnsEmptyString()
         {
-            // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
-
             // Act
-            var normalized = filePathNormalizer.Normalize(string.Empty);
+            var normalized = FilePathNormalizer.Normalize(string.Empty);
 
             // Assert
             Assert.Equal("/", normalized);
@@ -160,11 +146,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void Normalize_NonWindows_AddsLeadingForwardSlash()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath = "path/to/document.cshtml";
 
             // Act
-            var normalized = filePathNormalizer.Normalize(filePath);
+            var normalized = FilePathNormalizer.Normalize(filePath);
 
             // Assert
             Assert.Equal("/path/to/document.cshtml", normalized);
@@ -174,11 +159,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void Normalize_UrlDecodesFilePath()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath = "C:/path%20to/document.cshtml";
 
             // Act
-            var normalized = filePathNormalizer.Normalize(filePath);
+            var normalized = FilePathNormalizer.Normalize(filePath);
 
             // Assert
             Assert.Equal("C:/path to/document.cshtml", normalized);
@@ -188,12 +172,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void Normalize_UrlDecodesOnlyOnce()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath = "C:/path%2Bto/document.cshtml";
 
             // Act
-            var normalized = filePathNormalizer.Normalize(filePath);
-            normalized = filePathNormalizer.Normalize(normalized);
+            var normalized = FilePathNormalizer.Normalize(filePath);
+            normalized = FilePathNormalizer.Normalize(normalized);
 
             // Assert
             Assert.Equal("C:/path+to/document.cshtml", normalized);
@@ -203,11 +186,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common
         public void Normalize_ReplacesBackSlashesWithForwardSlashes()
         {
             // Arrange
-            var filePathNormalizer = new FilePathNormalizer();
             var filePath = "C:\\path\\to\\document.cshtml";
 
             // Act
-            var normalized = filePathNormalizer.Normalize(filePath);
+            var normalized = FilePathNormalizer.Normalize(filePath);
 
             // Assert
             Assert.Equal("C:/path/to/document.cshtml", normalized);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
@@ -38,7 +37,6 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
         // the opportunity to re-write our tests correctly.
         private protected ProjectSnapshotManagerDispatcher LegacyDispatcher { get; }
         private protected ProjectSnapshotManagerDispatcher Dispatcher { get; }
-        protected FilePathNormalizer FilePathNormalizer { get; }
         private protected IRazorSpanMappingService SpanMappingService { get; }
 
         protected JsonSerializer Serializer { get; }
@@ -53,7 +51,6 @@ namespace Microsoft.AspNetCore.Razor.Test.Common
             Dispatcher = new LSPProjectSnapshotManagerDispatcher(LoggerFactory);
             AddDisposable((IDisposable)Dispatcher);
 
-            FilePathNormalizer = new FilePathNormalizer();
             SpanMappingService = new ThrowingRazorSpanMappingService();
 
             Serializer = new JsonSerializer();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(1, -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(0, 1));
 
-            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService());
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(0, 0));
             context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService());
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(0, -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(contents.IndexOf("Component", StringComparison.Ordinal), 9));
 
-            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService());
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(1, -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(contents.IndexOf("Component", StringComparison.Ordinal), 9), supportsFileCreation: true);
 
-            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService());
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(1, -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(contents.IndexOf("Component", StringComparison.Ordinal), 9), supportsFileCreation: true);
 
-            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService());
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(1, -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(contents.IndexOf("Component", StringComparison.Ordinal), 9), supportsFileCreation: false);
 
-            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService());
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(1, -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(contents.IndexOf("Component", StringComparison.Ordinal), 9), supportsFileCreation: false);
 
-            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService(), FilePathNormalizer);
+            var provider = new ComponentAccessibilityCodeActionProvider(new DefaultTagHelperFactsService());
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
         public async Task Handle_MissingFile()
         {
             // Arrange
-            var resolver = new ExtractToCodeBehindCodeActionResolver(_emptyDocumentContextFactory, FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(_emptyDocumentContextFactory);
             var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             codeDocument.SetUnsupported();
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
             var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             codeDocument.SetFileKind(FileKinds.Legacy);
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
             var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
             {
                 Uri = new Uri("c:/Test.razor"),
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
             var actionParams = new ExtractToCodeBehindCodeActionParams
             {
                 Uri = documentPath,
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
             var actionParams = new ExtractToCodeBehindCodeActionParams
             {
                 Uri = documentPath,
@@ -218,7 +218,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var codeDocument = CreateCodeDocument(contents);
             Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), FilePathNormalizer);
+            var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
             var actionParams = new ExtractToCodeBehindCodeActionParams
             {
                 Uri = documentPath,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentResolverTest.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -27,11 +26,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentFilePath = @"C:\path\to\document.cshtml";
             var normalizedFilePath = "C:/path/to/document.cshtml";
-            var filePathNormalizer = new FilePathNormalizer();
             var expectedDocument = Mock.Of<DocumentSnapshot>(MockBehavior.Strict);
             var project = Mock.Of<ProjectSnapshot>(shim => shim.GetDocument(normalizedFilePath) == expectedDocument, MockBehavior.Strict);
             var projectResolver = Mock.Of<ProjectResolver>(resolver => resolver.TryResolveProject(normalizedFilePath, out project, true) == true, MockBehavior.Strict);
-            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver, filePathNormalizer);
+            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver);
 
             // Act
             var result = documentResolver.TryResolveDocument(documentFilePath, out var document);
@@ -47,11 +45,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentFilePath = @"C:\path\to\document.cshtml";
             var normalizedFilePath = "C:/path/to/document.cshtml";
-            var filePathNormalizer = new FilePathNormalizer();
             var expectedDocument = Mock.Of<DocumentSnapshot>(MockBehavior.Strict);
             var project = Mock.Of<ProjectSnapshot>(shim => shim.GetDocument(normalizedFilePath) == expectedDocument, MockBehavior.Strict);
             var projectResolver = Mock.Of<ProjectResolver>(resolver => resolver.TryResolveProject(normalizedFilePath, out project, true) == true, MockBehavior.Strict);
-            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver, filePathNormalizer);
+            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver);
 
             // Act
             var result = documentResolver.TryResolveDocument(documentFilePath, out var document);
@@ -67,13 +64,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentFilePath = @"C:\path\to\document.cshtml";
             var normalizedFilePath = "C:/path/to/document.cshtml";
-            var filePathNormalizer = new FilePathNormalizer();
             var project = Mock.Of<ProjectSnapshot>(shim => shim.DocumentFilePaths == Array.Empty<string>(), MockBehavior.Strict);
             var miscProject = Mock.Of<ProjectSnapshot>(shim => shim.DocumentFilePaths == Array.Empty<string>(), MockBehavior.Strict);
             ProjectSnapshot noProject = null;
             var projectResolver = Mock.Of<ProjectResolver>(resolver =>
                 resolver.TryResolveProject(normalizedFilePath, out noProject, true) == false, MockBehavior.Strict);
-            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver, filePathNormalizer);
+            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver);
 
             // Act
             var result = documentResolver.TryResolveDocument(documentFilePath, out var document);
@@ -89,13 +85,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             var documentFilePath = @"C:\path\to\document.cshtml";
             var normalizedFilePath = "C:/path/to/document.cshtml";
-            var filePathNormalizer = new FilePathNormalizer();
             var expectedDocument = Mock.Of<DocumentSnapshot>(MockBehavior.Strict);
             var project = Mock.Of<ProjectSnapshot>(shim => shim.DocumentFilePaths == Array.Empty<string>(), MockBehavior.Strict);
             var miscProject = Mock.Of<ProjectSnapshot>(shim => shim.GetDocument(normalizedFilePath) == expectedDocument, MockBehavior.Strict);
             var projectResolver = Mock.Of<ProjectResolver>(resolver =>
                 resolver.TryResolveProject(normalizedFilePath, out miscProject, true) == true, MockBehavior.Strict);
-            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver, filePathNormalizer);
+            var documentResolver = new DefaultDocumentResolver(LegacyDispatcher, projectResolver);
 
             // Act
             var result = documentResolver.TryResolveDocument(documentFilePath, out var document);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultProjectResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultProjectResolverTest.cs
@@ -205,7 +205,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             // Arrange
             DefaultProjectResolver projectResolver = null;
             var projects = new List<ProjectSnapshot>();
-            var filePathNormalizer = new FilePathNormalizer();
             var snapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             snapshotManager.Setup(manager => manager.Projects)
                 .Returns(() => projects);
@@ -214,7 +213,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             snapshotManager.Setup(manager => manager.ProjectAdded(It.IsAny<HostProject>()))
                 .Callback<HostProject>(hostProject => projects.Add(Mock.Of<ProjectSnapshot>(p => p.FilePath == hostProject.FilePath, MockBehavior.Strict)));
             var snapshotManagerAccessor = Mock.Of<ProjectSnapshotManagerAccessor>(accessor => accessor.Instance == snapshotManager.Object, MockBehavior.Strict);
-            projectResolver = new DefaultProjectResolver(LegacyDispatcher, filePathNormalizer, snapshotManagerAccessor);
+            projectResolver = new DefaultProjectResolver(LegacyDispatcher, snapshotManagerAccessor);
 
             // Act
             var project = projectResolver.GetMiscellaneousProject();
@@ -226,14 +225,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         private DefaultProjectResolver CreateProjectResolver(Func<ProjectSnapshot[]> projectFactory)
         {
-            var filePathNormalizer = new FilePathNormalizer();
             var snapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             snapshotManager.Setup(manager => manager.Projects)
                 .Returns(projectFactory);
             snapshotManager.Setup(manager => manager.GetLoadedProject(It.IsAny<string>()))
                 .Returns<string>(filePath => projectFactory().FirstOrDefault(project => project.FilePath == filePath));
             var snapshotManagerAccessor = Mock.Of<ProjectSnapshotManagerAccessor>(accessor => accessor.Instance == snapshotManager.Object, MockBehavior.Strict);
-            var projectResolver = new DefaultProjectResolver(LegacyDispatcher, filePathNormalizer, snapshotManagerAccessor);
+            var projectResolver = new DefaultProjectResolver(LegacyDispatcher, snapshotManagerAccessor);
 
             return projectResolver;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -983,7 +983,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 Mock.Get(documentVersionCache).Setup(c => c.TrackDocumentVersion(It.IsAny<DocumentSnapshot>(), It.IsAny<int>())).Verifiable();
             }
 
-            var filePathNormalizer = new FilePathNormalizer();
             var accessor = Mock.Of<ProjectSnapshotManagerAccessor>(a => a.Instance == projectSnapshotManager, MockBehavior.Strict);
             if (documentResolver is null)
             {
@@ -998,7 +997,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 documentResolver,
                 projectResolver,
                 documentVersionCache,
-                filePathNormalizer,
                 accessor,
                 LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingContentValidationPassTest.cs
@@ -127,7 +127,7 @@ public class Foo { }
             var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
 
             var client = Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict);
-            var pass = new FormattingContentValidationPass(mappingService, FilePathNormalizer, client, LoggerFactory)
+            var pass = new FormattingContentValidationPass(mappingService, client, LoggerFactory)
             {
                 DebugAssertsEnabled = false
             };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingDiagnosticValidationPassTest.cs
@@ -134,7 +134,7 @@ public class Foo { }
             var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
 
             var client = Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict);
-            var pass = new FormattingDiagnosticValidationPass(mappingService, FilePathNormalizer, client, LoggerFactory)
+            var pass = new FormattingDiagnosticValidationPass(mappingService, client, LoggerFactory)
             {
                 DebugAssertsEnabled = false
             };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerClient.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerClient.cs
@@ -38,14 +38,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 {
     internal class FormattingLanguageServerClient : ClientNotifierServiceBase
     {
-        private readonly FilePathNormalizer _filePathNormalizer = new FilePathNormalizer();
         private readonly Dictionary<string, RazorCodeDocument> _documents = new Dictionary<string, RazorCodeDocument>();
 
         public InitializeResult ServerSettings => throw new NotImplementedException();
 
         public void AddCodeDocument(RazorCodeDocument codeDocument)
         {
-            var path = _filePathNormalizer.Normalize(codeDocument.Source.FilePath);
+            var path = FilePathNormalizer.Normalize(codeDocument.Source.FilePath);
             _documents.TryAdd("/" + path, codeDocument);
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
@@ -47,14 +46,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             : base(testOutput)
         {
             TestProjectPath = GetProjectDirectory();
-            FilePathNormalizer = new FilePathNormalizer();
 
             ILoggerExtensions.TestOnlyLoggingEnabled = true;
         }
 
         public static string? TestProjectPath { get; private set; }
-
-        protected FilePathNormalizer FilePathNormalizer { get; }
 
         // Used by the test framework to set the 'base' name for test files.
         public static string FileName

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/TestRazorFormattingService.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -45,12 +44,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
 
             var passes = new List<IFormattingPass>()
             {
-                new HtmlFormattingPass(mappingService, FilePathNormalizer.Instance, client, versionCache, loggerFactory),
-                new CSharpFormattingPass(mappingService, FilePathNormalizer.Instance, client, loggerFactory),
-                new CSharpOnTypeFormattingPass(mappingService, FilePathNormalizer.Instance, client, loggerFactory),
-                new RazorFormattingPass(mappingService, FilePathNormalizer.Instance, client, loggerFactory),
-                new FormattingDiagnosticValidationPass(mappingService, FilePathNormalizer.Instance, client, loggerFactory),
-                new FormattingContentValidationPass(mappingService, FilePathNormalizer.Instance, client, loggerFactory),
+                new HtmlFormattingPass(mappingService, client, versionCache, loggerFactory),
+                new CSharpFormattingPass(mappingService, client, loggerFactory),
+                new CSharpOnTypeFormattingPass(mappingService, client, loggerFactory),
+                new RazorFormattingPass(mappingService, client, loggerFactory),
+                new FormattingDiagnosticValidationPass(mappingService, client, loggerFactory),
+                new FormattingContentValidationPass(mappingService, client, loggerFactory),
             };
 
             return new DefaultRazorFormattingService(passes, loggerFactory, TestAdhocWorkspaceFactory.Instance);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -39,7 +39,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Throws<XunitException>();
             var configurationFileEndpoint = new MonitorProjectConfigurationFilePathEndpoint(
                 LegacyDispatcher,
-                FilePathNormalizer,
                 directoryPathResolver.Object,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 TestLanguageServerFeatureOptions.Instance,
@@ -65,7 +64,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 .Throws<XunitException>();
             var configurationFileEndpoint = new MonitorProjectConfigurationFilePathEndpoint(
                 LegacyDispatcher,
-                FilePathNormalizer,
                 directoryPathResolver.Object,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 TestLanguageServerFeatureOptions.Instance,
@@ -89,7 +87,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
                 () => detector,
                 LegacyDispatcher,
-                FilePathNormalizer,
                 _directoryPathResolver,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 LoggerFactory);
@@ -122,7 +119,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
                 () => detector,
                 LegacyDispatcher,
-                FilePathNormalizer,
                 _directoryPathResolver,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 LoggerFactory);
@@ -148,7 +144,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
                 () => detector,
                 LegacyDispatcher,
-                FilePathNormalizer,
                 _directoryPathResolver,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 LoggerFactory);
@@ -176,7 +171,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
                 () => detector,
                 LegacyDispatcher,
-                FilePathNormalizer,
                 _directoryPathResolver,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 LoggerFactory);
@@ -209,7 +203,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
                 () => detector,
                 LegacyDispatcher,
-                FilePathNormalizer,
                 _directoryPathResolver,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 LoggerFactory);
@@ -246,7 +239,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
                 () => detectors[callCount++],
                 LegacyDispatcher,
-                FilePathNormalizer,
                 _directoryPathResolver,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 LoggerFactory);
@@ -294,7 +286,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
                 () => detectors[callCount++],
                 LegacyDispatcher,
-                FilePathNormalizer,
                 _directoryPathResolver,
                 Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
                 LoggerFactory);
@@ -335,13 +326,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
             public TestMonitorProjectConfigurationFilePathEndpoint(
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-                FilePathNormalizer filePathNormalizer,
                 WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
                 IEnumerable<IProjectConfigurationFileChangeListener> listeners,
-                ILoggerFactory loggerFactory) : this(
+                ILoggerFactory loggerFactory)
+                : this(
                     fileChangeDetectorFactory: null,
                     projectSnapshotManagerDispatcher,
-                    filePathNormalizer,
                     workspaceDirectoryPathResolver,
                     listeners,
                     loggerFactory)
@@ -351,13 +341,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             public TestMonitorProjectConfigurationFilePathEndpoint(
                 Func<IFileChangeDetector> fileChangeDetectorFactory,
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-                FilePathNormalizer filePathNormalizer,
                 WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
                 IEnumerable<IProjectConfigurationFileChangeListener> listeners,
                 ILoggerFactory loggerFactory)
                 : base(
                     projectSnapshotManagerDispatcher,
-                    filePathNormalizer,
                     workspaceDirectoryPathResolver,
                     listeners,
                     TestLanguageServerFeatureOptions.Instance,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
                 IEnumerable<IProjectConfigurationFileChangeListener> listeners,
                 IReadOnlyList<string> existingConfigurationFiles)
-                : base(projectSnapshotManagerDispatcher, new FilePathNormalizer(), listeners, TestLanguageServerFeatureOptions.Instance)
+                : base(projectSnapshotManagerDispatcher, listeners, TestLanguageServerFeatureOptions.Instance)
             {
                 _cancellationTokenSource = cancellationTokenSource;
                 _existingConfigurationFiles = existingConfigurationFiles;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -403,7 +402,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 
         private ProjectConfigurationStateSynchronizer GetSynchronizer(RazorProjectService razorProjectService)
         {
-            var synchronizer = new ProjectConfigurationStateSynchronizer(Dispatcher, razorProjectService, FilePathNormalizer, LoggerFactory);
+            var synchronizer = new ProjectConfigurationStateSynchronizer(Dispatcher, razorProjectService, LoggerFactory);
             synchronizer.EnqueueDelay = 5;
 
             return synchronizer;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectFileChangeDetectorTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
                 IEnumerable<IProjectFileChangeListener> listeners,
                 IReadOnlyList<string> existingprojectFiles)
-                : base(projectSnapshotManagerDispatcher, new FilePathNormalizer(), listeners)
+                : base(projectSnapshotManagerDispatcher, listeners)
             {
                 _cancellationTokenSource = cancellationTokenSource;
                 _existingProjectFiles = existingprojectFiles;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var changeKind = RazorFileChangeKind.Added;
             var listener = new Mock<IRazorFileChangeListener>(MockBehavior.Strict);
             listener.Setup(l => l.RazorFileChanged(filePath, changeKind)).Verifiable();
-            var fileChangeDetector = new RazorFileChangeDetector(Dispatcher, FilePathNormalizer, new[] { listener.Object })
+            var fileChangeDetector = new RazorFileChangeDetector(Dispatcher, new[] { listener.Object })
             {
                 EnqueueDelay = 50,
                 BlockNotificationWorkStart = new ManualResetEventSlim(initialState: false),
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var listenerCalled = false;
             var listener = new Mock<IRazorFileChangeListener>(MockBehavior.Strict);
             listener.Setup(l => l.RazorFileChanged(filePath, It.IsAny<RazorFileChangeKind>())).Callback(() => listenerCalled = true);
-            var fileChangeDetector = new RazorFileChangeDetector(Dispatcher, FilePathNormalizer, new[] { listener.Object })
+            var fileChangeDetector = new RazorFileChangeDetector(Dispatcher, new[] { listener.Object })
             {
                 EnqueueDelay = 10,
                 NotifyNotificationNoop = new ManualResetEventSlim(initialState: false),
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             var listener = new Mock<IRazorFileChangeListener>(MockBehavior.Strict);
             var callCount = 0;
             listener.Setup(l => l.RazorFileChanged(filePath, RazorFileChangeKind.Added)).Callback(() => callCount++);
-            var fileChangeDetector = new RazorFileChangeDetector(Dispatcher, FilePathNormalizer, new[] { listener.Object })
+            var fileChangeDetector = new RazorFileChangeDetector(Dispatcher, new[] { listener.Object })
             {
                 EnqueueDelay = 50,
                 BlockNotificationWorkStart = new ManualResetEventSlim(initialState: false),
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
                 ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
                 IEnumerable<IRazorFileChangeListener> listeners,
                 IReadOnlyList<string> existingprojectFiles)
-                : base(projectSnapshotManagerDispatcher, new FilePathNormalizer(), listeners)
+                : base(projectSnapshotManagerDispatcher, listeners)
             {
                 _cancellationTokenSource = cancellationTokenSource;
                 _existingProjectFiles = existingprojectFiles;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RemoteRazorProjectFileSystemTest.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,19 +11,16 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
 {
     public class RemoteRazorProjectFileSystemTest : TestBase
     {
-        private readonly FilePathNormalizer FilePathNormalizer;
-
         public RemoteRazorProjectFileSystemTest(ITestOutputHelper testOutput)
             : base(testOutput)
         {
-            FilePathNormalizer = new FilePathNormalizer();
         }
 
         [Fact]
         public void GetItem_RootlessFilePath()
         {
             // Arrange
-            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to", FilePathNormalizer);
+            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to");
             var documentFilePath = "file.cshtml";
 
             // Act
@@ -39,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void GetItem_RootedFilePath_BelongsToProject()
         {
             // Arrange
-            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to", FilePathNormalizer);
+            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to");
             var documentFilePath = "C:/path/to/file.cshtml";
 
             // Act
@@ -54,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
         public void GetItem_RootedFilePath_DoesNotBelongToProject()
         {
             // Arrange
-            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to", FilePathNormalizer);
+            var fileSystem = new RemoteRazorProjectFileSystem("C:/path/to");
             var documentFilePath = "C:/otherpath/to/file.cshtml";
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test/OmniSharpTestBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin
             var dispatcher = _dispatcherProperty.GetValue(Dispatcher);
             var testSnapshotManager = _createProjectSnapshotManagerMethod.Invoke(null, new object[] { dispatcher });
             _allowNotifyListenersProperty.SetValue(testSnapshotManager, allowNotifyListeners);
-            var remoteTextLoaderFactory = new DefaultRemoteTextLoaderFactory(new FilePathNormalizer());
+            var remoteTextLoaderFactory = new DefaultRemoteTextLoaderFactory();
             var snapshotManager = (OmniSharpProjectSnapshotManagerBase)_omniSharpProjectSnapshotMangerConstructor.Invoke(new[] { testSnapshotManager, remoteTextLoaderFactory });
 
             return snapshotManager;


### PR DESCRIPTION
`FilePathNormalizer` is defined as a normal class and instances of it are created. However, it's a general utility class with no subtypes that doesn't have any fields. So, it can just be made static, which cleans up a lot of code that was forced to always pass a `FilePathNormalizer` instance.
