### PR TITLE
[VSCode] Fix telemetry monitor exception

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/ExportedTagHelperResolverFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/ExportedTagHelperResolverFactory.cs
@@ -18,9 +18,9 @@ namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
         private readonly ITelemetryReporter _telemetryReporter;
 
         [ImportingConstructor]
-        public ExportedTagHelperResolverFactory(ITelemetryReporter telemetryReporter)
+        public ExportedTagHelperResolverFactory()
         {
-            _telemetryReporter = telemetryReporter;
+            _telemetryReporter = new OmniSharpTelemetryReporter();
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed/OmniSharpTelemetryReporter.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.AspNetCore.Razor.Common.Telemetry;
+using Microsoft.VisualStudio.Telemetry;
+
+namespace Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
+{
+    internal class OmniSharpTelemetryReporter : ITelemetryReporter
+    {
+        public void ReportEvent(string name, TelemetrySeverity severity)
+        {
+        }
+
+        public void ReportEvent<T>(string name, TelemetrySeverity severity, ImmutableDictionary<string, T> values)
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the changes

- After pulling in changes from main into the feature branch, VSCode started throwing an exception that an `ITelemetryMonitor` couldn't be found. This workaround solution creates a dummy class so the exception is no longer thrown. Since we aren't currently actively tracking telemetry for VSCode, imo it's not necessary for now to have a working telemetry monitor.