### PR TITLE
Publish to Build Asset Registry using specific pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -408,19 +408,19 @@ stages:
             artifactType: Container
             parallel: true
 
-- stage: publishBuildAssets
-  displayName: Publish to Build Asset Registry
-  dependsOn: build
-  jobs:
-    # Publish to Build Asset Registry
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        pool:
-          name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals windows.vs2022.amd64
-
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - stage: publishBuildAssets
+    displayName: Publish to Build Asset Registry
+    dependsOn: build
+    jobs:
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates/job/publish-build-assets.yml
+        parameters:
+          publishUsingPipelines: true
+          pool:
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals windows.vs2022.amd64
+
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       validateDependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,6 @@ stages:
       # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         enableMicrobuild: true
-        enablePublishBuildAssets: true
         enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
       jobs:
       - job: Windows
@@ -409,9 +408,23 @@ stages:
             artifactType: Container
             parallel: true
 
+- stage: publishBuildAssets
+  displayName: Publish to Build Asset Registry
+  dependsOn: build
+  jobs:
+    # Publish to Build Asset Registry
+    - template: /eng/common/templates/job/publish-build-assets.yml
+      parameters:
+        publishUsingPipelines: true
+        pool:
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals windows.vs2022.amd64
+
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
+      validateDependsOn:
+        - publishBuildAssets
       publishingInfraVersion: 3
       enableSigningValidation: false
       enableNugetValidation: false


### PR DESCRIPTION
### Summary of the changes
- The pool used for `Publish to Build Asset Registry` was somehow changed from under us, resulting in our official builds failing. This PR pulls `Publish to Build Asset Registry` into a separate step which allows us to specify the pool. This is similar to what [Roslyn does today](https://github.com/dotnet/roslyn/blob/eb5712232bf1d68a4f34214af32a16a6d4dda52e/azure-pipelines-official.yml#L316) (and is why they're not running into the same issue). Note, Roslyn includes `Publish to Build Asset Registry` as one of their build steps, but due to the different way Razor infra is set up, it was much easier to make it a separate stage.
- An alternate solution would be to track down whoever controls the default pool (maybe arcade?) and ask them for help, but pulling the pool into a separate step gives us more control in the future to ensure something like this won't happen again.
- Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2030241&view=results
