### PR TITLE
Increase wake time for ProcDump CI task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,6 +104,7 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         enableMicrobuild: true
         enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+
       jobs:
       - job: Windows
         timeoutInMinutes: 120
@@ -139,6 +140,7 @@ stages:
                     /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                     /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
                     /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+
         variables:
         - _DotNetPublishToBlobFeed: false
         - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json
@@ -159,27 +161,36 @@ stages:
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
+
         steps:
         - task: NodeTool@0
           displayName: Install Node 10.x
           inputs:
             versionSpec: 10.x
+
         - powershell: npm install -g yarn
           displayName: Install yarn
           condition: succeeded()
+
         - task: NuGetCommand@2
           displayName: 'Clear NuGet caches'
           condition: succeeded()
           inputs:
             command: custom
             arguments: 'locals all -clear'
+
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
           - template: /eng/restore-internal-tools.yml
 
         - powershell: ./eng/scripts/InstallProcDump.ps1
           displayName: Install ProcDump
-        - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1 $(ProcDumpPath)procdump.exe artifacts/log/$(_BuildConfig) (Get-Date).AddMinutes(25) devenv, xunit.console, xunit.console.x86
+
+        - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1
+            $(ProcDumpPath)procdump.exe artifacts/log/$(_BuildConfig)
+            (Get-Date).AddMinutes(60)
+            devenv, xunit.console, xunit.console.x86
           displayName: Start background dump collection
+
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
           - task: PowerShell@2
             displayName: Setup Private Feeds Credentials
@@ -188,6 +199,7 @@ stages:
               arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
         - script: eng\CIBuild.cmd
             -restore
             -build
@@ -203,6 +215,7 @@ stages:
           name: Build
           displayName: Build
           condition: succeeded()
+
         - task: PublishBuildArtifacts@1
           displayName: Upload Build BinLog
           condition: always()
@@ -212,6 +225,7 @@ stages:
               artifactName: $(Agent.Os)_$(Agent.JobName) BuildBinLog
               artifactType: Container
               parallel: true
+
         - script: eng\cibuild.cmd
             -configuration $(_BuildConfig)
             -msbuildEngine vs
@@ -228,6 +242,7 @@ stages:
           name: Build_Vsix
           displayName: Build and Deploy Vsix
           condition: succeeded()
+
         - task: PublishBuildArtifacts@1
           displayName: Upload Build VSIX BinLog
           condition: always()
@@ -237,6 +252,7 @@ stages:
               artifactName: $(Agent.Os)_$(Agent.JobName) BuildVSIXBinLog
               artifactType: Container
               parallel: true
+
         - script: eng\CIBuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
@@ -246,6 +262,7 @@ stages:
           name: Run_Tests
           displayName: Run Unit and Integration tests
           condition: succeeded()
+
         - task: PublishBuildArtifacts@1
           displayName: Upload Run tests BinLog
           condition: always()
@@ -255,10 +272,12 @@ stages:
               artifactName: $(Agent.Os)_$(Agent.JobName) RunTestsBinLog
               artifactType: Container
               parallel: true
+
         - powershell: ./eng/scripts/FinishDumpCollectionForHangingBuilds.ps1 artifacts/log/$(_BuildConfig)
           displayName: Finish background dump collection
           continueOnError: true
           condition: always()
+
         - powershell: |
             $version = $(node -p "require('./package.json').version" | Out-String).Trim()
             yarn install
@@ -268,6 +287,7 @@ stages:
           workingDirectory: $(Build.SourcesDirectory)/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension
           failOnStderr: true
           condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'))
+
         - task: PublishBuildArtifacts@1
           displayName: Upload Test Results
           condition: always()
@@ -277,6 +297,7 @@ stages:
             artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
             artifactType: Container
             parallel: true
+
         # - task: PublishTestResults@2
         #   displayName: Publish VSCode Test Results
         #   inputs:
@@ -285,6 +306,7 @@ stages:
         #     searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
         #   continueOnError: true
         #   condition: always()
+
         - task: PublishBuildArtifacts@1
           displayName: Publish VSIX Artifacts
           inputs:
@@ -293,6 +315,7 @@ stages:
             ArtifactName: VSIX_$(Agent.Os)_$(_BuildConfig)
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+
         - task: PublishBuildArtifacts@1
           displayName: Publish VS for Mac Artifacts
           inputs:
@@ -301,6 +324,7 @@ stages:
             ArtifactName: MPack_$(Agent.Os)_$(_BuildConfig)
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+
         - task: PublishBuildArtifacts@1
           displayName: Publish package artifacts
           inputs:
@@ -309,6 +333,7 @@ stages:
             ArtifactName: Packages_$(Agent.Os)_$(_BuildConfig)
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+
         - task: PublishBuildArtifacts@1
           displayName: Publish VS Code extension artifacts
           inputs:


### PR DESCRIPTION
Fixes #6297 

Currently, the scheduled job to run ProcDump on hanging processes runs after 25 minutes. However, the build and tests are taking upwards of ~35 minutes now that we've added the compiler and re-enabled integration tests. So, it _always_ ends up capturing a dump when tests are running.

Since our CI is set to time out at 120 minutes, I'm increasing the ProcDump timeout to 60 minutes. I've also made a couple of other tweaks to the dump collection scripts to improve the reporting slightly.