### PR TITLE
Make TelemetryReporter optional for TagHelperResolver

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -19,11 +17,11 @@ namespace Microsoft.CodeAnalysis.Razor
 {
     internal abstract class TagHelperResolver : IWorkspaceService
     {
-        private readonly ITelemetryReporter _telemetryReporter;
+        private readonly ITelemetryReporter? _telemetryReporter;
 
-        public TagHelperResolver(ITelemetryReporter telemetryReporter)
+        public TagHelperResolver(ITelemetryReporter? telemetryReporter = null)
         {
-            _telemetryReporter = telemetryReporter ?? throw new ArgumentNullException(nameof(telemetryReporter));
+            _telemetryReporter = telemetryReporter;
         }
 
         public abstract Task<TagHelperResolutionResult> GetTagHelpersAsync(Project workspaceProject, ProjectSnapshot projectSnapshot, CancellationToken cancellationToken = default);
@@ -71,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 timingDictionary[propertyName] = stopWatch.ElapsedMilliseconds;
             }
 
-            _telemetryReporter.ReportEvent("taghelperresolver/gettaghelpers", VisualStudio.Telemetry.TelemetrySeverity.Normal, timingDictionary.ToImmutableDictionary());
+            _telemetryReporter?.ReportEvent("taghelperresolver/gettaghelpers", VisualStudio.Telemetry.TelemetrySeverity.Normal, timingDictionary.ToImmutableDictionary());
             return new TagHelperResolutionResult(results, Array.Empty<RazorDiagnostic>());
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Common.Telemetry;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -17,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
     {
         protected readonly ServiceBrokerClient ServiceBrokerClient;
 
-        public RazorServiceBase(IServiceBroker serviceBroker, ITelemetryReporter telemetryReporter)
+        public RazorServiceBase(IServiceBroker serviceBroker)
         {
-            RazorServices = new RazorServices(telemetryReporter);
+            RazorServices = new RazorServices();
 
 #pragma warning disable VSTHRD012 // Provide JoinableTaskFactory where allowed
             ServiceBrokerClient = new ServiceBrokerClient(serviceBroker);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
@@ -12,10 +12,22 @@ using Nerdbank.Streams;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor
 {
+    /// <summary>
+    /// </summary>
+    /// <typeparam name="TService"></typeparam>
+    /// <remarks>
+    /// Implementors of <see cref="IServiceHubServiceFactory" /> (and thus this class) MUST provide a parameterless constructor or ServiceHub will fail to construct them.
+    /// </remarks>
     internal abstract class RazorServiceFactoryBase<TService> : IServiceHubServiceFactory where TService : class
     {
         private readonly RazorServiceDescriptorsWrapper _razorServiceDescriptors;
 
+        /// <summary>
+        /// </summary>
+        /// <param name="razorServiceDescriptors"></param>
+        /// <remarks>
+        /// Implementors of <see cref="IServiceHubServiceFactory" /> (and thus this class) MUST provide a parameterless constructor or ServiceHub will fail to construct them.
+        /// </remarks>
         public RazorServiceFactoryBase(RazorServiceDescriptorsWrapper razorServiceDescriptors)
         {
             _razorServiceDescriptors = razorServiceDescriptors;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServices.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServices.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Common.Telemetry;
-
 namespace Microsoft.CodeAnalysis.Razor
 {
     // Provides access to Razor language and workspace services that are avialable in the OOP host.
@@ -11,10 +9,10 @@ namespace Microsoft.CodeAnalysis.Razor
     // that we can construct directly.
     internal sealed class RazorServices
     {
-        public RazorServices(ITelemetryReporter telemetryReporter)
+        public RazorServices()
         {
             FallbackProjectEngineFactory = new FallbackProjectEngineFactory();
-            TagHelperResolver = new RemoteTagHelperResolver(FallbackProjectEngineFactory, telemetryReporter);
+            TagHelperResolver = new RemoteTagHelperResolver(FallbackProjectEngineFactory);
         }
 
         public IFallbackProjectEngineFactory FallbackProjectEngineFactory { get; }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderService.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Common.Telemetry;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
@@ -19,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
     {
         private readonly RemoteTagHelperDeltaProvider _tagHelperDeltaProvider;
 
-        internal RemoteTagHelperProviderService(IServiceBroker serviceBroker, ITelemetryReporter telemetryReporter)
-            : base(serviceBroker, telemetryReporter)
+        internal RemoteTagHelperProviderService(IServiceBroker serviceBroker)
+            : base(serviceBroker)
         {
             _tagHelperDeltaProvider = new RemoteTagHelperDeltaProvider();
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderServiceFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperProviderServiceFactory.cs
@@ -1,21 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Common.Telemetry;
 using Microsoft.ServiceHub.Framework;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor
 {
     internal sealed class RemoteTagHelperProviderServiceFactory : RazorServiceFactoryBase<IRemoteTagHelperProviderService>
     {
-        private readonly ITelemetryReporter _telemetryReporter;
-
-        public RemoteTagHelperProviderServiceFactory(ITelemetryReporter telemetryReporter) : base(RazorServiceDescriptors.TagHelperProviderServiceDescriptors)
+        // WARNING: We must always have a parameterless constructor in order to be properly handled by ServiceHub.
+        public RemoteTagHelperProviderServiceFactory() : base(RazorServiceDescriptors.TagHelperProviderServiceDescriptors)
         {
-            _telemetryReporter = telemetryReporter;
         }
 
         protected override IRemoteTagHelperProviderService CreateService(IServiceBroker serviceBroker)
-                => new RemoteTagHelperProviderService(serviceBroker, _telemetryReporter);
+                => new RemoteTagHelperProviderService(serviceBroker);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteTagHelperResolver.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Common.Telemetry;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -16,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Razor
 
         private readonly IFallbackProjectEngineFactory _fallbackFactory;
 
-        public RemoteTagHelperResolver(IFallbackProjectEngineFactory fallbackFactory, ITelemetryReporter telemetryReporter)
-            : base(telemetryReporter)
+        public RemoteTagHelperResolver(IFallbackProjectEngineFactory fallbackFactory)
+            : base()
         {
             if (fallbackFactory is null)
             {


### PR DESCRIPTION
### Summary of the changes

- Basically ServiceHub demands that instances of `IServiceHubServiceFactory` always have a parameterless constructor, so when we added a parameter it decided our factory was invalid. Not sure why this didn't show up in the integration tests, possibly when it failed to find the Experimental instances ServiceHub provider it used the one from VS?
- I tried to do this in the least destructive way to the Telemetry work, but I couldn't figure out how to get the TelemetryReporter where it was needed so I left the calls themselves in and we can fix `TelemetryReporter` acquisition in a later PR.
